### PR TITLE
Do apt-get update when fetching deps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           go-version: 1.17.5
 
       - name: Fetch deps
-        run: sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         run: |
@@ -149,7 +149,7 @@ jobs:
           go-version: 1.17.5
 
       - name: Fetch deps
-        run: sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         run: |
@@ -195,7 +195,7 @@ jobs:
 
       - name: Fetch deps
         if: env.run_tests
-        run: sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         if: env.run_tests


### PR DESCRIPTION
This fixes errors like these that I ran into in the "Fetch deps" of short_unit_tests, integration_tests, and e2e_tests:
```
The following NEW packages will be installed:
  libseccomp-dev
0 upgraded, 1 newly installed, 0 to remove and 17 not upgraded.
Need to get 83.6 kB of archives.
After this operation, 421 kB of additional disk space will be used.
Err:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libseccomp-dev amd64 2.5.1-1ubuntu1~20.04.1
  404  Not Found [IP: 52.250.76.244 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/libs/libseccomp/libseccomp-dev_2.5.1-1ubuntu1~20.04.1_amd64.deb  404  Not Found [IP: 52.250.76.244 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```