### PR TITLE
Update mvdan.cc/sh to HEAD of v3.4 branch, from sylabs 546

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix mount ordering between image bind and user binds.
 - Auto-generate release assets including the distribution tarball and
   rpm (built on CentOS 7) and deb (built on Debian 11) x86_64 packages.
+- Update dependency to correctly unset variables in container startup
+  environment processing. Fixes regression introduced in singularity-3.8.5.
 
 ## v1.0.0 Release Candidate 1 - \[22-01-19\]
 

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	golang.org/x/term v0.0.0-20210916214954-140adaaadfaf
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.1.0
-	mvdan.cc/sh/v3 v3.4.2
+	mvdan.cc/sh/v3 v3.4.3-0.20220202175809-113ed667a8a7
 	oras.land/oras-go v1.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1716,8 +1716,8 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 mvdan.cc/editorconfig v0.2.0/go.mod h1:lvnnD3BNdBYkhq+B4uBuFFKatfp02eB6HixDvEz91C0=
-mvdan.cc/sh/v3 v3.4.2 h1:d3TKODXfZ1bjWU/StENN+GDg5xOzNu5+C8AEu405E5U=
-mvdan.cc/sh/v3 v3.4.2/go.mod h1:p/tqPPI4Epfk2rICAe2RoaNd8HBSJ8t9Y2DA9yQlbzY=
+mvdan.cc/sh/v3 v3.4.3-0.20220202175809-113ed667a8a7 h1:z01n6PFbC85fnHS4Cz5CwLyZhAyXhmHm9RZJqVMvsHs=
+mvdan.cc/sh/v3 v3.4.3-0.20220202175809-113ed667a8a7/go.mod h1:p/tqPPI4Epfk2rICAe2RoaNd8HBSJ8t9Y2DA9yQlbzY=
 oras.land/oras-go v1.1.0 h1:tfWM1RT7PzUwWphqHU6ptPU3ZhwVnSw/9nEGf519rYg=
 oras.land/oras-go v1.1.0/go.mod h1:1A7vR/0KknT2UkJVWh+xMi95I/AhK8ZrxrnUSmXN0bQ=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=


### PR DESCRIPTION
This pulls in 
- sylabs/singularity#546
which addressed
- sylabs/singularity#543

The PR description was
> Restores `unset` of global vars within a function.