### PR TITLE
Handle remaining legacy environments variables

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/client/oci"
 	"github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/internal/pkg/client/shub"
+	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/spf13/cobra"
@@ -34,8 +35,9 @@ const (
 )
 
 func getCacheHandle(cfg cache.Config) *cache.Handle {
+	envKey := env.TrimApptainerKey(cache.DirEnv)
 	h, err := cache.New(cache.Config{
-		ParentDir: os.Getenv(cache.DirEnv),
+		ParentDir: env.GetenvLegacy(envKey, envKey),
 		Disable:   cfg.Disable,
 	})
 	if err != nil {

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -230,7 +231,8 @@ func New(cfg Config) (h *Handle, err error) {
 
 	// Check whether the cache is disabled by the user.
 	// strconv.ParseBool("") raises an error so we cannot directly use strconv.ParseBool(os.Getenv(DisableEnv))
-	envCacheDisabled := os.Getenv(DisableEnv)
+	envKey := env.TrimApptainerKey(DisableEnv)
+	envCacheDisabled := env.GetenvLegacy(envKey, envKey)
 	if envCacheDisabled == "" {
 		envCacheDisabled = "0"
 	}
@@ -304,7 +306,8 @@ func New(cfg Config) (h *Handle, err error) {
 func getCacheParentDir() string {
 	// If the user defined the special environment variable, we use its value
 	// as base directory.
-	parentDir := os.Getenv(DirEnv)
+	envKey := env.TrimApptainerKey(DirEnv)
+	parentDir := env.GetenvLegacy(envKey, envKey)
 	if parentDir != "" {
 		return parentDir
 	}

--- a/internal/pkg/client/library/library.go
+++ b/internal/pkg/client/library/library.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
+	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 	libClient "github.com/apptainer/container-library-client/client"
@@ -59,7 +60,8 @@ func NormalizeLibraryRef(ref string) (*libClient.Ref, error) {
 }
 
 func getEnvInt(key string, defval int64) int64 {
-	if env := os.Getenv(key); env != "" {
+	envKey := env.TrimApptainerKey(key)
+	if env := env.GetenvLegacy(envKey, envKey); env != "" {
 		if n, err := strconv.ParseInt(env, 10, 0); err == nil {
 			return n
 		}

--- a/internal/pkg/util/env/env_test.go
+++ b/internal/pkg/util/env/env_test.go
@@ -10,6 +10,8 @@
 package env
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/test"
@@ -65,6 +67,89 @@ func TestSetFromList(t *testing.T) {
 			}
 			if !tc.wantErr && err != nil {
 				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestTrimApptainerKey(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	tests := []struct {
+		name     string
+		envKey   string
+		expected string
+	}{
+		{
+			name:     "good",
+			envKey:   ApptainerPrefix + "TEST",
+			expected: "TEST",
+		},
+		{
+			name:     "bad",
+			envKey:   "BADPREFIX_TEST",
+			expected: "BADPREFIX_TEST",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resultKey := TrimApptainerKey(tt.envKey)
+			if tt.expected != resultKey {
+				t.Fatalf("Unexpected error for %s: got %s instead of %s", tt.name, resultKey, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetenvLegacy(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	tests := []struct {
+		name          string
+		envVar        []string
+		key           string
+		legacyKey     string
+		expectedValue string
+	}{
+		{
+			name:          "apptainer only",
+			envVar:        []string{"APPTAINER_TEST_APPTAINER=apptainer"},
+			key:           "TEST_APPTAINER",
+			legacyKey:     "TEST_APPTAINER",
+			expectedValue: "apptainer",
+		},
+		{
+			name:          "singularity only",
+			envVar:        []string{"SINGULARITY_TEST_SINGULARITY=singularity"},
+			key:           "TEST_SINGULARITY",
+			legacyKey:     "TEST_SINGULARITY",
+			expectedValue: "singularity",
+		},
+		{
+			name:          "both",
+			envVar:        []string{"APPTAINER_TEST_BOTH=apptainer", "SINGULARITY_TEST_BOTH=singularity"},
+			key:           "TEST_BOTH",
+			legacyKey:     "TEST_BOTH",
+			expectedValue: "apptainer",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, e := range tt.envVar {
+				s := strings.SplitN(e, "=", 2)
+				os.Setenv(s[0], s[1])
+			}
+			defer func() {
+				for _, e := range tt.envVar {
+					s := strings.SplitN(e, "=", 2)
+					os.Unsetenv(s[0])
+				}
+			}()
+			resultValue := GetenvLegacy(tt.key, tt.legacyKey)
+			if tt.expectedValue != resultValue {
+				t.Errorf("Unexpected error for %s: got %s instead of %s", tt.name, resultValue, tt.expectedValue)
 			}
 		})
 	}

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/internal/pkg/util/interactive"
 	"github.com/apptainer/apptainer/pkg/syfs"
@@ -107,27 +108,10 @@ func GetTokenFile() string {
 
 // dirPath returns a string describing the path to the sypgp home folder
 func dirPath() string {
-	const (
-		keysDirEnv        = "APPTAINER_KEYSDIR"
-		legacySypgpDirEnv = "SINGULARITY_SYPGPDIR"
-	)
-
-	keysEnvVal := os.Getenv(keysDirEnv)
-	legacyEnvVal := os.Getenv(legacySypgpDirEnv)
-
-	if keysEnvVal != "" {
-		if keysEnvVal == legacyEnvVal {
-			sylog.Debugf("%s and %s have the same value [%s]", legacySypgpDirEnv, keysDirEnv, keysEnvVal)
-		} else {
-			sylog.Warningf("%s and %s have different values, using the latter", legacySypgpDirEnv, keysDirEnv)
-		}
-
-		return keysEnvVal
-	} else if legacyEnvVal != "" {
-		sylog.Warningf("DEPRECATED USAGE: Environment variable %s will not be supported in the future, use %s instead", legacySypgpDirEnv, keysDirEnv)
-		return legacyEnvVal
+	// read this as: look for APPTAINER_KEYSDIR and/or SINGULARITY_SYPGPDIR
+	if dir := env.GetenvLegacy("KEYSDIR", "SYPGPDIR"); dir != "" {
+		return dir
 	}
-
 	return filepath.Join(syfs.ConfigDir(), Directory)
 }
 


### PR DESCRIPTION
Have been removed:
- APPTAINER_LOCALCACHEDIR (legacy v2 variable)
- APPTAINER_CACHEDIR, after all this the cache directory not for image extraction (and this is confusing)

Also fix remaining legacy environments variables:
- for cache config
- for library image download

Fixes #206 
