### PR TITLE
Warn if singularity configuration directory still exists

### DIFF
--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -447,6 +447,12 @@ func persistentPreRun(*cobra.Command, []string) {
 		}
 	}
 
+	oldconfdir := filepath.Dir(filepath.Dir(configurationFile)) + "/singularity/"
+
+	if _, err := os.Stat(oldconfdir); err == nil {
+		sylog.Warningf("%s exists, migration to apptainer by system administrator is not complete", oldconfdir)
+	}
+
 	sylog.Debugf("Parsing configuration file %s", configurationFile)
 	config, err := apptainerconf.Parse(configurationFile)
 	if err != nil {

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -148,6 +148,10 @@ cd %{name}-%{package_version}
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man1
 make -C builddir DESTDIR=$RPM_BUILD_ROOT install man
 
+%posttrans
+# clean out empty directories under /etc/singularity
+rmdir %{_sysconfdir}/singularity/* %{_sysconfdir}/singularity 2>/dev/null || true
+
 %files
 %attr(4755, root, root) %{_libexecdir}/%{name}/bin/starter-suid
 %{_bindir}/%{name}


### PR DESCRIPTION
Print a warning if `$(dirname $(dirname apptainerconf_path))/singularity/` still exists.  Make sure that any empty directories under that path get cleaned up when an apptainer rpm is installed.  Debian by default never cleans up old configurations so system administrators will need to do `dpkg purge singularity` or `apt-get purge singularity`.

 - Fixes #87
