### PR TITLE
Use tag to calculate release asset version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,13 +272,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow --tags --force
 
       - name: Make dist tarball and rpm packages
         env:
           OS_TYPE: centos
           OS_VERSION: 7
           GO_ARCH: linux-amd64
-          GITHUB_REF: ${{github.ref}}
         run: |
           # Move the source directory down a level to separate it
           #  from later builds; the docker build runs privileged and
@@ -288,7 +288,6 @@ jobs:
           shopt -s extglob
           mv .??* !(rpmdir) rpmdir
           cd rpmdir
-          echo ${GITHUB_REF#refs/tags/v*} >VERSION
           ./scripts/ci-docker-run
           cp *.tar.gz *.rpm ..
           cd ..
@@ -299,12 +298,11 @@ jobs:
           OS_TYPE: debian
           OS_VERSION: 11
           GO_ARCH: linux-amd64
-          GITHUB_REF: ${{github.ref}}
         run: |
           # Make a new copy of the source files for this build
           set -x
           tar xf apptainer-*.tar.gz
-          cd apptainer-${GITHUB_REF#refs/tags/v*}
+          cd `basename apptainer-*.tar.gz .tar.gz`
           ./scripts/ci-docker-run
           cp *.deb ..
           cd ..


### PR DESCRIPTION
This changes the release assets CI step to use the given tag instead of setting it directly in VERSION.

I originally looked at this because I noticed a strange naming of the rpm files in the release assets, with a dot where a tilde should be for a prerelease, and I thought this might make that behavior change.  It turns out that the behavior doesn't change, but I think it's worth doing anyway.  The code actually produces filenames with tildes in them, but for some reason the tilde gets turned into a dot when it is uploaded to github.  The filename is correct in the sha256sums file.