### PR TITLE
Switch centos:8 to rockylinux:8 (release-1.0)

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -289,9 +289,9 @@ func (c ctx) testDockerDefFile(t *testing.T) {
 			from:                "centos:7",
 		},
 		{
-			name:                "CentOS_8",
+			name:                "RockyLinux_8",
 			kernelMajorRequired: 3,
-			from:                "centos:8",
+			from:                "rockylinux:8",
 		},
 		{
 			name:                "Ubuntu_1604",

--- a/examples/build-apptainer/build-apptainer.def
+++ b/examples/build-apptainer/build-apptainer.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: rockylinux/rockylinux:8.4
+From: rockylinux:8
 
 %post
     # Set build time env variable


### PR DESCRIPTION
This cherry-picks the following PR into the release-1.0 branch:
- #217