### PR TITLE
Auto-release dist tarball and standard rpm & deb packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,42 +265,56 @@ jobs:
             exit 1
           fi
 
-  release_packages:
-    name: Release packages
+  release_assets:
+    name: release_assets
     runs-on: ubuntu-20.04
     if: startsWith(github.ref, 'refs/tags/')
-    needs:
-      - check_go_mod
-      - lint_markdown
-      - check_source
-      - short_unit_tests
-      - integration_tests
-      - e2e_tests
-      - check_pkg_no_buildcfg
-      - shellcheck
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build packages
+      - name: Make dist tarball and rpm packages
         env:
-          DOCKERFILE: ./dist/nfpm/Dockerfile
-          DOCKER_CLI_EXPERIMENTAL: enabled
+          OS_TYPE: centos
+          OS_VERSION: 7
+          GO_ARCH: linux-amd64
           GITHUB_REF: ${{github.ref}}
         run: |
-          docker buildx create --use
-          docker buildx build --platform linux/amd64 \
-          --target build-packages \
-          --build-arg VERSION=${GITHUB_REF#refs/tags/v*} \
-          --build-arg NAME=apptainer \
-          --build-arg PREFIX=/usr/local \
-          --output type=local,dest=./builddir/packages \
-          -f $DOCKERFILE \
-          .
+          # Move the source directory down a level to separate it
+          #  from later builds; the docker build runs privileged and
+          #  changes the ownership of the files.
+          set -x
+          mkdir rpmdir
+          shopt -s extglob
+          mv .??* !(rpmdir) rpmdir
+          cd rpmdir
+          echo ${GITHUB_REF#refs/tags/v*} >VERSION
+          ./scripts/ci-docker-run
+          cp *.tar.gz *.rpm ..
+          cd ..
+          sha256sum *.tar.gz *.rpm > sha256sums
+
+      - name: Make deb packages
+        env:
+          OS_TYPE: debian
+          OS_VERSION: 11
+          GO_ARCH: linux-amd64
+          GITHUB_REF: ${{github.ref}}
+        run: |
+          # Make a new copy of the source files for this build
+          set -x
+          tar xf apptainer-*.tar.gz
+          cd apptainer-${GITHUB_REF#refs/tags/v*}
+          ./scripts/ci-docker-run
+          cp *.deb ..
+          cd ..
+          sha256sum *.deb >> sha256sums
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            ./builddir/packages/*.deb
-            ./builddir/packages/*.rpm
+            *.tar.gz
+            *.rpm
+            *.deb
+            sha256sums

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - The `SINGULARITY_LABELS` environment variable within build definitions has
   been restored.
 - Fix mount ordering between image bind and user binds.
+- Auto-generate release assets including the distribution tarball and
+  rpm (built on CentOS 7) and deb (built on Debian 11) x86_64 packages.
 
 ## v1.0.0 Release Candidate 1 - \[22-01-19\]
 

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -34,22 +34,19 @@ and steps 1-2 should be skipped.
 
 1. From a repository that is up-to-date with main, create a release
    branch e.g. `git checkout upstream/main -b release-1.0`.
-2. Push the release branch to GitHub via `git push upstream release-1.0`.
-3. Examine the GitHub branch protection rules, to extend them to the
+1. Push the release branch to GitHub via `git push upstream release-1.0`.
+1. Examine the GitHub branch protection rules, to extend them to the
    new release branch if needed.  Also examine `.github/dependabot.yml`
    to see if the new branch should be added there.
-4. Modify the `README.md`, `INSTALL.md`, `CHANGELOG.md` via PR against
+1. Modify the `README.md`, `INSTALL.md`, `CHANGELOG.md` via PR against
    the release-1.Y branch, so that they reflect the version to be released.
    1. Apply an annotated tag via `git tag -a -m "Apptainer v1.0.0
       Release Candidate 1" v1.0.0-rc.1`.
-5. Push the tag via `git push upstream v1.0.0-rc.1`.
-6. Create a tarball via `./mconfig --only-rpm -v && make -C builddir dist`.
-7. Test installation from the tarball.
-8. Compute the sha256sum of the tarball e.g. `sha256sum *.tar.gz > sha256sums`.
-9. Create a GitHub release, marked as a 'pre-release', incorporating
-   `CHANGELOG.md` information, and attaching the tarball and
-   `sha256sums`.
-10. Notify the community about the RC via the Google Group and Slack.
+1. Push the tag via `git push upstream v1.0.0-rc.1`.
+1. Create a GitHub release, marked as a 'pre-release', incorporating
+   `CHANGELOG.md` information.  A tarball, rpm packages, deb packages,
+   and a `sha256sums` should get automatically attached.
+1. Notify the community about the RC via the Google Group and Slack.
 
 There will often be multiple release candidates issued prior to the final
 release of a new 1.Y.0 minor version.
@@ -72,11 +69,7 @@ covered by tests.
    the release-1.Y branch, so that they reflect the version to be released.
 1. Apply an annotated tag via `git tag -a -m "Apptainer v1.0.0" v1.0.0`.
 1. Push the tag via `git push upstream v1.0.0`.
-1. Create a tarball via `./mconfig -v && make -C builddir dist`.
-1. Test installation from the tarball.
-1. Compute the sha256sum of the tarball e.g. `sha256sum *.tar.gz > sha256sums`.
-1. Create a GitHub release, incorporating `CHANGELOG.md` information,
-   and attaching the tarball and `sha256sums`.
+1. Create a GitHub release, incorporating `CHANGELOG.md` information.
 1. Notify the community about the RC via the Google Group and Slack.
 
 ## After the Release

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -39,6 +39,8 @@ su testuser -c '
   fi
   go version
   sudo yum-builddep -y apptainer.spec
+  # eliminate the "dist" part in the rpm name, for the release_assets
+  echo "%dist %{nil}" >$HOME/.rpmmacros
   make -C builddir rpm
   sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
   BLD="$(echo $HOME/rpmbuild/BUILD/apptainer-*)"
@@ -46,4 +48,7 @@ su testuser -c '
   PATH=$GOPATH/bin:$PATH
 
   apptainer exec oras://ghcr.io/apptainer/alpine:3.15.0 /bin/true
+
+  # copy the rpms into the current directory for the "release_assets" CI
+  cp $HOME/rpmbuild/SRPMS/*.rpm $HOME/rpmbuild/RPMS/*/*.rpm .
 '


### PR DESCRIPTION
This replaces the existing auto-release of packages built by nfpm with a release of the dist tarball, sha256sums, and rpm (centos7) and deb (debian11) x86_64 packages.