### PR TITLE
Best effort singularty user configuration migration

### DIFF
--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -334,6 +334,7 @@ func migrateRemoteConf(confDir, legacyConfigDir string) {
 	ok, err := fs.PathExists(syfs.LegacyRemoteConf())
 	if err != nil {
 		sylog.Warningf("Failed to retrieve information for %s: %s", syfs.LegacyRemoteConf(), err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", syfs.LegacyRemoteConf(), syfs.RemoteConf())
 		return
 	} else if !ok {
 		return
@@ -343,6 +344,7 @@ func migrateRemoteConf(confDir, legacyConfigDir string) {
 	err = fs.CopyFile(syfs.LegacyRemoteConf(), syfs.RemoteConf(), 0o600)
 	if err != nil {
 		sylog.Warningf("Failed to migrate %s to %s: %s", syfs.LegacyRemoteConf(), syfs.RemoteConf(), err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", syfs.LegacyRemoteConf(), syfs.RemoteConf())
 	}
 }
 
@@ -350,6 +352,7 @@ func migrateDockerConf(confDir, legacyConfigDir string) {
 	ok, err := fs.PathExists(syfs.LegacyDockerConf())
 	if err != nil {
 		sylog.Warningf("Failed to retrieve information for %s: %s", syfs.LegacyDockerConf(), err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", syfs.LegacyDockerConf(), syfs.DockerConf())
 		return
 	} else if !ok {
 		return
@@ -359,23 +362,26 @@ func migrateDockerConf(confDir, legacyConfigDir string) {
 	err = fs.CopyFile(syfs.LegacyDockerConf(), syfs.DockerConf(), 0o600)
 	if err != nil {
 		sylog.Warningf("Failed to migrate %s to %s: %s", syfs.LegacyDockerConf(), syfs.DockerConf(), err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", syfs.LegacyDockerConf(), syfs.DockerConf())
 	}
 }
 
 func migrateSypgp(confDir, legacyConfigDir string) {
 	legacySypgpDir := filepath.Join(syfs.LegacyConfigDir(), sypgp.Directory)
+	sypgpDir := filepath.Join(syfs.ConfigDir(), sypgp.Directory)
 	ok, err := fs.PathExists(legacySypgpDir)
 	if err != nil {
 		sylog.Warningf("Failed to retrieve information for %s: %s", legacySypgpDir, err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", legacySypgpDir, sypgpDir)
 		return
 	} else if !ok {
 		return
 	}
 
-	sypgpDir := filepath.Join(syfs.ConfigDir(), sypgp.Directory)
 	err = fs.Mkdir(sypgpDir, 0o700)
 	if err != nil {
 		sylog.Debugf("Could not create %s: %s", sypgpDir, err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", legacySypgpDir, sypgpDir)
 		return
 	}
 
@@ -389,6 +395,7 @@ func migrateSypgpPublic(sypgpDir, legacySypgpDir string) {
 	ok, err := fs.PathExists(legacyPublicPath)
 	if err != nil {
 		sylog.Warningf("Failed to retrieve information for %s: %s", legacyPublicPath, err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", legacyPublicPath, publicPath)
 		return
 	} else if !ok {
 		return
@@ -398,6 +405,7 @@ func migrateSypgpPublic(sypgpDir, legacySypgpDir string) {
 	err = fs.CopyFile(legacyPublicPath, publicPath, 0o600)
 	if err != nil {
 		sylog.Warningf("Failed to migrate %s to %s: %s", legacyPublicPath, publicPath, err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", legacyPublicPath, publicPath)
 	}
 }
 
@@ -407,6 +415,7 @@ func migrateSypgpPrivate(sypgpDir, legacySypgpDir string) {
 	ok, err := fs.PathExists(legacyPrivatePath)
 	if err != nil {
 		sylog.Warningf("Failed to retrieve information for %s: %s", legacyPrivatePath, err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", legacyPrivatePath, privatePath)
 		return
 	} else if !ok {
 		return
@@ -416,6 +425,7 @@ func migrateSypgpPrivate(sypgpDir, legacySypgpDir string) {
 	err = fs.CopyFile(legacyPrivatePath, privatePath, 0o600)
 	if err != nil {
 		sylog.Warningf("Failed to migrate %s to %s: %s", legacyPrivatePath, privatePath, err)
+		sylog.Warningf("Migration failed, you can migrate manually with \"cp -a %s %s\"", legacyPrivatePath, privatePath)
 	}
 }
 

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -330,7 +330,6 @@ func handleConfDir(confDir, legacyConfigDir string) {
 }
 
 func migrateRemoteConf(confDir, legacyConfigDir string) {
-	// migrate remote config
 	ok, err := fs.PathExists(syfs.LegacyRemoteConf())
 	if err != nil {
 		sylog.Warningf("Failed to retrieve information for %s: %s", syfs.LegacyRemoteConf(), err)
@@ -341,6 +340,15 @@ func migrateRemoteConf(confDir, legacyConfigDir string) {
 	}
 
 	sylog.Infof("Detected Singularity remote configuration, migrating...")
+
+	// Try to load legacy remote config to check version compatibility
+	_, err = loadRemoteConf(syfs.LegacyRemoteConf())
+	if err != nil {
+		sylog.Warningf("Migration failed, unable to read legacy remote configuration: %s", err)
+		sylog.Warningf("It may be of an incompatible format and needs to be reconstructed manually with the \"apptainer remote\" command group.")
+		return
+	}
+
 	err = fs.CopyFile(syfs.LegacyRemoteConf(), syfs.RemoteConf(), 0o600)
 	if err != nil {
 		sylog.Warningf("Failed to migrate %s to %s: %s", syfs.LegacyRemoteConf(), syfs.RemoteConf(), err)

--- a/cmd/internal/cli/apptainer_test.go
+++ b/cmd/internal/cli/apptainer_test.go
@@ -26,14 +26,14 @@ func TestCreateConfDir(t *testing.T) {
 	dir := "/tmp/" + string(bytes)
 
 	// create the directory and check that it exists
-	handleConfDir(dir)
+	handleConfDir(dir, "")
 	defer os.RemoveAll(dir)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		t.Errorf("failed to create directory %s", dir)
 	} else {
 		// stick something in the directory and make sure it isn't deleted
 		ioutil.WriteFile(dir+"/foo", []byte(""), 0o655)
-		handleConfDir(dir)
+		handleConfDir(dir, "")
 		if _, err := os.Stat(dir + "/foo"); os.IsNotExist(err) {
 			t.Errorf("inadvertently overwrote existing directory %s", dir)
 		}

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -29,6 +29,7 @@ const (
 	RemoteCache    = "remote-cache"
 	DockerConfFile = "docker-config.json"
 	apptainerDir   = ".apptainer"
+	legacyDir      = ".singularity"
 )
 
 // cache contains the information for the current user
@@ -41,14 +42,14 @@ var cache struct {
 // configuration and data is located.
 func ConfigDir() string {
 	cache.Do(func() {
-		cache.configDir = configDir()
+		cache.configDir = configDir(apptainerDir)
 		sylog.Debugf("Using apptainer directory %q", cache.configDir)
 	})
 
 	return cache.configDir
 }
 
-func configDir() string {
+func configDir(dir string) string {
 	user, err := user.Current()
 	if err != nil {
 		sylog.Warningf("Could not lookup the current user's information: %s", err)
@@ -56,13 +57,13 @@ func configDir() string {
 		cwd, err := os.Getwd()
 		if err != nil {
 			sylog.Warningf("Could not get current working directory: %s", err)
-			return apptainerDir
+			return dir
 		}
 
-		return filepath.Join(cwd, apptainerDir)
+		return filepath.Join(cwd, dir)
 	}
 
-	return filepath.Join(user.HomeDir, apptainerDir)
+	return filepath.Join(user.HomeDir, dir)
 }
 
 func RemoteConf() string {
@@ -90,4 +91,25 @@ func ConfigDirForUsername(username string) (string, error) {
 	}
 
 	return filepath.Join(u.HomeDir, apptainerDir), nil
+}
+
+// LegacyConfigDir returns where singularity stores user configuration.
+// NOTE: this location should only be used for migration/compatibility and
+// never written to by apptainer.
+func LegacyConfigDir() string {
+	return configDir(legacyDir)
+}
+
+// LegacyRemoteConf returns where singularity stores user remote configuration.
+// NOTE: this location should only be used for migration/compatibility and
+// never written to by apptainer.
+func LegacyRemoteConf() string {
+	return filepath.Join(LegacyConfigDir(), RemoteConfFile)
+}
+
+// LegacyDockerConf reutrns where singularity stores user oci registry configuration.
+// NOTE: this location should only be used for migration/compatibility and
+// never written to by apptainer.
+func LegacyDockerConf() string {
+	return filepath.Join(LegacyConfigDir(), DockerConfFile)
 }

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -50,6 +50,12 @@ const (
 `
 )
 
+const (
+	Directory  = "sypgp"
+	PublicFile = "pgp-public"
+	SecretFile = "pgp-secret"
+)
+
 var (
 	errNotEncrypted = errors.New("key is not encrypted")
 
@@ -101,7 +107,7 @@ func GetTokenFile() string {
 func dirPath() string {
 	sypgpDir := os.Getenv("APPTAINER_SYPGPDIR")
 	if sypgpDir == "" {
-		return filepath.Join(syfs.ConfigDir(), "sypgp")
+		return filepath.Join(syfs.ConfigDir(), Directory)
 	}
 	return sypgpDir
 }
@@ -127,7 +133,7 @@ func NewHandle(path string, opts ...HandleOpt) *Handle {
 
 // SecretPath returns a string describing the path to the private keys store
 func (keyring *Handle) SecretPath() string {
-	return filepath.Join(keyring.path, "pgp-secret")
+	return filepath.Join(keyring.path, SecretFile)
 }
 
 // PublicPath returns a string describing the path to the public keys store
@@ -135,7 +141,7 @@ func (keyring *Handle) PublicPath() string {
 	if keyring.global {
 		return filepath.Join(keyring.path, "global-pgp-public")
 	}
-	return filepath.Join(keyring.path, "pgp-public")
+	return filepath.Join(keyring.path, PublicFile)
 }
 
 // ensureDirPrivate makes sure that the file system mode for the named


### PR DESCRIPTION
## Description of the Pull Request (PR):

In the scenario where a `~/.apptainer` directory doesn't exist, check if a `~/.singularity` directory does exist and migrate important user configuration to a newly created `~/.apptainer` directory for use by Apptainer. If a `~/.apptainer` directory already exists, use it as is. If an error is encountered during migration, it will continue to command execution without failure.

Relevant configurations to migrate:
- Remote endpoint configuration
- OCI registry credential configuration
- PGP keyrings


Example output:
```
$ apptainer key list
INFO:    Detected Singularity user configuration directory
INFO:    Detected Singularity remote configuration, migrating...
INFO:    Detected Singularity docker configuration, migrating...
INFO:    Detected public Singularity pgp keyring, migrating...
INFO:    Detected private Singularity pgp keyring, migrating...
Public key listing (/home/ian/.apptainer/sypgp/pgp-public):

0) U: ian (no) <yes>
   C: 2021-09-26 09:03:25 -0700 PDT
   F: B94AFD91E7B0E6BD78D0FD84E79724230F0280CF
   L: 4096
   --------
1) U: test (test) <test@example.com>
   C: 2021-09-26 12:33:22 -0700 PDT
   F: D869067C8CCADEE8E3749AAED390476B51506B96
   L: 4096
   --------
2) U: test (test) <test@example.com>
   C: 2021-09-26 12:33:43 -0700 PDT
   F: 652216A95FC64CBE881CEE5EF3C3BCFE64525D5C
   L: 4096
   --------
$ apptainer key list
Public key listing (/home/ian/.apptainer/sypgp/pgp-public):

0) U: ian (no) <yes>
   C: 2021-09-26 09:03:25 -0700 PDT
   F: B94AFD91E7B0E6BD78D0FD84E79724230F0280CF
   L: 4096
   --------
1) U: test (test) <test@example.com>
   C: 2021-09-26 12:33:22 -0700 PDT
   F: D869067C8CCADEE8E3749AAED390476B51506B96
   L: 4096
   --------
2) U: test (test) <test@example.com>
   C: 2021-09-26 12:33:43 -0700 PDT
   F: 652216A95FC64CBE881CEE5EF3C3BCFE64525D5C
   L: 4096
   --------

```

### This fixes or addresses the following GitHub issues:

 - Fixes #46 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
