### PR TITLE
Reduce changelog version to low number so debchange will run and set a valid number

### DIFF
--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -97,16 +97,17 @@ clean copy of the debian directory before you switch to (checkout) an
 older version.
 
 Usually `debchange` is configured by the environment variables
-`DEBFULLNAME` and `EMAIL`. As `debuild` creates a clean environment it
-filters out most of the environment variables. To set `DEBFULLNAME` for
+`DEBFULLNAME` and `DEBEMAIL`. As `debuild` creates a clean environment it
+filters out many of the environment variables, so to set `DEBFULLNAME` for
 the `debchange` command in the makefile, you have to set `DEB_FULLNAME`.
+`DEBEMAIL` is not filtered, so you an use that directly.
 If these variables are not set, `debchange` will try to find appropriate
 values from the system configuration, usually by using the login name
 and the domain-name.
 
 ```sh
 export DEB_FULLNAME="Your Name"
-export EMAIL="you@example.org"
+export DEBEMAIL="you@example.org"
 ```
 
 ## Building

--- a/dist/debian/changelog
+++ b/dist/debian/changelog
@@ -1,4 +1,4 @@
-apptainer (1.0.0-1) unstable; urgency=low
+apptainer (0.1.0-1) unstable; urgency=low
 
   * Placeholder
 

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -55,6 +55,8 @@ su testuser -c '
     fi
   fi
   go version
+  export DEB_FULLNAME="'"${DEB_FULLNAME:-CI Test}"'"
+  export DEBEMAIL="'${DEBEMAIL:-citest@example.com}'"
   debuild --build=binary --no-sign --lintian-opts --display-info --show-overrides
   sudo dpkg -i ../apptainer*.deb
 


### PR DESCRIPTION
I think this will fix the errors seen in the debian ci test that cause it to fail due to an invalid version number starting with a hexadecimal letter.