### PR TITLE
fix: do not require working keyserver config in local build, from sylabs 466

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Restructure loop device discovery to address `EAGAIN` issue, sleep/retry
   approach is replaced by a call to the sync syscall to commit cached pages
   to the underyling filesystem.
+- Ensure a local build does not fail unnecessarily if a keyserver
+  config cannot be retrieved from the remote endpoint.
 
 ### Changes for Testing / Development
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/cryptkey"
+	keyClient "github.com/apptainer/container-key-client/client"
 	"github.com/spf13/cobra"
 )
 
@@ -179,21 +180,28 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 		sylog.Fatalf("Unable to build from %s: %v", spec, err)
 	}
 
+	authToken := ""
 	hasLibrary := false
 	libraryURL := ""
+	hasSIF := false
 
-	// only resolve remote endpoints if library is a build source
 	for _, d := range defs {
+		// If there's a library source we need the library client, and it'll be a SIF
 		if d.Header["bootstrap"] == "library" {
 			hasLibrary = true
+			hasSIF = true
 		}
 		if val, ok := d.Header["library"]; ok {
 			libraryURL = val
 		}
+		// Certain other bootstrap sources may result in a SIF image source
+		if d.Header["bootstrap"] == "localimage" || d.Header["bootstrap"] == "oras" || d.Header["bootstrap"] == "shub" {
+			hasSIF = true
+		}
 	}
 
-	authToken := ""
-
+	// We only need to initialize the library client if we have a library source
+	// in our definition file.
 	if hasLibrary {
 		if buildArgs.libraryURL == "" && libraryURL != "" {
 			buildArgs.libraryURL = libraryURL
@@ -206,9 +214,16 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 		authToken = lc.AuthToken
 	}
 
-	co, err := getKeyserverClientOpts(buildArgs.keyServerURL, endpoint.KeyserverVerifyOp)
-	if err != nil {
-		sylog.Fatalf("Unable to get key server client configuration: %v", err)
+	// We only need to initialize the key server client if we have a source
+	// in our definition file that could provide a SIF. Only SIFs verify in the build.
+	var ko []keyClient.Option
+	if hasSIF {
+		ko, err = getKeyserverClientOpts(buildArgs.keyServerURL, endpoint.KeyserverVerifyOp)
+		if err != nil {
+			// Do not hard fail if we can't get a keyserver config.
+			// Verification can use the local keyring still.
+			sylog.Warningf("Unable to get key server client configuration: %v", err)
+		}
 	}
 
 	buildFormat := "sif"
@@ -236,7 +251,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 				NoHTTPS:           noHTTPS,
 				LibraryURL:        buildArgs.libraryURL,
 				LibraryAuthToken:  authToken,
-				KeyServerOpts:     co,
+				KeyServerOpts:     ko,
 				DockerAuthConfig:  authConf,
 				EncryptionKeyInfo: keyInfo,
 				FixPerms:          buildArgs.fixPerms,


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#466
which fixed
- sylabs/singularity#465

The original PR description was:

> At the CLI level, local builds had a hard fail if a keyserver config could not be retrieved.
> 
> 1. Warn instead of fail. For builds that perform verification of a
>        SIF, it may still be possbile to verify using the local keyring.
> 
> 2. Don't attempt to get a keyserver config at all, unless build
>        definition has a bootstrap that will, or may provide a SIF source
>        image (library/localimage/oras/shub).