### PR TITLE
Update mvdan.cc/sh/v3 to 3.4.1 to fix dependabot error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	golang.org/x/term v0.0.0-20210916214954-140adaaadfaf
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
-	mvdan.cc/sh/v3 v3.4.1-0.20211117155449-fd5bf4bda085
+	mvdan.cc/sh/v3 v3.4.1
 	oras.land/oras-go v1.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1520,8 +1520,8 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 mvdan.cc/editorconfig v0.2.0/go.mod h1:lvnnD3BNdBYkhq+B4uBuFFKatfp02eB6HixDvEz91C0=
-mvdan.cc/sh/v3 v3.4.1-0.20211117155449-fd5bf4bda085 h1:5DEMijC3Bv/c5bNGMB+fb744YYK9qXz8gclnfaxHm38=
-mvdan.cc/sh/v3 v3.4.1-0.20211117155449-fd5bf4bda085/go.mod h1:p/tqPPI4Epfk2rICAe2RoaNd8HBSJ8t9Y2DA9yQlbzY=
+mvdan.cc/sh/v3 v3.4.1 h1:sY7JU00i7R0mEm7v0g7Z88l1Hf/6K5wVIdA0o4hoSbo=
+mvdan.cc/sh/v3 v3.4.1/go.mod h1:p/tqPPI4Epfk2rICAe2RoaNd8HBSJ8t9Y2DA9yQlbzY=
 oras.land/oras-go v1.0.0 h1:R5+g6OYqsOPGcdwHZkMpT0tpKvTiIB8zAer0Nv+WF3c=
 oras.land/oras-go v1.0.0/go.mod h1:MZN6VbUUZjfWRF1EJKPbAWhJtE+R8JVicRmeYZp8qDg=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=


### PR DESCRIPTION
This fixes a [dependabot error](https://github.com/apptainer/apptainer/network/updates/239804288):
```
go: mvdan.cc/sh/v3@v3.4.1-0.20211117155449-fd5bf4bda085: invalid version: unknown revision fd5bf4bda085
```
by upgrading to the 3.4.1 release.