### PR TITLE
Fixes #62 - remove references to commercial remote `keyserver`

### DIFF
--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -33,9 +33,9 @@ import (
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
+	keyClient "github.com/apptainer/container-key-client/client"
 	ocitypes "github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
-	scskeyclient "github.com/sylabs/scs-key-client/client"
 	"golang.org/x/term"
 )
 
@@ -600,7 +600,7 @@ func CheckRootOrUnpriv(cmd *cobra.Command, args []string) {
 // getKeyServerClientOpts returns client options for keyserver access.
 // A "" value for uri will return client options for the current endpoint.
 // A specified uri will return client options for that keyserver.
-func getKeyserverClientOpts(uri string, op endpoint.KeyserverOp) ([]scskeyclient.Option, error) {
+func getKeyserverClientOpts(uri string, op endpoint.KeyserverOp) ([]keyClient.Option, error) {
 	if currentRemoteEndpoint == nil {
 		var err error
 

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -19,8 +19,8 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/sypgp"
+	"github.com/apptainer/container-key-client/client"
 	"github.com/spf13/cobra"
-	"github.com/sylabs/scs-key-client/client"
 )
 
 // KeyPullCmd is `apptainer key pull' and fetches public keys from a key server

--- a/cmd/internal/cli/key_push.go
+++ b/cmd/internal/cli/key_push.go
@@ -20,8 +20,8 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/sypgp"
+	"github.com/apptainer/container-key-client/client"
 	"github.com/spf13/cobra"
-	"github.com/sylabs/scs-key-client/client"
 )
 
 // KeyPushCmd is `apptainer key list' and lists local store OpenPGP keys

--- a/cmd/internal/cli/key_search.go
+++ b/cmd/internal/cli/key_search.go
@@ -17,8 +17,8 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/sypgp"
+	"github.com/apptainer/container-key-client/client"
 	"github.com/spf13/cobra"
-	"github.com/sylabs/scs-key-client/client"
 )
 
 // KeySearchCmd is 'apptainer key search' and look for public keys from a key server

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210707164159-52430bf6b52c
 	github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60
 	github.com/apex/log v1.9.0
+	github.com/apptainer/container-key-client v0.7.2
 	github.com/apptainer/sif/v2 v2.2.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/buger/jsonparser v1.1.1
@@ -35,7 +36,6 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/sylabs/json-resp v0.8.0
-	github.com/sylabs/scs-key-client v0.7.1
 	github.com/urfave/cli v1.22.5 // indirect
 	github.com/vbauerster/mpb/v4 v4.12.2
 	github.com/vbauerster/mpb/v6 v6.0.4

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/apex/logs v0.0.7/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDw
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
+github.com/apptainer/container-key-client v0.7.2 h1:lfKlKgONO8CvlZ11bbWE0vwJtMx/IE2Tg01g1/YCY+4=
+github.com/apptainer/container-key-client v0.7.2/go.mod h1:hLHrJBfdMb8SHy1pbCTNRQ7bxqcSh4GPiMV4ajEnAqk=
 github.com/apptainer/sif/v2 v2.2.3 h1:L+PCzSgWcB0ta5T9wpqZ2rWk0cn9yiypG4LmX2kERpg=
 github.com/apptainer/sif/v2 v2.2.3/go.mod h1:FbdvfevquJjRsaFK0lSetw3aw/HxVxRVoAFw7OYottg=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -973,8 +975,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sylabs/json-resp v0.8.0 h1:bZ932uaF220aPqT0+x/vakoaGCGNbpLCjUFm1f+JKlY=
 github.com/sylabs/json-resp v0.8.0/go.mod h1:bUGV9cqShOyxz7RxBq03Yt9raKGfELKrfN6Yac3lfiw=
-github.com/sylabs/scs-key-client v0.7.1 h1:m8w1fK5Ja/ahdgDRiAaFJ8CMOIOm8m37gKgSCwOgoeY=
-github.com/sylabs/scs-key-client v0.7.1/go.mod h1:/5RJxsW7iIKDD9FU2qfGvlCs+MfjigV7InUDE1SIR30=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=

--- a/internal/app/apptainer/push.go
+++ b/internal/app/apptainer/push.go
@@ -21,8 +21,8 @@ import (
 	registryclient "github.com/apptainer/apptainer/internal/pkg/registry"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	keyClient "github.com/apptainer/container-key-client/client"
 	"github.com/apptainer/sif/v2/pkg/sif"
-	keyclient "github.com/sylabs/scs-key-client/client"
 	"github.com/vbauerster/mpb/v4"
 	"github.com/vbauerster/mpb/v4/decor"
 	"golang.org/x/term"
@@ -83,7 +83,7 @@ func (c *progressCallback) Finish() {
 
 // RegistryPush will upload an image file according to the provided RegistryPushSpec
 // Before uploading, the image will be checked for a valid signature unless AllowUnsigned is true
-func RegistryPush(ctx context.Context, pushSpec RegistryPushSpec, registryConfig *registryclient.Config, co []keyclient.Option) error {
+func RegistryPush(ctx context.Context, pushSpec RegistryPushSpec, registryConfig *registryclient.Config, co []keyClient.Option) error {
 	fi, err := os.Stat(pushSpec.SourceFile)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/app/apptainer/verify.go
+++ b/internal/app/apptainer/verify.go
@@ -19,9 +19,9 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/pkg/sypgp"
+	"github.com/apptainer/container-key-client/client"
 	"github.com/apptainer/sif/v2/pkg/integrity"
 	"github.com/apptainer/sif/v2/pkg/sif"
-	"github.com/sylabs/scs-key-client/client"
 )
 
 // TODO - error overlaps with ECL - should probably become part of a common errors package at some point.

--- a/internal/app/apptainer/verify_test.go
+++ b/internal/app/apptainer/verify_test.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/apptainer/container-key-client/client"
 	"github.com/apptainer/sif/v2/pkg/integrity"
 	"github.com/apptainer/sif/v2/pkg/sif"
-	"github.com/sylabs/scs-key-client/client"
 )
 
 const (

--- a/internal/pkg/build/sources/verify_sif.go
+++ b/internal/pkg/build/sources/verify_sif.go
@@ -13,17 +13,17 @@ import (
 
 	"github.com/apptainer/apptainer/internal/app/apptainer"
 	"github.com/apptainer/apptainer/pkg/sylog"
-	scskeyclient "github.com/sylabs/scs-key-client/client"
+	keyClient "github.com/apptainer/container-key-client/client"
 )
 
 // checkSIFFingerprint checks whether a bootstrap SIF image verifies, and was signed with a specified fingerprint
-func checkSIFFingerprint(ctx context.Context, imagePath string, fingerprints []string, co ...scskeyclient.Option) error {
+func checkSIFFingerprint(ctx context.Context, imagePath string, fingerprints []string, co ...keyClient.Option) error {
 	sylog.Infof("Checking bootstrap image verifies with fingerprint(s): %v", fingerprints)
 	return apptainer.VerifyFingerprints(ctx, imagePath, fingerprints, apptainer.OptVerifyUseKeyServer(co...))
 }
 
 // verifySIF checks whether a bootstrap SIF image verifies
-func verifySIF(ctx context.Context, imagePath string, co ...scskeyclient.Option) error {
+func verifySIF(ctx context.Context, imagePath string, co ...keyClient.Option) error {
 	sylog.Infof("Verifying bootstrap image %s", imagePath)
 	return apptainer.Verify(ctx, imagePath, apptainer.OptVerifyUseKeyServer(co...))
 }

--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -16,11 +16,11 @@ import (
 	remoteutil "github.com/apptainer/apptainer/internal/pkg/remote/util"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
+	keyClient "github.com/apptainer/container-key-client/client"
 	golog "github.com/go-log/log"
-	keyclient "github.com/sylabs/scs-key-client/client"
 )
 
-func (ep *Config) KeyserverClientOpts(uri string, op KeyserverOp) ([]keyclient.Option, error) {
+func (ep *Config) KeyserverClientOpts(uri string, op KeyserverOp) ([]keyClient.Option, error) {
 	// empty uri means to use the default endpoint
 	isDefault := uri == ""
 
@@ -87,10 +87,10 @@ func (ep *Config) KeyserverClientOpts(uri string, op KeyserverOp) ([]keyclient.O
 		}
 	}
 
-	co := []keyclient.Option{
-		keyclient.OptBaseURL(uri),
-		keyclient.OptUserAgent(useragent.Value()),
-		keyclient.OptHTTPClient(newClient(keyservers, op)),
+	co := []keyClient.Option{
+		keyClient.OptBaseURL(uri),
+		keyClient.OptUserAgent(useragent.Value()),
+		keyClient.OptHTTPClient(newClient(keyservers, op)),
 	}
 	return co, nil
 }

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -19,8 +19,8 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/cryptkey"
+	keyClient "github.com/apptainer/container-key-client/client"
 	ocitypes "github.com/containers/image/v5/types"
-	scskeyclient "github.com/sylabs/scs-key-client/client"
 	"golang.org/x/sys/unix"
 )
 
@@ -49,7 +49,7 @@ type Options struct {
 	// LibraryAuthToken contains authentication token to access specified library.
 	LibraryAuthToken string `json:"libraryAuthToken"`
 	// KeyServerOpts contains options for keyserver used for SIF fingerprint verification in builds.
-	KeyServerOpts []scskeyclient.Option
+	KeyServerOpts []keyClient.Option
 	// contains docker credentials if specified.
 	DockerAuthConfig *ocitypes.DockerAuthConfig
 	// EncryptionKeyInfo specifies the key used for filesystem

--- a/pkg/sypgp/keyring.go
+++ b/pkg/sypgp/keyring.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/apptainer/apptainer/pkg/sylog"
-	"github.com/sylabs/scs-key-client/client"
+	"github.com/apptainer/container-key-client/client"
 )
 
 // PublicKeyRing retrieves the Apptainer public KeyRing.

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -36,7 +36,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/interactive"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
-	"github.com/sylabs/scs-key-client/client"
+	"github.com/apptainer/container-key-client/client"
 )
 
 const (

--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/apptainer/apptainer/internal/pkg/test"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
-	"github.com/sylabs/scs-key-client/client"
+	"github.com/apptainer/container-key-client/client"
 )
 
 const (


### PR DESCRIPTION
Fixes #62 - remove references to commercial remote `keyserver`