### PR TITLE
Remove subshell overhead in environment processing, from sylabs 545

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   rpm (built on CentOS 7) and deb (built on Debian 11) x86_64 packages.
 - Update dependency to correctly unset variables in container startup
   environment processing. Fixes regression introduced in singularity-3.8.5.
+- Remove subshell overhead when processing large environments on container
+  startup.
 
 ## v1.0.0 Release Candidate 1 - \[22-01-19\]
 

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -6,7 +6,7 @@ Copyright (c) Contributors to the Apptainer project, established as
 - For website terms of use, trademark policy, privacy policy and other
   project policies see: [LF_POLICIES](https://lfprojects.org/policies)
 
-Copyright (c) 2017-2018, Sylabs, Inc. All rights reserved.
+Copyright (c) 2017-2022, Sylabs, Inc. All rights reserved.
 
 Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
 

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -704,27 +704,6 @@ func sylogBuiltin(ctx context.Context, argv []string) error {
 	return nil
 }
 
-// unescapeBuiltin returns a string, unescaping \n to a newline
-// Used to return newlines when we export a var in the action script
-func unescapeBuiltin(ctx context.Context, argv []string) error {
-	if len(argv) < 1 {
-		return fmt.Errorf("unescape builtin requires one argument")
-	}
-	hc := interp.HandlerCtx(ctx)
-	fmt.Fprintf(hc.Stdout, "%s", strings.Replace(argv[0], "\\n", "\n", -1))
-	return nil
-}
-
-// getEnvKeyBuiltin returns the KEY part of an environment variable.
-func getEnvKeyBuiltin(ctx context.Context, argv []string) error {
-	if len(argv) < 1 {
-		return fmt.Errorf("getenvkey builtin requires one argument")
-	}
-	hc := interp.HandlerCtx(ctx)
-	fmt.Fprintf(hc.Stdout, "%s\n", strings.SplitN(argv[0], "=", 2)[0])
-	return nil
-}
-
 // getAllEnvBuiltin display all exported variables in the form KEY=VALUE.
 func getAllEnvBuiltin(shell *interpreter.Shell) interpreter.ShellBuiltin {
 	return func(ctx context.Context, argv []string) error {
@@ -840,11 +819,9 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 
 	// register few builtin
 	shell.RegisterShellBuiltin("getallenv", getAllEnvBuiltin(shell))
-	shell.RegisterShellBuiltin("getenvkey", getEnvKeyBuiltin)
 	shell.RegisterShellBuiltin("sylog", sylogBuiltin)
 	shell.RegisterShellBuiltin("fixpath", fixPathBuiltin)
 	shell.RegisterShellBuiltin("hash", hashBuiltin)
-	shell.RegisterShellBuiltin("unescape", unescapeBuiltin)
 	shell.RegisterShellBuiltin("umask_builtin", umaskBuiltin)
 
 	// exec builtin won't execute the command but instead

--- a/internal/pkg/util/fs/files/action_script.sh
+++ b/internal/pkg/util/fs/files/action_script.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) Contributors to the Apptainer project, established as
 #   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
-# Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+# Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 # This software is licensed under a 3-clause BSD license. Please consult the
 # LICENSE.md file distributed with the sources of this project regarding your
 # rights to use or distribute this software.
@@ -38,7 +38,7 @@ clear_env() {
     set -o noglob
 
     for e in ${__exported_env__}; do
-        key=$(getenvkey "${e}")
+        key=${e%%=*}
         case "${key}" in
         PWD|HOME|OPTIND|UID|GID|SINGULARITY_APPNAME|SINGULARITY_SHELL)
             ;;
@@ -68,9 +68,9 @@ restore_env() {
     # defined by docker or virtual file above, empty
     # variables are also unset
     for e in ${__exported_env__}; do
-        key=$(getenvkey "${e}")
+        key=${e%%=*}
         if ! test -v "${key}"; then
-            export "$(unescape ${e})"
+            export "${e//'\n'/$IFS}"
         elif test -z "${!key}"; then
             unset "${key}"
         fi


### PR DESCRIPTION
This pulls from sylabs
- sylabs/singularity#545
which addressed
- sylabs/singularity#544

The original PR description was
> The action script environment processing was calling out to `getenvkey` and `unescape` go functions via subshell. This is expensive, especially with large environments, as the environment etc. must be duplicated for each subshell and other subshell setup performed.
> 
> Replace these two go functions with shell var substitution syntax.