### PR TITLE
Clarify source of key index, from sylabs 456

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,6 +85,7 @@
 - Rafal Gumienny <rafal.gumienny@gmail.com>
 - Ralph Castain <rhc@open-mpi.org>
 - Rémy Dernat <remy.dernat@umontpellier.fr>
+- Richard Hattersley <richard.hattersley@metoffice.gov.uk>
 - Richard Neuboeck <hawk@tbi.univie.ac.at>
 - Sasha Yakovtseva <sasha@sylabs.io>, <sashayakovtseva@gmail.com>
 - Satish Chebrolu  <satish@sylabs.io>

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	privKey int // -k encryption key (index from 'keys list') specification
+	privKey int // -k encryption key (index from 'key list --secret') specification
 	signAll bool
 )
 
@@ -71,7 +71,7 @@ var signKeyIdxFlag = cmdline.Flag{
 	DefaultValue: 0,
 	Name:         "keyidx",
 	ShortHand:    "k",
-	Usage:        "private key to use (index from 'key list')",
+	Usage:        "private key to use (index from 'key list --secret')",
 }
 
 // -a|--all (deprecated)


### PR DESCRIPTION
This pulls in sylabs PR

* sylabs/singularity#456

The original PR description was:

> This is purely a change to the documentation to clarify that the `--keyidx` key index parameter for the `singularity sign ...` command relates to the _private_ keys, so the `--secret` argument is necessary when obtaining the index from `singularity key list`.