### PR TITLE
Restore SINGULARITY_LABELS environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes since last release
+
+- The `SINGULARITY_LABELS` environment variable within build definitions has
+  been restored.
+
 ## v1.0.0 Release Candidate 1 - \[22-01-19\]
 
 ### Changes due to the project re-branding

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -38,7 +38,8 @@ const (
 	sLabelsPath  = "/.build.labels"
 	aEnvironment = "APPTAINER_ENVIRONMENT=/.singularity.d/env/91-environment.sh"
 	sEnvironment = "SINGULARITY_ENVIRONMENT=/.singularity.d/env/91-environment.sh"
-	sLabels      = "APPTAINER_LABELS=" + sLabelsPath
+	aLabels      = "APPTAINER_LABELS=" + sLabelsPath
+	sLabels      = "SINGULARITY_LABELS=" + sLabelsPath
 )
 
 // Assemble assembles the bundle to the specified path.
@@ -85,7 +86,7 @@ func (s *stage) runSectionScript(name string, script types.Script) error {
 func (s *stage) runPostScript(configFile, sessionResolv, sessionHosts string) error {
 	if s.b.Recipe.BuildData.Post.Script != "" {
 		cmdArgs := []string{"-s", "-c", configFile, "exec", "--pwd", "/", "--writable"}
-		cmdArgs = append(cmdArgs, "--cleanenv", "--env", aEnvironment, "--env", sEnvironment, "--env", sLabels)
+		cmdArgs = append(cmdArgs, "--cleanenv", "--env", aEnvironment, "--env", sEnvironment, "--env", aLabels, "--env", sLabels)
 
 		if sessionResolv != "" {
 			cmdArgs = append(cmdArgs, "-B", sessionResolv+":/etc/resolv.conf")


### PR DESCRIPTION
## Description of the Pull Request (PR):

During the rename `SINGULARITY_LABELS` was renamed to `APPTAINER_LABELS`. Both need to be supported for definition file compatibility.

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
