### PR TITLE
allow mixing of underscores and asterisks in markdown (release-1.0)

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,4 +2,6 @@
 MD024: false
 # Allow hard tabs (go snippets in e2e)
 MD010: false
-
+# Allow mixing of asterisks and underscores for emphasis
+MD049: false
+MD050: false


### PR DESCRIPTION
This is a cherry-pick of #227 for the release-1.0 branch.