### PR TITLE
fix: split man generation and install, from sylabs 557

### DIFF
--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -5,19 +5,6 @@
 
 all: $(ALL)
 
-# install man pages
-.PHONY: man
-man: apptainer
-	@printf " MAN\n"
-	mkdir -p $(DESTDIR)$(MANDIR)/man1
-	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
-		$(SOURCEDIR)/cmd/docs/docs.go man --dir $(DESTDIR)$(MANDIR)/man1
-	$(V)cd $(DESTDIR)$(MANDIR)/man1; 				\
-		for M in apptainer*; do 				\
-			S="`echo $$M|sed 's/apptainer/singularity/'`";	\
-			ln -fs $$M $$S; 				\
-		done
-
 .PHONY: collect
 collect:
 	@printf " DEPENDS\n"
@@ -135,7 +122,7 @@ clean:
 	$(V)rm -rf $(BUILDDIR)/mergeddeps cscope.* $(CLEANFILES)
 
 .PHONY: install
-install: $(INSTALLFILES) man
+install: $(INSTALLFILES)
 	@echo " DONE"
 
 -include $(BUILDDIR)/mergeddeps

--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -90,3 +90,24 @@ $(remote_config_INSTALL): $(remote_config)
 	$(V)install -m 0644 $< $@
 
 INSTALLFILES += $(remote_config_INSTALL)
+
+man_pages := $(BUILDDIR)$(MANDIR)/man1
+$(man_pages): apptainer
+	@echo " MAN" $@
+	mkdir -p $@
+	$(V)$(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" $(GO_GCFLAGS) $(GO_ASMFLAGS) \
+		$(SOURCEDIR)/cmd/docs/docs.go man --dir $@
+	$(V)cd $@;							\
+		for M in apptainer*; do					\
+			S="`echo $$M|sed 's/apptainer/singularity/'`";	\
+			ln -fs $$M $$S;					\
+		done
+
+man_pages_INSTALL := $(DESTDIR)$(MANDIR)/man1
+$(man_pages_INSTALL): $(man_pages)
+	@echo " INSTALL" $@
+	$(V)umask 0022 && mkdir -p $@
+	$(V)install -m 0644 -t $@ $(man_pages)/*
+
+INSTALLFILES += $(man_pages_INSTALL)
+ALL += $(man_pages)


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#557
which fixed
- sylabs/singularity#555

The original PR description was:

> Make man page generation part of the `build_cli.mk` fragment, so that man pages are built under `make` and installed with `make install`.
> 
> What I should have originally done in sylabs/singularity#524 instead!