### PR TITLE
Replace year in Apptainer copyright with "Contributors" (release-1.0)

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,6 +1,7 @@
 # Copyright
 
-Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+Copyright (c) Contributors to the Apptainer project, established as
+  Apptainer a Series of LF Projects LLC.
 
 - For website terms of use, trademark policy, privacy policy and other
   project policies see: [LF_POLICIES](https://lfprojects.org/policies)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 # License
 
-Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+Copyright (c) Contributors to the Apptainer project, established as
+  Apptainer a Series of LF Projects LLC.
 
 - For website terms of use, trademark policy, privacy policy and other
    project policies see: [LF_POLICIES](https://lfprojects.org/policies)

--- a/cmd/apptainer/.gitignore
+++ b/cmd/apptainer/.gitignore
@@ -1,4 +1,5 @@
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 apptainer

--- a/cmd/apptainer/cli.go
+++ b/cmd/apptainer/cli.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/cmd/bash_completion/bash_completion.go
+++ b/cmd/bash_completion/bash_completion.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/cmd/docs/cmds/cmdtree.go
+++ b/cmd/docs/cmds/cmdtree.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/apptainer_test.go
+++ b/cmd/internal/cli/apptainer_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/buildconfig.go
+++ b/cmd/internal/cli/buildconfig.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/cache_clean_linux.go
+++ b/cmd/internal/cli/cache_clean_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/cache_linux.go
+++ b/cmd/internal/cli/cache_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/cache_list_linux.go
+++ b/cmd/internal/cli/cache_list_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/capability_linux.go
+++ b/cmd/internal/cli/capability_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/checkpoint.go
+++ b/cmd/internal/cli/checkpoint.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/cmd/internal/cli/config_fakeroot_linux.go
+++ b/cmd/internal/cli/config_fakeroot_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/config_global_linux.go
+++ b/cmd/internal/cli/config_global_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/config_linux.go
+++ b/cmd/internal/cli/config_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/delete.go
+++ b/cmd/internal/cli/delete.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/instance_linux.go
+++ b/cmd/internal/cli/instance_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/instance_list_linux.go
+++ b/cmd/internal/cli/instance_list_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/instance_start_linux.go
+++ b/cmd/internal/cli/instance_start_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/instance_stop_linux.go
+++ b/cmd/internal/cli/instance_stop_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/key_import.go
+++ b/cmd/internal/cli/key_import.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/key_list.go
+++ b/cmd/internal/cli/key_list.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/key_newpair_test.go
+++ b/cmd/internal/cli/key_newpair_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/key_push.go
+++ b/cmd/internal/cli/key_push.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/key_search.go
+++ b/cmd/internal/cli/key_search.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 

--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 

--- a/cmd/internal/cli/pgp.go
+++ b/cmd/internal/cli/pgp.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/plugin_compile_linux.go
+++ b/cmd/internal/cli/plugin_compile_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/plugin_create_linux.go
+++ b/cmd/internal/cli/plugin_create_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/plugin_disable_linux.go
+++ b/cmd/internal/cli/plugin_disable_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/plugin_enable_linux.go
+++ b/cmd/internal/cli/plugin_enable_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/plugin_inspect_linux.go
+++ b/cmd/internal/cli/plugin_inspect_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/plugin_install_linux.go
+++ b/cmd/internal/cli/plugin_install_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/plugin_linux.go
+++ b/cmd/internal/cli/plugin_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/plugin_list_linux.go
+++ b/cmd/internal/cli/plugin_list_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/plugin_uninstall_linux.go
+++ b/cmd/internal/cli/plugin_uninstall_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/run_help_linux.go
+++ b/cmd/internal/cli/run_help_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/search.go
+++ b/cmd/internal/cli/search.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/internal/cli/siftool.go
+++ b/cmd/internal/cli/siftool.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2017-2020, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/startvm.go
+++ b/cmd/internal/cli/startvm.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/term.go
+++ b/cmd/internal/cli/term.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/cmd/starter/c/capability.c
+++ b/cmd/starter/c/capability.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+ * Copyright (c) Contributors to the Apptainer project, established as
+ *   Apptainer a Series of LF Projects LLC.
  *   For website terms of use, trademark policy, privacy policy and other
  *   project policies see https://lfprojects.org/policies
  * Copyright (c) 2017-2019, SyLabs, Inc. All rights reserved.

--- a/cmd/starter/c/include/capability.h
+++ b/cmd/starter/c/include/capability.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+ * Copyright (c) Contributors to the Apptainer project, established as
+ *   Apptainer a Series of LF Projects LLC.
  *   For website terms of use, trademark policy, privacy policy and other
  *   project policies see https://lfprojects.org/policies
  * Copyright (c) 2017-2019, SyLabs, Inc. All rights reserved.

--- a/cmd/starter/c/include/message.h
+++ b/cmd/starter/c/include/message.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+ * Copyright (c) Contributors to the Apptainer project, established as
+ *   Apptainer a Series of LF Projects LLC.
  *   For website terms of use, trademark policy, privacy policy and other
  *   project policies see https://lfprojects.org/policies
  * Copyright (c) 2017-2019, SyLabs, Inc. All rights reserved.

--- a/cmd/starter/c/include/securebits.h
+++ b/cmd/starter/c/include/securebits.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+ * Copyright (c) Contributors to the Apptainer project, established as
+ *   Apptainer a Series of LF Projects LLC.
  *   For website terms of use, trademark policy, privacy policy and other
  *   project policies see https://lfprojects.org/policies
  */

--- a/cmd/starter/c/include/setns.h
+++ b/cmd/starter/c/include/setns.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+ * Copyright (c) Contributors to the Apptainer project, established as
+ *   Apptainer a Series of LF Projects LLC.
  *   For website terms of use, trademark policy, privacy policy and other
  *   project policies see https://lfprojects.org/policies
  * Copyright (c) 2017-2019, SyLabs, Inc. All rights reserved.

--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -1,5 +1,6 @@
 /*
-  Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+  Copyright (c) Contributors to the Apptainer project, established as
+    Apptainer a Series of LF Projects LLC.
     For website terms of use, trademark policy, privacy policy and other
     project policies see https://lfprojects.org/policies
   Copyright (c) 2018-2019, Sylabs, Inc. All rights reserved.

--- a/cmd/starter/c/message.c
+++ b/cmd/starter/c/message.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+ * Copyright (c) Contributors to the Apptainer project, established as
+ *   Apptainer a Series of LF Projects LLC.
  *   For website terms of use, trademark policy, privacy policy and other
  *   project policies see https://lfprojects.org/policies
  * Copyright (c) 2017-2019, SyLabs, Inc. All rights reserved.

--- a/cmd/starter/c/setns.c
+++ b/cmd/starter/c/setns.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+ * Copyright (c) Contributors to the Apptainer project, established as
+ *   Apptainer a Series of LF Projects LLC.
  *   For website terms of use, trademark policy, privacy policy and other
  *   project policies see https://lfprojects.org/policies
  * Copyright (c) 2017-2019, SyLabs, Inc. All rights reserved.

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -1,5 +1,6 @@
 /*
-  Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+  Copyright (c) Contributors to the Apptainer project, established as
+    Apptainer a Series of LF Projects LLC.
     For website terms of use, trademark policy, privacy policy and other
     project policies see https://lfprojects.org/policies
   Copyright (c) 2018-2020, Sylabs, Inc. All rights reserved.

--- a/cmd/starter/engines/apptainer_linux.go
+++ b/cmd/starter/engines/apptainer_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/cmd/starter/engines/engines.go
+++ b/cmd/starter/engines/engines.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/cmd/starter/engines/fakeroot_linux.go
+++ b/cmd/starter/engines/fakeroot_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/cmd/starter/engines/oci_linux.go
+++ b/cmd/starter/engines/oci_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/cmd/starter/main_linux.go
+++ b/cmd/starter/main_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/dist/debian/copyright
+++ b/dist/debian/copyright
@@ -5,7 +5,8 @@ Source: https://github.com/apptainer/apptainer
 Files-Excluded: debian
 
 Files: *
-Copyright: Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+Copyright: Copyright (c) Contributors to the Apptainer project, established as
+             Apptainer a Series of LF Projects LLC.
              For website terms of use, trademark policy, privacy policy and other
              project policies see https://lfprojects.org/policies
            2015-2017, Gregory M. Kurtzer <gmkurtzer@lbl.gov>

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2017-2021, SyLabs, Inc. All rights reserved.

--- a/docs/content.go
+++ b/docs/content.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2017-2021, Sylabs Inc. All rights reserved.

--- a/docs/plugin.go
+++ b/docs/plugin.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/docs/templates.go
+++ b/docs/templates.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/buildcfg/buildcfg.go
+++ b/e2e/buildcfg/buildcfg.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/delete/delete.go
+++ b/e2e/delete/delete.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021 Sylabs Inc. All rights reserved.

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/help/help.go
+++ b/e2e/help/help.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/instance/checkpoint.go
+++ b/e2e/instance/checkpoint.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/instance/regressions.go
+++ b/e2e/instance/regressions.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/apptainercmd.go
+++ b/e2e/internal/e2e/apptainercmd.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/config.go
+++ b/e2e/internal/e2e/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/e2e/internal/e2e/docker_auth_server.go
+++ b/e2e/internal/e2e/docker_auth_server.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/e2e/internal/e2e/dockerhub_auth.go
+++ b/e2e/internal/e2e/dockerhub_auth.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/e2e/internal/e2e/ecl_key.go
+++ b/e2e/internal/e2e/ecl_key.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/encrypt.go
+++ b/e2e/internal/e2e/encrypt.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/fileutil.go
+++ b/e2e/internal/e2e/fileutil.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/home.go
+++ b/e2e/internal/e2e/home.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/imagebuild.go
+++ b/e2e/internal/e2e/imagebuild.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/init/init_linux.go
+++ b/e2e/internal/e2e/init/init_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/plugin.go
+++ b/e2e/internal/e2e/plugin.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/priv.go
+++ b/e2e/internal/e2e/priv.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021 Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/profile.go
+++ b/e2e/internal/e2e/profile.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/remote.go
+++ b/e2e/internal/e2e/remote.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021 Sylabs Inc. All rights reserved.

--- a/e2e/internal/e2e/user.go
+++ b/e2e/internal/e2e/user.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/internal/testhelper/doc.go
+++ b/e2e/internal/testhelper/doc.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/internal/testhelper/testhelper.go
+++ b/e2e/internal/testhelper/testhelper.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/e2e/legacy/actions.go
+++ b/e2e/legacy/actions.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 

--- a/e2e/plugin/plugin.go
+++ b/e2e/plugin/plugin.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/plugin/testdata/cli/callback.go
+++ b/e2e/plugin/testdata/cli/callback.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/plugin/testdata/runtime_apptainer/callback.go
+++ b/e2e/plugin/testdata/runtime_apptainer/callback.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/e2e/pull/regressions.go
+++ b/e2e/pull/regressions.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/e2e/runhelp/runhelp.go
+++ b/e2e/runhelp/runhelp.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/e2e/version/version.go
+++ b/e2e/version/version.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/etc/conf/gen.go
+++ b/etc/conf/gen.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/etc/conf/gen_test.go
+++ b/etc/conf/gen_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/etc/configure_transform.py
+++ b/etc/configure_transform.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 '''
-Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+Copyright (c) Contributors to the Apptainer project, established as
+  Apptainer a Series of LF Projects LLC.
   For website terms of use, trademark policy, privacy policy and other
   project policies see https://lfprojects.org/policies
 

--- a/examples/arch/Apptainer
+++ b/examples/arch/Apptainer
@@ -1,4 +1,5 @@
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2015-2016, Maciej Sieczka, Gregory M. Kurtzer. All rights

--- a/examples/plugins/cli-plugin/main.go
+++ b/examples/plugins/cli-plugin/main.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/examples/plugins/config-plugin/main_linux.go
+++ b/examples/plugins/config-plugin/main_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/examples/plugins/log-plugin/main.go
+++ b/examples/plugins/log-plugin/main.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/examples/plugins/ubuntu-userns-overlay-plugin/main.go
+++ b/examples/plugins/ubuntu-userns-overlay-plugin/main.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/cache_clean_linux.go
+++ b/internal/app/apptainer/cache_clean_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/cache_list_linux.go
+++ b/internal/app/apptainer/cache_list_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/capability_avail_linux.go
+++ b/internal/app/apptainer/capability_avail_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/capability_list_linux.go
+++ b/internal/app/apptainer/capability_list_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/capability_manage_linux.go
+++ b/internal/app/apptainer/capability_manage_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/config_fakeroot_linux.go
+++ b/internal/app/apptainer/config_fakeroot_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/config_global_linux.go
+++ b/internal/app/apptainer/config_global_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/delete.go
+++ b/internal/app/apptainer/delete.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/instance_linux.go
+++ b/internal/app/apptainer/instance_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_attach_linux.go
+++ b/internal/app/apptainer/oci_attach_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_create_linux.go
+++ b/internal/app/apptainer/oci_create_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_delete_linux.go
+++ b/internal/app/apptainer/oci_delete_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_exec_linux.go
+++ b/internal/app/apptainer/oci_exec_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_kill_linux.go
+++ b/internal/app/apptainer/oci_kill_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_linux.go
+++ b/internal/app/apptainer/oci_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_mount_linux.go
+++ b/internal/app/apptainer/oci_mount_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_pause_linux.go
+++ b/internal/app/apptainer/oci_pause_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_run_linux.go
+++ b/internal/app/apptainer/oci_run_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_start_linux.go
+++ b/internal/app/apptainer/oci_start_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_state_linux.go
+++ b/internal/app/apptainer/oci_state_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/oci_update_linux.go
+++ b/internal/app/apptainer/oci_update_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/overlay_create.go
+++ b/internal/app/apptainer/overlay_create.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/plugin_compile_linux.go
+++ b/internal/app/apptainer/plugin_compile_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/plugin_create_linux.go
+++ b/internal/app/apptainer/plugin_create_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/plugin_disable_linux.go
+++ b/internal/app/apptainer/plugin_disable_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/plugin_enable_linux.go
+++ b/internal/app/apptainer/plugin_enable_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/plugin_inspect_linux.go
+++ b/internal/app/apptainer/plugin_inspect_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/plugin_install_linux.go
+++ b/internal/app/apptainer/plugin_install_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/plugin_list_linux.go
+++ b/internal/app/apptainer/plugin_list_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/plugin_uninstall_linux.go
+++ b/internal/app/apptainer/plugin_uninstall_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/push.go
+++ b/internal/app/apptainer/push.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/app/apptainer/remote_add.go
+++ b/internal/app/apptainer/remote_add.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/remote_add_keyserver.go
+++ b/internal/app/apptainer/remote_add_keyserver.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/remote_add_test.go
+++ b/internal/app/apptainer/remote_add_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/remote_list.go
+++ b/internal/app/apptainer/remote_list.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/app/apptainer/remote_login.go
+++ b/internal/app/apptainer/remote_login.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/app/apptainer/remote_logout.go
+++ b/internal/app/apptainer/remote_logout.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/app/apptainer/remote_remove.go
+++ b/internal/app/apptainer/remote_remove.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/remote_remove_keyserver.go
+++ b/internal/app/apptainer/remote_remove_keyserver.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/remote_remove_test.go
+++ b/internal/app/apptainer/remote_remove_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/remote_status.go
+++ b/internal/app/apptainer/remote_status.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/app/apptainer/remote_use.go
+++ b/internal/app/apptainer/remote_use.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/app/apptainer/sign.go
+++ b/internal/app/apptainer/sign.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/sign_test.go
+++ b/internal/app/apptainer/sign_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/app/apptainer/verify.go
+++ b/internal/app/apptainer/verify.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/app/apptainer/verify_test.go
+++ b/internal/app/apptainer/verify_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/app/starter/master_linux.go
+++ b/internal/app/starter/master_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/starter/master_linux_test.go
+++ b/internal/app/starter/master_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/app/starter/rpc_linux.go
+++ b/internal/app/starter/rpc_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/app/starter/stage_linux.go
+++ b/internal/app/starter/stage_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/assembler.go
+++ b/internal/pkg/build/assembler.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/assemblers/sandbox.go
+++ b/internal/pkg/build/assemblers/sandbox.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/assemblers/sandbox_test.go
+++ b/internal/pkg/build/assemblers/sandbox_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/assemblers/sif.go
+++ b/internal/pkg/build/assemblers/sif.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/assemblers/sif_test.go
+++ b/internal/pkg/build/assemblers/sif_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/conveyorPacker.go
+++ b/internal/pkg/build/conveyorPacker.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/files/copy.go
+++ b/internal/pkg/build/files/copy.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/files/files.go
+++ b/internal/pkg/build/files/files.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/files/files_test.go
+++ b/internal/pkg/build/files/files_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/01-base.sh
+++ b/internal/pkg/build/sources/01-base.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/90-environment.sh
+++ b/internal/pkg/build/sources/90-environment.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/91-environment.sh
+++ b/internal/pkg/build/sources/91-environment.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/95-apps.sh
+++ b/internal/pkg/build/sources/95-apps.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/99-base.sh
+++ b/internal/pkg/build/sources/99-base.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/99-runtimevars.sh
+++ b/internal/pkg/build/sources/99-runtimevars.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/base_environment.go
+++ b/internal/pkg/build/sources/base_environment.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/base_environment_test.go
+++ b/internal/pkg/build/sources/base_environment_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_arch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_busybox_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_oras.go
+++ b/internal/pkg/build/sources/conveyorPacker_oras.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_scratch.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_scratch_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_shub_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_yum_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/conveyorPacker_zypper_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/exec.sh
+++ b/internal/pkg/build/sources/exec.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/oci_unpack.go
+++ b/internal/pkg/build/sources/oci_unpack.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/packer_ext3.go
+++ b/internal/pkg/build/sources/packer_ext3.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/packer_sandbox.go
+++ b/internal/pkg/build/sources/packer_sandbox.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/packer_sif.go
+++ b/internal/pkg/build/sources/packer_sif.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/packer_squashfs.go
+++ b/internal/pkg/build/sources/packer_squashfs.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/run.sh
+++ b/internal/pkg/build/sources/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/runscript.sh
+++ b/internal/pkg/build/sources/runscript.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/shell.sh
+++ b/internal/pkg/build/sources/shell.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/start.sh
+++ b/internal/pkg/build/sources/start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/startscript.sh
+++ b/internal/pkg/build/sources/startscript.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/test.sh
+++ b/internal/pkg/build/sources/test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/sources/verify_sif.go
+++ b/internal/pkg/build/sources/verify_sif.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/build/util.go
+++ b/internal/pkg/build/util.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/buildcfg/confgen/gen.go
+++ b/internal/pkg/buildcfg/confgen/gen.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/buildcfg/config_gen.go
+++ b/internal/pkg/buildcfg/config_gen.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/cache/entry.go
+++ b/internal/pkg/cache/entry.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/cgroups/config_linux.go
+++ b/internal/pkg/cgroups/config_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/cgroups/manager_linux_test.go
+++ b/internal/pkg/cgroups/manager_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/cgroups/managerv1_linux.go
+++ b/internal/pkg/cgroups/managerv1_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/cgroups/managerv1_linux_test.go
+++ b/internal/pkg/cgroups/managerv1_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/cgroups/managerv2_linux.go
+++ b/internal/pkg/cgroups/managerv2_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/cgroups/managerv2_linux_test.go
+++ b/internal/pkg/cgroups/managerv2_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/checkpoint/checkpoint.go
+++ b/internal/pkg/checkpoint/checkpoint.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/internal/pkg/checkpoint/dmtcp/checkpoint.go
+++ b/internal/pkg/checkpoint/dmtcp/checkpoint.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/internal/pkg/checkpoint/dmtcp/commands.go
+++ b/internal/pkg/checkpoint/dmtcp/commands.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/internal/pkg/checkpoint/dmtcp/dmtcp.go
+++ b/internal/pkg/checkpoint/dmtcp/dmtcp.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // This software is licensed under a 3-clause BSD license. Please consult the

--- a/internal/pkg/client/library/library.go
+++ b/internal/pkg/client/library/library.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/library/library_test.go
+++ b/internal/pkg/client/library/library_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/client/oci/transports.go
+++ b/internal/pkg/client/oci/transports.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/oci/transports_test.go
+++ b/internal/pkg/client/oci/transports_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/progress_test.go
+++ b/internal/pkg/client/progress_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/shub/api.go
+++ b/internal/pkg/client/shub/api.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/shub/pull_test.go
+++ b/internal/pkg/client/shub/pull_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/shub/util.go
+++ b/internal/pkg/client/shub/util.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/client/shub/util_test.go
+++ b/internal/pkg/client/shub/util_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/fakeroot/fakeroot.go
+++ b/internal/pkg/fakeroot/fakeroot.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/fakeroot/fakeroot_test.go
+++ b/internal/pkg/fakeroot/fakeroot_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/image/packer/squashfs.go
+++ b/internal/pkg/image/packer/squashfs.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021 Sylabs Inc. All rights reserved.

--- a/internal/pkg/image/packer/squashfs_test.go
+++ b/internal/pkg/image/packer/squashfs_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/image/unpacker/squashfs.go
+++ b/internal/pkg/image/unpacker/squashfs.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/image/unpacker/squashfs_apptainer.go
+++ b/internal/pkg/image/unpacker/squashfs_apptainer.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/image/unpacker/squashfs_no_apptainer.go
+++ b/internal/pkg/image/unpacker/squashfs_no_apptainer.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/image/unpacker/squashfs_test.go
+++ b/internal/pkg/image/unpacker/squashfs_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/instance/instance_linux_test.go
+++ b/internal/pkg/instance/instance_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/instance/logger.go
+++ b/internal/pkg/instance/logger.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/instance/logger_test.go
+++ b/internal/pkg/instance/logger_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/plugin/binary.go
+++ b/internal/pkg/plugin/binary.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/plugin/callback/callback.go
+++ b/internal/pkg/plugin/callback/callback.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/plugin/create.go
+++ b/internal/pkg/plugin/create.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/plugin/load.go
+++ b/internal/pkg/plugin/load.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/plugin/meta.go
+++ b/internal/pkg/plugin/meta.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/plugin/module.go
+++ b/internal/pkg/plugin/module.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/plugin/sif.go
+++ b/internal/pkg/plugin/sif.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/remote/credential/config.go
+++ b/internal/pkg/remote/credential/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/credential/manager.go
+++ b/internal/pkg/remote/credential/manager.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/endpoint/client_test.go
+++ b/internal/pkg/remote/endpoint/client_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/endpoint/keyserver.go
+++ b/internal/pkg/remote/endpoint/keyserver.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/endpoint/keyserver_test.go
+++ b/internal/pkg/remote/endpoint/keyserver_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/endpoint/token.go
+++ b/internal/pkg/remote/endpoint/token.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/util/util.go
+++ b/internal/pkg/remote/util/util.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/remote/util/util_test.go
+++ b/internal/pkg/remote/util/util_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/create_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/create_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/engine_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/engine_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/monitor_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/monitor_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/plugins_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/plugins_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/rpc/args.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/args.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/config/oci/config.go
+++ b/internal/pkg/runtime/engine/config/oci/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/config/oci/generate/generate.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright 2015 The Linux Foundation.

--- a/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/engine_linux.go
+++ b/internal/pkg/runtime/engine/engine_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/fakeroot/config/config.go
+++ b/internal/pkg/runtime/engine/fakeroot/config/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/oci/cleanup_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/config_linux.go
+++ b/internal/pkg/runtime/engine/oci/config_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/create_linux.go
+++ b/internal/pkg/runtime/engine/oci/create_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/engine_linux.go
+++ b/internal/pkg/runtime/engine/oci/engine_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/monitor_linux.go
+++ b/internal/pkg/runtime/engine/oci/monitor_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/prepare_linux.go
+++ b/internal/pkg/runtime/engine/oci/prepare_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/process_linux.go
+++ b/internal/pkg/runtime/engine/oci/process_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/rpc/args.go
+++ b/internal/pkg/runtime/engine/oci/rpc/args.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/oci/rpc/client/client.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/runtime/engine/oci/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/oci/rpc/server/server_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/security/apparmor/apparmor_supported.go
+++ b/internal/pkg/security/apparmor/apparmor_supported.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/security/apparmor/apparmor_unsupported.go
+++ b/internal/pkg/security/apparmor/apparmor_unsupported.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/security/seccomp/seccomp_supported.go
+++ b/internal/pkg/security/seccomp/seccomp_supported.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/security/seccomp/seccomp_supported_test.go
+++ b/internal/pkg/security/seccomp/seccomp_supported_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/security/seccomp/seccomp_unsupported.go
+++ b/internal/pkg/security/seccomp/seccomp_unsupported.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/security/security.go
+++ b/internal/pkg/security/security.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/security/security_test.go
+++ b/internal/pkg/security/security_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/security/selinux/selinux_supported.go
+++ b/internal/pkg/security/selinux/selinux_supported.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/security/selinux/selinux_unsupported.go
+++ b/internal/pkg/security/selinux/selinux_unsupported.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/syecl/syecl_test.go
+++ b/internal/pkg/syecl/syecl_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/internal/pkg/test/privilege_linux.go
+++ b/internal/pkg/test/privilege_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/test/tool/cache/cache.go
+++ b/internal/pkg/test/tool/cache/cache.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/test/tool/doc.go
+++ b/internal/pkg/test/tool/doc.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/test/tool/exec/exec.go
+++ b/internal/pkg/test/tool/exec/exec.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/auth/auth_test.go
+++ b/internal/pkg/util/auth/auth_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/auth/token.go
+++ b/internal/pkg/util/auth/token.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 /*

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/bin/bin_test.go
+++ b/internal/pkg/util/bin/bin_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/crypt/crypt_dev.go
+++ b/internal/pkg/util/crypt/crypt_dev.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/env/create.go
+++ b/internal/pkg/util/env/create.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/env/create_test.go
+++ b/internal/pkg/util/env/create_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/env/env_test.go
+++ b/internal/pkg/util/env/env_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/exec/hook.go
+++ b/internal/pkg/util/exec/hook.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/files/action_script.sh
+++ b/internal/pkg/util/fs/files/action_script.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/files/default_hosts.go
+++ b/internal/pkg/util/fs/files/default_hosts.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/files/files_linux_test.go
+++ b/internal/pkg/util/fs/files/files_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/files/group.go
+++ b/internal/pkg/util/fs/files/group.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/files/hostname.go
+++ b/internal/pkg/util/fs/files/hostname.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/files/passwd.go
+++ b/internal/pkg/util/fs/files/passwd.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/files/resolv_conf.go
+++ b/internal/pkg/util/fs/files/resolv_conf.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/files/runtime_vars.sh
+++ b/internal/pkg/util/fs/files/runtime_vars.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/layout/layer/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/overlay/overlay_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/layout/manager_test.go
+++ b/internal/pkg/util/fs/layout/manager_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/layout/session_linux.go
+++ b/internal/pkg/util/fs/layout/session_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/mount/mount_linux_test.go
+++ b/internal/pkg/util/fs/mount/mount_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/mount/system_linux.go
+++ b/internal/pkg/util/fs/mount/system_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/mount/system_linux_test.go
+++ b/internal/pkg/util/fs/mount/system_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/gpu/nvidia.go
+++ b/internal/pkg/util/gpu/nvidia.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/gpu/nvidia_legacy.go
+++ b/internal/pkg/util/gpu/nvidia_legacy.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/gpu/nvidia_test.go
+++ b/internal/pkg/util/gpu/nvidia_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/gpu/paths.go
+++ b/internal/pkg/util/gpu/paths.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/gpu/paths_test.go
+++ b/internal/pkg/util/gpu/paths_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/gpu/rocm.go
+++ b/internal/pkg/util/gpu/rocm.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/interactive/interactive.go
+++ b/internal/pkg/util/interactive/interactive.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/interactive/interactive_test.go
+++ b/internal/pkg/util/interactive/interactive_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/machine/machine.go
+++ b/internal/pkg/util/machine/machine.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/mainthread/mainthread.go
+++ b/internal/pkg/util/mainthread/mainthread.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/paths/resolve.go
+++ b/internal/pkg/util/paths/resolve.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/paths/resolve_test.go
+++ b/internal/pkg/util/paths/resolve_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/priv/priv_linux.go
+++ b/internal/pkg/util/priv/priv_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/shell/escape.go
+++ b/internal/pkg/util/shell/escape.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021 Sylabs, Inc. All rights reserved.

--- a/internal/pkg/util/shell/escape_test.go
+++ b/internal/pkg/util/shell/escape_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021 Sylabs, Inc. All rights reserved.

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs, Inc. All rights reserved.

--- a/internal/pkg/util/shell/interpreter/interpreter_test.go
+++ b/internal/pkg/util/shell/interpreter/interpreter_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs, Inc. All rights reserved.

--- a/internal/pkg/util/signal/signal_linux.go
+++ b/internal/pkg/util/signal/signal_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/signal/signal_linux_test.go
+++ b/internal/pkg/util/signal/signal_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/starter/starter.go
+++ b/internal/pkg/util/starter/starter.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/uri/uri.go
+++ b/internal/pkg/util/uri/uri.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/uri/uri_test.go
+++ b/internal/pkg/util/uri/uri_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/user/cgo_lookup_unix.go
+++ b/internal/pkg/util/user/cgo_lookup_unix.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/user/identity_unix.go
+++ b/internal/pkg/util/user/identity_unix.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/user/identity_unix_test.go
+++ b/internal/pkg/util/user/identity_unix_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/user/membership.go
+++ b/internal/pkg/util/user/membership.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/internal/pkg/util/user/membership_test.go
+++ b/internal/pkg/util/user/membership_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/mconfig
+++ b/mconfig
@@ -1,5 +1,6 @@
 #!/bin/sh -
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -1,5 +1,6 @@
 #!/bin/sh -
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2015-2018, Yannick Cote <yhcote@gmail.com>. All rights reserved.

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -1,5 +1,6 @@
 #!/bin/sh -
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 #

--- a/mlocal/checks/project-pre.chk
+++ b/mlocal/checks/project-pre.chk
@@ -1,5 +1,6 @@
 #!/bin/sh -
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2015-2018, Yannick Cote <yhcote@gmail.com>. All rights reserved.

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/pkg/build/types/bundle_test.go
+++ b/pkg/build/types/bundle_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/build/types/definition.go
+++ b/pkg/build/types/definition.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/build/types/definition_test.go
+++ b/pkg/build/types/definition_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/cmdline/cmd.go
+++ b/pkg/cmdline/cmd.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/cmdline/cmd_test.go
+++ b/pkg/cmdline/cmd_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/cmdline/env.go
+++ b/pkg/cmdline/env.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/pkg/cmdline/env_test.go
+++ b/pkg/cmdline/env_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/cmdline/flag_test.go
+++ b/pkg/cmdline/flag_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/image/doc.go
+++ b/pkg/image/doc.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/image/driver.go
+++ b/pkg/image/driver.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/pkg/image/ext3.go
+++ b/pkg/image/ext3.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/image/ext3_test.go
+++ b/pkg/image/ext3_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/image/reader.go
+++ b/pkg/image/reader.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/image/sandbox.go
+++ b/pkg/image/sandbox.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/image/sandbox_test.go
+++ b/pkg/image/sandbox_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/image/sif.go
+++ b/pkg/image/sif.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/pkg/image/sif_test.go
+++ b/pkg/image/sif_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/image/squashfs.go
+++ b/pkg/image/squashfs.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/pkg/image/squashfs_test.go
+++ b/pkg/image/squashfs_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/inspect/metadata.go
+++ b/pkg/inspect/metadata.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/pkg/network/network_linux.go
+++ b/pkg/network/network_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/ocibundle/bundle.go
+++ b/pkg/ocibundle/bundle.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/ocibundle/sif/bundle_linux.go
+++ b/pkg/ocibundle/sif/bundle_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/pkg/ocibundle/tools/loop.go
+++ b/pkg/ocibundle/tools/loop.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/ocibundle/tools/oci.go
+++ b/pkg/ocibundle/tools/oci.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.

--- a/pkg/ocibundle/tools/overlay_linux.go
+++ b/pkg/ocibundle/tools/overlay_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/ociruntime/ociruntime.go
+++ b/pkg/ociruntime/ociruntime.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/plugin/callback/cli/cli.go
+++ b/pkg/plugin/callback/cli/cli.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/pkg/plugin/callback/runtime/engine/apptainer/apptainer.go
+++ b/pkg/plugin/callback/runtime/engine/apptainer/apptainer.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/pkg/plugin/callback/runtime/fakeroot/fakeroot.go
+++ b/pkg/plugin/callback/runtime/fakeroot/fakeroot.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021-2022 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/runtime/engine/config/config.go
+++ b/pkg/runtime/engine/config/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -1,7 +1,9 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/pkg/sylog/doc.go
+++ b/pkg/sylog/doc.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/sylog/sylog.go
+++ b/pkg/sylog/sylog.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/pkg/sylog/sylog_common.go
+++ b/pkg/sylog/sylog_common.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/sylog/sylog_dummy.go
+++ b/pkg/sylog/sylog_dummy.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/sylog/sylog_dummy_test.go
+++ b/pkg/sylog/sylog_dummy_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/sylog/sylog_test.go
+++ b/pkg/sylog/sylog_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/pkg/sypgp/keyring.go
+++ b/pkg/sypgp/keyring.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/pkg/sypgp/select.go
+++ b/pkg/sypgp/select.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/pkg/sypgp/sypgp_test.go
+++ b/pkg/sypgp/sypgp_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.

--- a/pkg/sypgp/testdata_test.go
+++ b/pkg/sypgp/testdata_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright 2011 The Go Authors. All rights reserved.

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/apptainerconf/parser.go
+++ b/pkg/util/apptainerconf/parser.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/apptainerconf/parser_test.go
+++ b/pkg/util/apptainerconf/parser_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/archive/copy.go
+++ b/pkg/util/archive/copy.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/archive/copy_test.go
+++ b/pkg/util/archive/copy_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/capabilities/capabilities.go
+++ b/pkg/util/capabilities/capabilities.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/capabilities/capabilities_test.go
+++ b/pkg/util/capabilities/capabilities_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/capabilities/config.go
+++ b/pkg/util/capabilities/config.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.

--- a/pkg/util/capabilities/config_test.go
+++ b/pkg/util/capabilities/config_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/capabilities/process_linux.go
+++ b/pkg/util/capabilities/process_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/pkg/util/capabilities/process_linux_test.go
+++ b/pkg/util/capabilities/process_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Sylabs Inc. All rights reserved.

--- a/pkg/util/copy/buffer.go
+++ b/pkg/util/copy/buffer.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/copy/buffer_test.go
+++ b/pkg/util/copy/buffer_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/copy/writer.go
+++ b/pkg/util/copy/writer.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/copy/writer_test.go
+++ b/pkg/util/copy/writer_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/cryptkey/key.go
+++ b/pkg/util/cryptkey/key.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/cryptkey/key_test.go
+++ b/pkg/util/cryptkey/key_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/cryptkey/rsa.go
+++ b/pkg/util/cryptkey/rsa.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/fs/lock/lock.go
+++ b/pkg/util/fs/lock/lock.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/fs/lock/lock_test.go
+++ b/pkg/util/fs/lock/lock_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/fs/lock/var.go
+++ b/pkg/util/fs/lock/var.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/fs/lock/var_linux_32bit.go
+++ b/pkg/util/fs/lock/var_linux_32bit.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/fs/proc/proc.go
+++ b/pkg/util/fs/proc/proc.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/fs/proc/proc_linux_test.go
+++ b/pkg/util/fs/proc/proc_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/loop/loop_apptainer.go
+++ b/pkg/util/loop/loop_apptainer.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/loop/loop_no_apptainer.go
+++ b/pkg/util/loop/loop_no_apptainer.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/loop/loop_test.go
+++ b/pkg/util/loop/loop_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/namespaces/setns_linux.go
+++ b/pkg/util/namespaces/setns_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/namespaces/setns_linux_test.go
+++ b/pkg/util/namespaces/setns_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/namespaces/user_linux.go
+++ b/pkg/util/namespaces/user_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/rlimit/rlimit_linux.go
+++ b/pkg/util/rlimit/rlimit_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/rlimit/rlimit_linux_test.go
+++ b/pkg/util/rlimit/rlimit_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2021, Sylabs Inc. All rights reserved.

--- a/pkg/util/sysctl/sysctl_linux.go
+++ b/pkg/util/sysctl/sysctl_linux.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/sysctl/sysctl_linux_test.go
+++ b/pkg/util/sysctl/sysctl_linux_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/unix/socket.go
+++ b/pkg/util/unix/socket.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/unix/socket_test.go
+++ b/pkg/util/unix/socket_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/pkg/util/user-agent/agent.go
+++ b/pkg/util/user-agent/agent.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/pkg/util/user-agent/agent_test.go
+++ b/pkg/util/user-agent/agent_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2018, Sylabs Inc. All rights reserved.

--- a/scripts/check-go.mod
+++ b/scripts/check-go.mod
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -1,5 +1,6 @@
 #!/bin/bash -ex
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 

--- a/scripts/ci-docker-run
+++ b/scripts/ci-docker-run
@@ -1,5 +1,6 @@
 #!/bin/bash -e
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -1,5 +1,6 @@
 #!/bin/bash -ex
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 

--- a/scripts/expand-env.go
+++ b/scripts/expand-env.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2019, Sylabs Inc. All rights reserved.

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 

--- a/scripts/go-test.in
+++ b/scripts/go-test.in
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.

--- a/scripts/run-singularity
+++ b/scripts/run-singularity
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 # Copyright (c) 2017-2018, SyLabs, Inc. All rights reserved.

--- a/scripts/should-e2e-run
+++ b/scripts/should-e2e-run
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Copyright (c) 2021 Apptainer a Series of LF Projects LLC
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
 #   project policies see https://lfprojects.org/policies
 


### PR DESCRIPTION
This cherry-picks #192 into the release-1.0 branch.

It applied cleanly, no merging was needed.