### PR TITLE
Disable go optimization with mconfig -P debug

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -805,6 +805,7 @@ case $profile in
 		if [ $lang_go -eq 1 ]; then
 			drawline $makeit_fragsdir/go_normal_opts.mk
 			cat $makeit_fragsdir/go_normal_opts.mk >> $makeit_makefile
+			cat $makeit_fragsdir/go_debug_opts.mk >> $makeit_makefile
 		fi
 		;;
 esac

--- a/mlocal/frags/go_debug_opts.mk
+++ b/mlocal/frags/go_debug_opts.mk
@@ -1,0 +1,2 @@
+# This disables go's optimization and inlining, for debug purposes
+GO_GCFLAGS += -gcflags="all=-N -l"


### PR DESCRIPTION
This disables golang optimization with mconfig -P debug, making it possible to use the delve/dlv debugger.