### PR TITLE
Fixes #155 - stop using keywords as variable names

### DIFF
--- a/internal/app/apptainer/capability_avail_linux.go
+++ b/internal/app/apptainer/capability_avail_linux.go
@@ -29,8 +29,8 @@ func CapabilityAvail(c CapAvailConfig) error {
 	}
 
 	if len(caps) > 0 {
-		for _, cap := range caps {
-			fmt.Printf("%-22s %s\n\n", cap+":", capabilities.Map[cap].Description)
+		for _, capability := range caps {
+			fmt.Printf("%-22s %s\n\n", capability+":", capabilities.Map[capability].Description)
 		}
 		return nil
 	}

--- a/internal/app/apptainer/capability_list_linux.go
+++ b/internal/app/apptainer/capability_list_linux.go
@@ -50,16 +50,16 @@ func CapabilityList(capFile string, c CapListConfig) error {
 	if c.All {
 		users, groups := capConfig.ListAllCaps()
 
-		for user, cap := range users {
-			if len(cap) > 0 {
-				fmt.Printf("%s [user]: %s\n", user, strings.Join(cap, ","))
+		for user, capability := range users {
+			if len(capability) > 0 {
+				fmt.Printf("%s [user]: %s\n", user, strings.Join(capability, ","))
 				outputCaps++
 			}
 		}
 
-		for group, cap := range groups {
-			if len(cap) > 0 {
-				fmt.Printf("%s [group]: %s\n", group, strings.Join(cap, ","))
+		for group, capability := range groups {
+			if len(capability) > 0 {
+				fmt.Printf("%s [group]: %s\n", group, strings.Join(capability, ","))
 				outputCaps++
 			}
 		}

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -357,7 +357,7 @@ func copyFiles(b *types.Bundle, a *App) error {
 		trimLine := strings.Split(strings.TrimSpace(line), "#")[0]
 		splitLine := strings.SplitN(strings.TrimSpace(trimLine), " ", 2)
 
-		// copy to dst of same name in app if no dst is specified
+		// copyFile to dst of same name in app if no dst is specified
 		var src, dst string
 		if len(splitLine) < 2 {
 			src = splitLine[0]
@@ -367,7 +367,7 @@ func copyFiles(b *types.Bundle, a *App) error {
 			dst = splitLine[1]
 		}
 
-		if err := copy(src, filepath.Join(appBase, dst)); err != nil {
+		if err := copyFile(src, filepath.Join(appBase, dst)); err != nil {
 			return err
 		}
 	}
@@ -427,17 +427,17 @@ func appData(b *types.Bundle, a *App) string {
 	return filepath.Join(b.RootfsPath, "/scif/data/", a.Name)
 }
 
-func copy(src, dst string) error {
+func copyFile(src, dst string) error {
 	cp, err := bin.FindBin("cp")
 	if err != nil {
 		return err
 	}
 
 	var stderr bytes.Buffer
-	copy := exec.Command(cp, "-fLr", src, dst)
-	copy.Stderr = &stderr
+	copyCommand := exec.Command(cp, "-fLr", src, dst)
+	copyCommand.Stderr = &stderr
 	sylog.Debugf("Copying %v to %v", src, dst)
-	if err := copy.Run(); err != nil {
+	if err := copyCommand.Run(); err != nil {
 		return fmt.Errorf("while copying %v to %v: %v: %v", src, dst, err, stderr.String())
 	}
 

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -84,10 +84,10 @@ func CopyFromHost(src, dstRel, dstRootfs string) error {
 		if err != nil {
 			return err
 		}
-		copy := exec.Command(cp, args...)
-		copy.Stdout = &output
-		copy.Stderr = &stderr
-		if err := copy.Run(); err != nil {
+		copyCmd := exec.Command(cp, args...)
+		copyCmd.Stdout = &output
+		copyCmd.Stderr = &stderr
+		if err := copyCmd.Run(); err != nil {
 			return fmt.Errorf("while copying %s to %s: %v: %s", paths, dstResolved, args, stderr.String())
 		}
 

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -191,8 +191,8 @@ func insertDefinition(b *types.Bundle) error {
 			}
 
 			// name is "Apptainer" concatenated with an index based on number of other files in bootstrap_history
-			len := strconv.Itoa(len(files))
-			histName := "Apptainer" + len
+			length := strconv.Itoa(len(files))
+			histName := "Apptainer" + length
 			// move old definition into bootstrap_history
 			err = os.Rename(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history", histName))
 			if err != nil {

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -90,13 +90,13 @@ func TestWriteToReadFrom(t *testing.T) {
 
 			test.c.WriteTo(&r)
 
-			new, err := ReadFrom(&r)
+			item, err := ReadFrom(&r)
 			if err != nil {
 				t.Errorf("unexpected failure running %s test: %s", test.name, err)
 			}
 
-			if !reflect.DeepEqual(test.c, *new) {
-				t.Errorf("failed to read/write config:\n\thave: %v\n\twant: %v", test.c, *new)
+			if !reflect.DeepEqual(test.c, *item) {
+				t.Errorf("failed to read/write config:\n\thave: %v\n\twant: %v", test.c, *item)
 			}
 		})
 	}

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -293,10 +293,10 @@ func (e *EngineOperations) prepareUserCaps(enforced bool) error {
 	if len(ignoredCaps) > 0 {
 		sylog.Warningf("won't drop unknown capability: %s", strings.Join(ignoredCaps, ","))
 	}
-	for _, cap := range caps {
+	for _, capability := range caps {
 		for i, c := range commonCaps {
-			if c == cap {
-				sylog.Debugf("Capability %s dropped", cap)
+			if c == capability {
+				sylog.Debugf("Capability %s dropped", capability)
 				commonCaps = append(commonCaps[:i], commonCaps[i+1:]...)
 				break
 			}
@@ -378,17 +378,17 @@ func (e *EngineOperations) prepareRootCaps() error {
 	if len(ignoredCaps) > 0 {
 		sylog.Warningf("won't add unknown capability: %s", strings.Join(ignoredCaps, ","))
 	}
-	for _, cap := range caps {
+	for _, capability := range caps {
 		found := false
 		for _, c := range commonCaps {
-			if c == cap {
+			if c == capability {
 				found = true
 				break
 			}
 		}
 		if !found {
-			sylog.Debugf("Root capability %s added", cap)
-			commonCaps = append(commonCaps, cap)
+			sylog.Debugf("Root capability %s added", capability)
+			commonCaps = append(commonCaps, capability)
 		}
 	}
 
@@ -398,10 +398,10 @@ func (e *EngineOperations) prepareRootCaps() error {
 	if len(ignoredCaps) > 0 {
 		sylog.Warningf("won't add unknown capability: %s", strings.Join(ignoredCaps, ","))
 	}
-	for _, cap := range caps {
+	for _, capability := range caps {
 		for i, c := range commonCaps {
-			if c == cap {
-				sylog.Debugf("Root capability %s dropped", cap)
+			if c == capability {
+				sylog.Debugf("Root capability %s dropped", capability)
 				commonCaps = append(commonCaps[:i], commonCaps[i+1:]...)
 				break
 			}

--- a/internal/pkg/runtime/engine/oci/prepare_linux.go
+++ b/internal/pkg/runtime/engine/oci/prepare_linux.go
@@ -227,29 +227,29 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 }
 
 func (e *EngineOperations) checkCapabilities() error {
-	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Permitted {
-		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("unrecognized capabilities %s", cap)
+	for _, capability := range e.EngineConfig.OciConfig.Process.Capabilities.Permitted {
+		if _, ok := capabilities.Map[capability]; !ok {
+			return fmt.Errorf("unrecognized capabilities %s", capability)
 		}
 	}
-	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Effective {
-		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("unrecognized capabilities %s", cap)
+	for _, capability := range e.EngineConfig.OciConfig.Process.Capabilities.Effective {
+		if _, ok := capabilities.Map[capability]; !ok {
+			return fmt.Errorf("unrecognized capabilities %s", capability)
 		}
 	}
-	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Inheritable {
-		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("unrecognized capabilities %s", cap)
+	for _, capability := range e.EngineConfig.OciConfig.Process.Capabilities.Inheritable {
+		if _, ok := capabilities.Map[capability]; !ok {
+			return fmt.Errorf("unrecognized capabilities %s", capability)
 		}
 	}
-	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Bounding {
-		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("unrecognized capabilities %s", cap)
+	for _, capability := range e.EngineConfig.OciConfig.Process.Capabilities.Bounding {
+		if _, ok := capabilities.Map[capability]; !ok {
+			return fmt.Errorf("unrecognized capabilities %s", capability)
 		}
 	}
-	for _, cap := range e.EngineConfig.OciConfig.Process.Capabilities.Ambient {
-		if _, ok := capabilities.Map[cap]; !ok {
-			return fmt.Errorf("unrecognized capabilities %s", cap)
+	for _, capability := range e.EngineConfig.OciConfig.Process.Capabilities.Ambient {
+		if _, ok := capabilities.Map[capability]; !ok {
+			return fmt.Errorf("unrecognized capabilities %s", capability)
 		}
 	}
 	return nil

--- a/internal/pkg/util/gpu/nvidia.go
+++ b/internal/pkg/util/gpu/nvidia.go
@@ -177,11 +177,11 @@ func NVCLIEnvToFlags(nvidiaEnv []string) (flags []string, err error) {
 			defaultDriverCaps = false
 			caps := strings.Split(pair[1], ",")
 
-			for _, cap := range caps {
-				if slice.ContainsString(nVDriverCapabilities, cap) {
-					flags = append(flags, "--"+cap)
+			for _, capability := range caps {
+				if slice.ContainsString(nVDriverCapabilities, capability) {
+					flags = append(flags, "--"+capability)
 				} else {
-					return nil, fmt.Errorf("unknown NVIDIA_DRIVER_CAPABILITIES value: %s", cap)
+					return nil, fmt.Errorf("unknown NVIDIA_DRIVER_CAPABILITIES value: %s", capability)
 				}
 			}
 		}
@@ -199,8 +199,8 @@ func NVCLIEnvToFlags(nvidiaEnv []string) (flags []string, err error) {
 	}
 
 	if defaultDriverCaps {
-		for _, cap := range nVDriverDefaultCapabilities {
-			flags = append(flags, "--"+cap)
+		for _, capability := range nVDriverDefaultCapabilities {
+			flags = append(flags, "--"+capability)
 		}
 	}
 

--- a/pkg/util/capabilities/config.go
+++ b/pkg/util/capabilities/config.go
@@ -89,19 +89,19 @@ func (c *Config) AddUserCaps(user string, caps []string) error {
 	if err := c.checkCaps(caps); err != nil {
 		return err
 	}
-	for _, cap := range caps {
+	for _, capability := range caps {
 		present := false
 		for _, c := range c.Users[user] {
-			if c == cap {
+			if c == capability {
 				present = true
 			}
 		}
 		if !present {
-			c.Users[user] = append(c.Users[user], cap)
-			sylog.Warningf("Adding '%s' capability will likely allow user %s to escalate privilege on the host", cap, user)
-			sylog.Warningf("Use 'apptainer capability drop --user %s %s' to reverse this action if necessary", user, cap)
+			c.Users[user] = append(c.Users[user], capability)
+			sylog.Warningf("Adding '%s' capability will likely allow user %s to escalate privilege on the host", capability, user)
+			sylog.Warningf("Use 'apptainer capability drop --user %s %s' to reverse this action if necessary", user, capability)
 		} else {
-			sylog.Warningf("Won't add capability '%s', already assigned to user %s", cap, user)
+			sylog.Warningf("Won't add capability '%s', already assigned to user %s", capability, user)
 		}
 	}
 	return nil
@@ -112,17 +112,17 @@ func (c *Config) AddGroupCaps(group string, caps []string) error {
 	if err := c.checkCaps(caps); err != nil {
 		return err
 	}
-	for _, cap := range caps {
+	for _, capability := range caps {
 		present := false
 		for _, c := range c.Groups[group] {
-			if c == cap {
+			if c == capability {
 				present = true
 			}
 		}
 		if !present {
-			c.Groups[group] = append(c.Groups[group], cap)
+			c.Groups[group] = append(c.Groups[group], capability)
 		} else {
-			sylog.Warningf("Won't add capability '%s', already assigned to group %s", cap, group)
+			sylog.Warningf("Won't add capability '%s', already assigned to group %s", capability, group)
 		}
 	}
 	return nil
@@ -137,17 +137,17 @@ func (c *Config) DropUserCaps(user string, caps []string) error {
 	if _, ok := c.Users[user]; !ok {
 		return fmt.Errorf("user '%s' doesn't have any capability assigned", user)
 	}
-	for _, cap := range caps {
+	for _, capability := range caps {
 		dropped := false
 		for i := len(c.Users[user]) - 1; i >= 0; i-- {
-			if c.Users[user][i] == cap {
+			if c.Users[user][i] == capability {
 				c.Users[user] = append(c.Users[user][:i], c.Users[user][i+1:]...)
 				dropped = true
 				break
 			}
 		}
 		if !dropped {
-			sylog.Warningf("Won't drop capability '%s', not assigned to user %s", cap, user)
+			sylog.Warningf("Won't drop capability '%s', not assigned to user %s", capability, user)
 		}
 	}
 	if len(c.Users[user]) == 0 {
@@ -165,17 +165,17 @@ func (c *Config) DropGroupCaps(group string, caps []string) error {
 	if _, ok := c.Groups[group]; !ok {
 		return fmt.Errorf("group '%s' doesn't have any capability assigned", group)
 	}
-	for _, cap := range caps {
+	for _, capability := range caps {
 		dropped := false
 		for i := len(c.Groups[group]) - 1; i >= 0; i-- {
-			if c.Groups[group][i] == cap {
+			if c.Groups[group][i] == capability {
 				c.Groups[group] = append(c.Groups[group][:i], c.Groups[group][i+1:]...)
 				dropped = true
 				break
 			}
 		}
 		if !dropped {
-			sylog.Warningf("Won't drop capability '%s', not assigned to group %s", cap, group)
+			sylog.Warningf("Won't drop capability '%s', not assigned to group %s", capability, group)
 		}
 	}
 	if len(c.Groups[group]) == 0 {

--- a/pkg/util/capabilities/config_test.go
+++ b/pkg/util/capabilities/config_test.go
@@ -49,13 +49,13 @@ func TestReadFromWriteTo(t *testing.T) {
 
 			test.c.WriteTo(&r)
 
-			new, err := ReadFrom(&r)
+			item, err := ReadFrom(&r)
 			if err != nil {
 				t.Errorf("unexpected failure running %s test: %s", test.name, err)
 			}
 
-			if !reflect.DeepEqual(test.c, *new) {
-				t.Errorf("failed to read/write config:\n\thave: %v\n\twant: %v", test.c, *new)
+			if !reflect.DeepEqual(test.c, *item) {
+				t.Errorf("failed to read/write config:\n\thave: %v\n\twant: %v", test.c, *item)
 			}
 		})
 	}

--- a/pkg/util/capabilities/process_linux.go
+++ b/pkg/util/capabilities/process_linux.go
@@ -86,9 +86,9 @@ func SetProcessEffective(caps uint64) (uint64, error) {
 				continue
 			}
 			strCap := "UNKNOWN"
-			for _, cap := range Map {
-				if uint(i) == cap.Value {
-					strCap = cap.Name
+			for _, capability := range Map {
+				if uint(i) == capability.Value {
+					strCap = capability.Name
 					break
 				}
 			}

--- a/pkg/util/capabilities/process_linux_test.go
+++ b/pkg/util/capabilities/process_linux_test.go
@@ -46,8 +46,8 @@ func TestGetProcess(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error while getting process %s capabilities: %s", tt.name, err)
 		}
-		cap := Map[tt.cap]
-		if tt.cap != "" && caps&uint64(1<<cap.Value) == 0 {
+		capability := Map[tt.cap]
+		if tt.cap != "" && caps&uint64(1<<capability.Value) == 0 {
 			t.Fatalf("%s capability %s missing", tt.name, tt.cap)
 		}
 	}


### PR DESCRIPTION
Fixes #155 - stop using keywords as variable names
rename:
* caps
* len
* new
