### PR TITLE
Fix search for keys.openpgp.org and for multiple names on a key

### DIFF
--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -91,13 +91,14 @@ func (c *ctx) apptainerKeySearch(t *testing.T) {
 			stdout: "^Search for keys on a key server",
 		},
 		{
+			// keys.openpgp.org does not support short id searches, use sylabs
 			name:   "key search 0x<key id>",
-			args:   []string{"search", "0x8BD91BEE"},
+			args:   []string{"search", "-u", "https://keys.sylabs.io", "0x8BD91BEE"},
 			stdout: "^Showing 1 results",
 		},
 		{
 			name:   "key search <key id>",
-			args:   []string{"search", "8BD91BEE"},
+			args:   []string{"search", "-u", "https://keys.sylabs.io", "8BD91BEE"},
 			stdout: "^Showing 1 results",
 		},
 		{
@@ -111,8 +112,28 @@ func (c *ctx) apptainerKeySearch(t *testing.T) {
 			stdout: "^Showing 1 results",
 		},
 		{
+			name:   "key search -u https://keys.openpgp.org 0x<key fingerprint>",
+			args:   []string{"search", "-u", "https://keys.openpgp.org", "0x7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
+			stdout: "^Showing 1 results",
+		},
+		{
+			name:   "key search -u https://keys.openpgp.org <key fingerprint>",
+			args:   []string{"search", "-u", "https://keys.openpgp.org", "7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
+			stdout: "^Showing 1 results",
+		},
+		{
+			name:   "key search <key with at least two emails>",
+			args:   []string{"search", "-u", "https://keys.openpgp.org", "dwd@fnal.gov"},
+			stdout: "\n  .*@",
+		},
+		{
+			name:   "key search -l <key with at least two emails>",
+			args:   []string{"search", "-u", "https://keys.openpgp.org", "-l", "dwd@fnal.gov"},
+			stdout: "\n  .*@",
+		},
+		{
 			name:   "key search <name>",
-			args:   []string{"search", "westley"},
+			args:   []string{"search", "-u", "https://keys.sylabs.io", "westley"},
 			stdout: "^Showing",
 		},
 		{


### PR DESCRIPTION
This fixes a few problems with searching on the https://keys.openpg.org key server:
1. Lines read needed trimming because of a trailing carriage return.
2. The name/email portion needed to be url-decoded.
3. There is not always exactly one name/email/uid; sometimes there are zero (if no email addresses have been confirmed), one as normal, or more than one if there are multiple uids associated with a key.

In addition, this renames several variables which had misleading names, and consolidates duplicate code in the formatting functions.

- Fixes: #96