### PR TITLE
Remove PACKAGE_BUGREPORT constant

### DIFF
--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -13,7 +13,6 @@ config_add_def PACKAGE_NAME \"$package_name\"
 config_add_def PACKAGE_TARNAME \"$package_name\"
 config_add_def PACKAGE_VERSION \"$package_version\"
 config_add_def PACKAGE_STRING \"apptainer $package_version\"
-config_add_def PACKAGE_BUGREPORT \"support@sylabs.io\"
 config_add_def PACKAGE_URL \"\"
 
 config_add_def BUILDDIR \"$builddir\"


### PR DESCRIPTION
Removes PACKAGE_BUGREPORT constant which was unused.

- Fixes: #95