### PR TITLE
Fixes #54 - containers need to be built and hosted in an OCI compatible registry

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -363,14 +363,14 @@ func (c actionTests) STDPipe(t *testing.T) {
 		{
 			name:    "TrueLibrary",
 			command: "shell",
-			argv:    []string{"library://busybox:1.31.1"},
+			argv:    []string{"oras://ghcr.io/apptainer/busybox:1.31.1"},
 			input:   "true",
 			exit:    0,
 		},
 		{
 			name:    "FalseLibrary",
 			command: "shell",
-			argv:    []string{"library://busybox:1.31.1"},
+			argv:    []string{"oras://ghcr.io/apptainer/busybox:1.31.1"},
 			input:   "false",
 			exit:    1,
 		},
@@ -514,7 +514,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "RunFromLibraryOK",
 			command: "run",
-			argv:    []string{"--bind", bind, "library://busybox:1.31.1", size},
+			argv:    []string{"--bind", bind, "oras://ghcr.io/apptainer/busybox:1.31.1", size},
 			exit:    0,
 			profile: e2e.UserProfile,
 		},
@@ -543,7 +543,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "RunFromLibraryKO",
 			command: "run",
-			argv:    []string{"--bind", bind, "library://busybox:1.31.1", "0"},
+			argv:    []string{"--bind", bind, "oras://ghcr.io/apptainer/busybox:1.31.1", "0"},
 			exit:    1,
 			profile: e2e.UserProfile,
 		},
@@ -574,7 +574,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecTrueLibrary",
 			command: "exec",
-			argv:    []string{"library://busybox:1.31.1", "true"},
+			argv:    []string{"oras://ghcr.io/apptainer/busybox:1.31.1", "true"},
 			exit:    0,
 			profile: e2e.UserProfile,
 		},
@@ -603,7 +603,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecFalseLibrary",
 			command: "exec",
-			argv:    []string{"library://busybox:1.31.1", "false"},
+			argv:    []string{"oras://ghcr.io/apptainer/busybox:1.31.1", "false"},
 			exit:    1,
 			profile: e2e.UserProfile,
 		},
@@ -634,7 +634,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecTrueLibraryUserns",
 			command: "exec",
-			argv:    []string{"library://busybox:1.31.1", "true"},
+			argv:    []string{"oras://ghcr.io/apptainer/busybox:1.31.1", "true"},
 			exit:    0,
 			profile: e2e.UserNamespaceProfile,
 		},
@@ -663,7 +663,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 		{
 			name:    "ExecFalseLibraryUserns",
 			command: "exec",
-			argv:    []string{"library://busybox:1.31.1", "false"},
+			argv:    []string{"oras://ghcr.io/apptainer/busybox:1.31.1", "false"},
 			exit:    1,
 			profile: e2e.UserNamespaceProfile,
 		},

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -626,7 +626,7 @@ func (c actionTests) issue5690(t *testing.T) {
 func (c actionTests) invalidRemote(t *testing.T) {
 	testEndpoint := "invalid"
 	testEndpointURI := "https://cloud.example.com"
-	testImage := "library://alpine"
+	testImage := "oras://ghcr.io/apptainer/alpine:latest"
 
 	// Exec library image from the default remote... ensure it succeeds
 	argv := []string{testImage, "/bin/true"}
@@ -681,7 +681,7 @@ func (c actionTests) invalidRemote(t *testing.T) {
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("exec"),
 		e2e.WithArgs(argv...),
-		e2e.ExpectExit(255),
+		e2e.ExpectExit(0), // e2e.ExpectExit(255), // oras protocol does not adhere to `remote use`
 	)
 }
 

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -16,8 +16,8 @@ import (
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/e2e/internal/testhelper"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
+	client "github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
-	"github.com/sylabs/scs-library-client/client"
 )
 
 type cacheTests struct {
@@ -26,7 +26,7 @@ type cacheTests struct {
 
 const (
 	imgName = "alpine_latest.sif"
-	imgURL  = "library://alpine:latest"
+	imgURL  = "oras://ghcr.io/apptainer/alpine:latest"
 )
 
 func prepTest(t *testing.T, testEnv e2e.TestEnv, testName string, cacheParentDir string, imagePath string) {
@@ -186,7 +186,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		},
 		{
 			name:               "clean type confirmed",
-			options:            []string{"clean", "--type", "library"},
+			options:            []string{"clean", "--type", "oras"},
 			expect:             "Do you want to continue? [N/y]",
 			send:               "y",
 			expectedEmptyCache: true,
@@ -194,7 +194,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 		},
 		{
 			name:               "clean type not confirmed",
-			options:            []string{"clean", "--type", "library"},
+			options:            []string{"clean", "--type", "oras"},
 			expect:             "Do you want to continue? [N/y]",
 			send:               "n",
 			expectedEmptyCache: false,
@@ -265,7 +265,7 @@ func ensureNotCached(t *testing.T, testName string, imagePath string, cacheParen
 	}
 
 	// Where the cached image should be
-	cacheImagePath := path.Join(cacheParentDir, "cache", "library", shasum)
+	cacheImagePath := path.Join(cacheParentDir, "cache", "oras", shasum)
 
 	// The image file shouldn't be present
 	if e2e.PathExists(t, cacheImagePath) {
@@ -281,7 +281,7 @@ func ensureCached(t *testing.T, testName string, imagePath string, cacheParentDi
 	}
 
 	// Where the cached image should be
-	cacheImagePath := path.Join(cacheParentDir, "cache", "library", shasum)
+	cacheImagePath := path.Join(cacheParentDir, "cache", "oras", shasum)
 
 	// The image file shouldn't be present
 	if !e2e.PathExists(t, cacheImagePath) {

--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
+	client "github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
-	"github.com/sylabs/scs-library-client/client"
 )
 
 // issue5097 - need to handle an existing directory entry present in the cache
@@ -45,7 +45,7 @@ func (c cacheTests) issue5097(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not calculate hash of test image: %v", err)
 	}
-	cachePath := path.Join(imgCacheDir, "cache", "library", hash)
+	cachePath := path.Join(imgCacheDir, "cache", "oras", hash)
 	err = os.Remove(cachePath)
 	if err != nil {
 		t.Fatalf("Could not remove cached image '%s': %v", cachePath, err)
@@ -95,7 +95,7 @@ func (c cacheTests) issue5350(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs([]string{"--force", "-s", sandboxDir, "library://alpine:3.11.5"}...),
+		e2e.WithArgs([]string{"--force", "-s", sandboxDir, "oras://ghcr.io/apptainer/alpine:3.15.0"}...),
 		e2e.ExpectExit(0),
 	)
 

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/e2e/internal/testhelper"
-	"github.com/sylabs/scs-library-client/client"
+	client "github.com/apptainer/apptainer/internal/pkg/client/oras"
 )
 
 type ctx struct {
@@ -75,7 +75,7 @@ func (c ctx) pullTestImage(t *testing.T) string {
 
 	imgPath := filepath.Join(tmpdir, "testImg.sif")
 
-	cmdArgs := []string{imgPath, "library://alpine:latest"}
+	cmdArgs := []string{imgPath, "oras://ghcr.io/apptainer/alpine:latest"}
 
 	// Pull the specified image to the temporary location
 	c.env.RunApptainer(
@@ -96,7 +96,7 @@ func (c ctx) assertLibraryCacheEntryExists(t *testing.T, imgPath, imgName string
 		t.Fatalf("Cannot get the shasum for image %s: %s", imgPath, err)
 	}
 
-	cacheEntryPath := filepath.Join(c.env.ImgCacheDir, "cache", "library", shasum, imgName)
+	cacheEntryPath := filepath.Join(c.env.ImgCacheDir, "cache", "oras", shasum)
 	if _, err := os.Stat(cacheEntryPath); os.IsNotExist(err) {
 		ls(t, c.env.TestDir)
 		ls(t, c.env.ImgCacheDir)

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -90,7 +90,7 @@ func (c *ctx) eclConfig(t *testing.T) {
 			name:    "build signed image",
 			command: "build",
 			profile: e2e.UserProfile,
-			args:    []string{signed, "library://busybox"},
+			args:    []string{signed, "oras://ghcr.io/apptainer/busybox:1.31.1"},
 			exit:    0,
 		},
 		{

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -194,11 +194,11 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 		},
 		{
 			name:      "library sif",
-			buildSpec: "library://busybox:1.31.1",
+			buildSpec: "oras://ghcr.io/apptainer/busybox:1.31.1",
 		},
 		{
 			name:      "library sif sandbox",
-			buildSpec: "library://busybox:1.31.1",
+			buildSpec: "oras://ghcr.io/apptainer/busybox:1.31.1",
 			args:      []string{"--sandbox"},
 		},
 		// TODO: uncomment when shub is working
@@ -880,7 +880,7 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 
 	// First with the command line argument
 	imgPath1 := filepath.Join(dn, "encrypted_cmdline_option.sif")
-	cmdArgs := []string{"--encrypt", "--pem-path", pemFile, imgPath1, "library://alpine:latest"}
+	cmdArgs := []string{"--encrypt", "--pem-path", pemFile, imgPath1, "oras://ghcr.io/apptainer/alpine:latest"}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -899,7 +899,7 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 	// Second with the environment variable
 	pemEnvVar := fmt.Sprintf("%s=%s", "APPTAINER_ENCRYPTION_PEM_PATH", pemFile)
 	imgPath2 := filepath.Join(dn, "encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", imgPath2, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", imgPath2, "oras://ghcr.io/apptainer/alpine:latest"}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -944,7 +944,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	}
 	cmdlineTestImgPath := filepath.Join(dn, "encrypted_cmdline_option.sif")
 	// The image is deleted during cleanup of the temporary directory
-	cmdArgs := []string{"--passphrase", cmdlineTestImgPath, "library://alpine:latest"}
+	cmdArgs := []string{"--passphrase", cmdlineTestImgPath, "oras://ghcr.io/apptainer/alpine:latest"}
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("passphrase flag"),
@@ -964,7 +964,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 
 	// With the command line argument, using --encrypt and --passphrase
 	cmdlineTest2ImgPath := filepath.Join(dn, "encrypted_cmdline2_option.sif")
-	cmdArgs = []string{"--encrypt", "--passphrase", cmdlineTest2ImgPath, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", "--passphrase", cmdlineTest2ImgPath, "oras://ghcr.io/apptainer/alpine:latest"}
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("encrypt and passphrase flags"),
@@ -985,7 +985,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// With the environment variable
 	passphraseEnvVar := fmt.Sprintf("%s=%s", "APPTAINER_ENCRYPTION_PASSPHRASE", e2e.Passphrase)
 	envvarImgPath := filepath.Join(dn, "encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", envvarImgPath, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", envvarImgPath, "oras://ghcr.io/apptainer/alpine:latest"}
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("passphrase env var"),
@@ -1005,7 +1005,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 
 	// Finally a test that must fail: try to specify the passphrase on the command line
 	dummyImgPath := filepath.Join(dn, "dummy_encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", "--passphrase", e2e.Passphrase, dummyImgPath, "library://alpine:latest"}
+	cmdArgs = []string{"--encrypt", "--passphrase", e2e.Passphrase, dummyImgPath, "oras://ghcr.io/apptainer/alpine:latest"}
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("passphrase on cmdline"),
@@ -1114,7 +1114,7 @@ func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 		{
 			name:    "build single signed source image",
 			command: "build",
-			args:    []string{singleSigned, "library://busybox"},
+			args:    []string{singleSigned, "oras://ghcr.io/apptainer/busybox:1.31.1"},
 		},
 		{
 			name:    "build double signed source image",

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -214,7 +214,7 @@ func (c *ctx) testInstanceFromURI(t *testing.T) {
 		},
 		{
 			name: "test_from_library",
-			uri:  "library://busybox:1.31.1",
+			uri:  "oras://ghcr.io/apptainer/busybox:1.31.1",
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -40,7 +40,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs(sifSignedImage, "library://busybox:1.31.1"),
+		e2e.WithArgs(sifSignedImage, "oras://ghcr.io/apptainer/busybox:1.31.1"),
 		e2e.ExpectExit(0),
 	)
 
@@ -67,7 +67,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs(sifImage, "library://busybox:1.31.1"),
+		e2e.WithArgs(sifImage, "oras://ghcr.io/apptainer/busybox:1.31.1"),
 		e2e.ExpectExit(0),
 	)
 
@@ -156,7 +156,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 			t,
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs("--encrypt", sifEncryptedImage, "library://busybox:1.31.1"),
+			e2e.WithArgs("--encrypt", sifEncryptedImage, "oras://ghcr.io/apptainer/busybox:1.31.1"),
 			e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
 			e2e.ExpectExit(0),
 		)

--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -49,7 +49,7 @@ func (c ctx) testConcurrencyConfig(t *testing.T) {
 }
 
 func (c ctx) testConcurrentPulls(t *testing.T) {
-	const srcURI = "library://alpine:3.11.5"
+	const srcURI = "oras://ghcr.io/apptainer/alpine:3.15.0"
 
 	tests := []struct {
 		name             string

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -53,14 +53,14 @@ type testStruct struct {
 var tests = []testStruct{
 	{
 		desc:             "non existent image",
-		srcURI:           "library://sylabs/tests/does_not_exist:0",
+		srcURI:           "oras://image/does/not:exist",
 		expectedExitCode: 255,
 	},
 
 	// --allow-unauthenticated tests
 	{
 		desc:             "unsigned image allow unauthenticated",
-		srcURI:           "library://sylabs/tests/unsigned:1.0.0",
+		srcURI:           "oras://ghcr.io/apptainer/alpine:3.15.0",
 		unauthenticated:  true,
 		expectedExitCode: 0,
 	},
@@ -68,7 +68,7 @@ var tests = []testStruct{
 	// --force tests
 	{
 		desc:             "force existing file",
-		srcURI:           "library://alpine:3.11.5",
+		srcURI:           "oras://ghcr.io/apptainer/alpine:3.15.0",
 		force:            true,
 		createDst:        true,
 		unauthenticated:  true,
@@ -76,7 +76,7 @@ var tests = []testStruct{
 	},
 	{
 		desc:             "force non-existing file",
-		srcURI:           "library://alpine:3.11.5",
+		srcURI:           "oras://ghcr.io/apptainer/alpine:3.15.0",
 		force:            true,
 		createDst:        false,
 		unauthenticated:  true,
@@ -85,7 +85,7 @@ var tests = []testStruct{
 	{
 		// --force should not have an effect on --allow-unauthenticated=false
 		desc:             "unsigned image force require authenticated",
-		srcURI:           "library://sylabs/tests/unsigned:1.0.0",
+		srcURI:           "oras://ghcr.io/apptainer/alpine:3.15.0",
 		force:            true,
 		unauthenticated:  false,
 		expectedExitCode: 0,
@@ -94,13 +94,13 @@ var tests = []testStruct{
 	// test version specifications
 	{
 		desc:             "image with specific hash",
-		srcURI:           "library://alpine:sha256.03883ca565b32e58fa0a496316d69de35741f2ef34b5b4658a6fec04ed8149a8",
+		srcURI:           "oras://ghcr.io/apptainer/alpine@sha256:aef2a1baf177ee2e6f21da40bdb7025f58466d39116507837f74c2ab4abf5606",
 		unauthenticated:  true,
 		expectedExitCode: 0,
 	},
 	{
 		desc:             "latest tag",
-		srcURI:           "library://alpine:latest",
+		srcURI:           "oras://ghcr.io/apptainer/alpine:latest",
 		unauthenticated:  true,
 		expectedExitCode: 0,
 	},
@@ -108,7 +108,7 @@ var tests = []testStruct{
 	// --dir tests
 	{
 		desc:             "dir no image path",
-		srcURI:           "library://alpine:3.11.5",
+		srcURI:           "oras://ghcr.io/apptainer/alpine:3.15.0",
 		unauthenticated:  true,
 		setPullDir:       true,
 		setImagePath:     false,
@@ -123,7 +123,7 @@ var tests = []testStruct{
 		// the directory /tmp/a/b/c/tmp/a/b does not exist, it fails to create the file
 		// image.sif in there.
 		desc:             "dir image path",
-		srcURI:           "library://alpine:3.11.5",
+		srcURI:           "oras://ghcr.io/apptainer/alpine:3.15.0",
 		unauthenticated:  true,
 		setPullDir:       true,
 		setImagePath:     true,
@@ -188,35 +188,14 @@ var tests = []testStruct{
 	// pulling with library URI argument
 	{
 		desc:             "bad library URI",
-		srcURI:           "library://busybox:1.31.1",
+		srcURI:           "oras://ghcr.io/apptainer/bad/busybox:1.31.1",
 		library:          "https://bad-library.sylabs.io",
 		expectedExitCode: 255,
 	},
 	{
 		desc:             "default library URI",
-		srcURI:           "library://busybox:1.31.1",
+		srcURI:           "oras://ghcr.io/apptainer/busybox:1.31.1",
 		library:          "https://library.sylabs.io",
-		force:            true,
-		expectedExitCode: 0,
-	},
-
-	// pulling with library URI containing host name and library argument
-	{
-		desc:             "library URI containing host name and library argument",
-		srcURI:           "library://notlibrary.sylabs.io/library/default/busybox:1.31.1",
-		library:          "https://notlibrary.sylabs.io",
-		expectedExitCode: 255,
-	},
-
-	// pulling with library URI containing host name
-	{
-		desc:             "library URI containing bad host name",
-		srcURI:           "library://notlibrary.sylabs.io/library/default/busybox:1.31.1",
-		expectedExitCode: 255,
-	},
-	{
-		desc:             "library URI containing host name",
-		srcURI:           "library://library.sylabs.io/library/default/busybox:1.31.1",
 		force:            true,
 		expectedExitCode: 0,
 	},
@@ -491,7 +470,7 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 		{
 			name:      "library",
 			imagePath: filepath.Join(c.env.TestDir, "library.sif"),
-			imageSrc:  "library://alpine:latest",
+			imageSrc:  "oras://ghcr.io/apptainer/alpine:latest",
 		},
 		{
 			name:      "docker",
@@ -608,7 +587,7 @@ func (c ctx) testPullUmask(t *testing.T) {
 		if tc.force {
 			cmdArgs = append(cmdArgs, "--force")
 		}
-		cmdArgs = append(cmdArgs, tc.imagePath, "library://alpine")
+		cmdArgs = append(cmdArgs, tc.imagePath, "oras://ghcr.io/apptainer/alpine:latest")
 
 		c.env.RunApptainer(
 			t,

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -37,7 +37,7 @@ func (c ctx) testRun555Cache(t *testing.T) {
 	}
 	// Directory is deleted when tempDir is deleted
 
-	cmdArgs := []string{"library://lolcow"}
+	cmdArgs := []string{"oras://ghcr.io/apptainer/alpine:3.15.0", "/bin/true"}
 	// We explicitly pass the environment to the command, not through c.env.ImgCacheDir
 	// because c.env is shared between all the tests, something we do not want here.
 	cacheDirEnv := fmt.Sprintf("%s=%s", cache.DirEnv, cacheDir)
@@ -69,7 +69,7 @@ func (c ctx) testRunPEMEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_pem-path.sif")
-	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, "library://alpine:3.11.5"}
+	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, "oras://ghcr.io/apptainer/alpine:3.15.0"}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -119,7 +119,7 @@ func (c ctx) testRunPassphraseEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_passphrase.sif")
-	cmdArgs := []string{"--encrypt", imgPath, "library://alpine:3.11.5"}
+	cmdArgs := []string{"--encrypt", imgPath, "oras://ghcr.io/apptainer/alpine:3.15.0"}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -26,7 +26,7 @@ type ctx struct {
 }
 
 const (
-	imgURL  = "library://sylabs/tests/unsigned:1.0.0"
+	imgURL  = "oras://ghcr.io/apptainer/alpine:3.15.0"
 	imgName = "testImage.sif"
 )
 
@@ -80,8 +80,8 @@ func (c ctx) apptainerSignIDOption(t *testing.T) {
 			expectExit: 0,
 		},
 		{
-			name:       "sign non-exsistent ID",
-			args:       []string{"--sif-id", "5", imgPath},
+			name:       "sign non-existent ID",
+			args:       []string{"--sif-id", "99", imgPath},
 			expectOp:   e2e.ExpectError(e2e.ContainMatch, "integrity: object not found"),
 			expectExit: 255,
 		},

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -35,7 +35,7 @@ type verifyOutput struct {
 }
 
 const (
-	successURL   = "library://sylabs/tests/verify_success:1.0.2"
+	successURL   = "oras://ghcr.io/apptainer/verify_success:1.0.2"
 	corruptedURL = "library://sylabs/tests/verify_corrupted:1.0.1"
 )
 

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -28,8 +28,8 @@ import (
 
 const (
 	dockerURI         = "docker://alpine"
-	dockerArchiveURI  = "https://s3.amazonaws.com/singularity-ci-public/alpine-docker-save.tar"
-	ociArchiveURI     = "https://s3.amazonaws.com/singularity-ci-public/alpine-oci-archive.tar"
+	dockerArchiveURI  = "https://github.com/apptainer/apptainer/releases/download/v0.1.0/alpine-docker-save.tar"
+	ociArchiveURI     = "https://github.com/apptainer/apptainer/releases/download/v0.1.0/alpine-oci-archive.tar"
 	dockerDaemonImage = "alpine:latest"
 )
 

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -34,5 +34,5 @@ su testuser -c '
   export GOPATH=$BLD/gopath
   PATH=$GOPATH/bin:$PATH
 
-  apptainer exec library://alpine:3.11.5 /bin/true
+  apptainer exec oras://ghcr.io/apptainer/alpine:3.15.0 /bin/true
 '


### PR DESCRIPTION
Fixes #54 - containers need to be built and hosted in an OCI compatible registry

also, update cache references to build correct file path based on URI protocol
