### PR TITLE
Fixes #145 - document export names

### DIFF
--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -1,6 +1,7 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
+
 package cli
 
 import (

--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -1,6 +1,7 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
+
 package cli
 
 import (

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -1,6 +1,7 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
+
 package overlay
 
 import (

--- a/examples/plugins/ubuntu-userns-overlay-plugin/main.go
+++ b/examples/plugins/ubuntu-userns-overlay-plugin/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.
@@ -18,7 +18,7 @@ import (
 	apptainercallback "github.com/apptainer/apptainer/pkg/plugin/callback/runtime/engine/apptainer"
 )
 
-// Allow to use overlay with user namespace on Ubuntu flavors.
+// Plugin allows usage of overlay with user namespace on Ubuntu flavors.
 var Plugin = pluginapi.Plugin{
 	Manifest: pluginapi.Manifest{
 		Name:        "github.com/apptainer/apptainer/ubuntu-userns-overlay-plugin",

--- a/internal/app/apptainer/overlay_create.go
+++ b/internal/app/apptainer/overlay_create.go
@@ -1,10 +1,11 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
+
 package apptainer
 
 import (

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.
@@ -69,7 +69,7 @@ func NewManagerFromFile(specPath string, pid int, group string) (manager Manager
 	return &mgrv1, mgrv1.ApplyFromFile(specPath)
 }
 
-// NewManagerFromFile creates a Manager, applies the configuration in spec, and adds pid to the cgroup.
+// NewManagerFromSpec creates a Manager, applies the configuration in spec, and adds pid to the cgroup.
 // If a group name is supplied, it will be used by the manager.
 // If group = "" then "/apptainer/<pid>" is used as a default.
 func NewManagerFromSpec(spec *specs.LinuxResources, pid int, group string) (manager Manager, err error) {

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.
@@ -17,20 +17,19 @@ import (
 const (
 	// DefaultPath defines default value for PATH environment variable.
 	DefaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	// Apptainer environment variable recognized prefixes.
-	ApptainerPrefix    = "APPTAINER_"
+
+	// ApptainerPrefix Apptainer environment variable recognized prefixes for Apptainer CLI
+	ApptainerPrefix = "APPTAINER_"
+
+	// ApptainerEnvPrefix Apptainer environment variables recognized prefixes for passthru to container
 	ApptainerEnvPrefix = "APPTAINERENV_"
 )
 
-// the following prefixes are for settings looked at by Apptainer command
-// ApptainerPrefixes defines the e2nvironment variable prefixes
+// ApptainerPrefixes the following prefixes are for settings looked at by Apptainer command
 var ApptainerPrefixes = []string{ApptainerPrefix, "SINGULARITY_"}
 
-// the following prefixes are for pass-through to containers
-//
-
 // ApptainerEnvPrefixes defines the environment variable prefixes for passthru
-// variables
+// to container
 var ApptainerEnvPrefixes = []string{ApptainerEnvPrefix, "SINGULARITYENV_"}
 
 // SetFromList sets environment variables from environ argument list.

--- a/internal/pkg/util/user/cgo_lookup_unix.go
+++ b/internal/pkg/util/user/cgo_lookup_unix.go
@@ -1,6 +1,15 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+//
+// This is a slightly patched version of Go's os/user/cgo_lookup_unix.go file.
+// We need full gecos content so the only way to do so is to call C ourselves.
+// User and Group types are taken from this package rather then from os/user.
+//
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -10,19 +19,9 @@
 // +build cgo
 // +build !osusergo
 
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
-// This software is licensed under a 3-clause BSD license. Please consult the
-// LICENSE.md file distributed with the sources of this project regarding your
-// rights to use or distribute this software.
-
-// This is a slightly patched version of Go's os/user/cgo_lookup_unix.go file.
-// We need full gecos content so the only way to do so is to call C ourselves.
-// User and Group types are taken from this package rather then from os/user.
-
 // Do not lint this file in order to keep it as close as possible to the
 // original, even if the original has linter issues.
 
-//nolint
 package user
 
 import (
@@ -96,6 +95,7 @@ func lookupUser(username string) (*User, error) {
 	return buildUser(&pwd), err
 }
 
+//nolint
 func lookupUserId(uid string) (*User, error) {
 	i, e := strconv.Atoi(uid)
 	if e != nil {
@@ -169,6 +169,7 @@ func lookupGroup(groupname string) (*Group, error) {
 	return buildGroup(&grp), nil
 }
 
+//nolint
 func lookupGroupId(gid string) (*Group, error) {
 	i, e := strconv.Atoi(gid)
 	if e != nil {
@@ -280,6 +281,7 @@ func isSizeReasonable(sz int64) bool {
 }
 
 // Because we can't use cgo in tests:
+//nolint
 func structPasswdForNegativeTest() C.struct_passwd {
 	sp := C.struct_passwd{}
 	sp.pw_uid = 1<<32 - 2

--- a/pkg/image/driver.go
+++ b/pkg/image/driver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.
@@ -59,7 +59,7 @@ type Driver interface {
 	Start(*DriverParams) error
 	// Stop the driver for cleanup.
 	Stop() error
-	// Feature returns supported features.
+	// Features Feature returns supported features.
 	Features() DriverFeature
 }
 

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
@@ -207,12 +207,12 @@ func (e *EngineConfig) GetNvCCLI() bool {
 	return e.JSON.NvCCLI
 }
 
-// SetNVCCLIEnv sets env vars holding options for nvidia-container-cli GPU setup
+// SetNvCCLIEnv sets env vars holding options for nvidia-container-cli GPU setup
 func (e *EngineConfig) SetNvCCLIEnv(NvCCLIEnv []string) {
 	e.JSON.NvCCLIEnv = NvCCLIEnv
 }
 
-// GetNVCCLIEnv returns env vars holding options for nvidia-container-cli GPU setup
+// GetNvCCLIEnv returns env vars holding options for nvidia-container-cli GPU setup
 func (e *EngineConfig) GetNvCCLIEnv() []string {
 	return e.JSON.NvCCLIEnv
 }


### PR DESCRIPTION
Fixes #145 - canonical documentation for export names