### PR TITLE
Allow unprivileged users to build images by default

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -43,6 +43,7 @@ var buildArgs struct {
 	nvccli        bool
 	rocm          bool
 	writableTmpfs bool // For test section only
+	unprivileged  bool
 }
 
 // -s|--sandbox
@@ -224,6 +225,16 @@ var buildWritableTmpfsFlag = cmdline.Flag{
 	EnvKeys:      []string{"WRITABLE_TMPFS"},
 }
 
+// -N|--unprivileged
+var buildUnprivilegedFlag = cmdline.Flag{
+	ID:           "buildUnprivilegedFlag",
+	Value:        &buildArgs.unprivileged,
+	DefaultValue: false,
+	Name:         "unprivileged",
+	ShortHand:    "N",
+	Usage:        "build without root-privilege examination. Conventional package managers (e.g. apt and rpm) and system tools may fail without root privileges.",
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(buildCmd)
@@ -256,6 +267,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&buildBindFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildMountFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildWritableTmpfsFlag, buildCmd)
+		cmdManager.RegisterFlagForCmd(&buildUnprivilegedFlag, buildCmd)
 	})
 }
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -161,8 +161,8 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 		sylog.Fatalf("Failed to create an image cache handle")
 	}
 
-	if syscall.Getuid() != 0 && !buildArgs.fakeroot && fs.IsFile(spec) && !isImage(spec) {
-		sylog.Fatalf("You must be the root user, however you can --fakeroot to build from an Apptainer recipe file")
+	if syscall.Getuid() != 0 && !buildArgs.fakeroot && !buildArgs.unprivileged && fs.IsFile(spec) && !isImage(spec) {
+		sylog.Fatalf("You must be the root user, however you can --fakeroot or --unprivileged to build from an Apptainer recipe file")
 	}
 
 	err := checkSections()
@@ -263,7 +263,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string) {
 		sylog.Fatalf("Unable to create build: %v", err)
 	}
 
-	if err = b.Full(ctx); err != nil {
+	if err = b.Full(ctx, buildArgs.unprivileged); err != nil {
 		sylog.Fatalf("While performing build: %v", err)
 	}
 }

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -329,7 +329,7 @@ func (b Build) cleanUp() {
 }
 
 // Full runs a standard build from start to finish.
-func (b *Build) Full(ctx context.Context) error {
+func (b *Build) Full(ctx context.Context, unprivileged bool) error {
 	sylog.Infof("Starting build...")
 
 	// monitor build for termination signal and clean up
@@ -377,7 +377,7 @@ func (b *Build) Full(ctx context.Context) error {
 
 	// build each stage one after the other
 	for i, stage := range b.stages {
-		if err := stage.runSectionScript("pre", stage.b.Recipe.BuildData.Pre); err != nil {
+		if err := stage.runSectionScript("pre", stage.b.Recipe.BuildData.Pre, unprivileged); err != nil {
 			return err
 		}
 
@@ -430,7 +430,7 @@ func (b *Build) Full(ctx context.Context) error {
 			}
 		}
 
-		if err := stage.runSectionScript("setup", stage.b.Recipe.BuildData.Setup); err != nil {
+		if err := stage.runSectionScript("setup", stage.b.Recipe.BuildData.Setup, unprivileged); err != nil {
 			return err
 		}
 

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -49,10 +49,10 @@ func (s *stage) Assemble(path string) error {
 }
 
 // runSetupScript executes the stage's pre script on host.
-func (s *stage) runSectionScript(name string, script types.Script) error {
+func (s *stage) runSectionScript(name string, script types.Script, unprivileged bool) error {
 	if s.b.RunSection(name) && script.Script != "" {
-		if syscall.Getuid() != 0 {
-			return fmt.Errorf("attempted to build with scripts as non-root user or without --fakeroot")
+		if syscall.Getuid() != 0 && !unprivileged {
+			return fmt.Errorf("attempted to build with scripts as non-root user or without --fakeroot or --unprivileged")
 		}
 
 		aRootfs := "APPTAINER_ROOTFS=" + s.b.RootfsPath

--- a/internal/pkg/build/util.go
+++ b/internal/pkg/build/util.go
@@ -53,7 +53,7 @@ func ConvertOciToSIF(ctx context.Context, imgCache *cache.Handle, image, cachedI
 		return fmt.Errorf("unable to create new build: %v", err)
 	}
 
-	return b.Full(ctx)
+	return b.Full(ctx, false)
 }
 
 func createStageFile(source string, b *types.Bundle, warnMsg string) (string, error) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

~This patch removes several `Geteuid() != 0` checks and allow unprivileged users to build images by default.~
This patch introduces a new flag `-N|--unprivileged`, with which some `Geteuid() != 0` will be skipped.

### Motivations
*   Nowadays, package managers such as Nix and Gentoo ebuild and a lot of projects manags don't require root privileges to work, while still benefits from / rely on the customized directory trees (not available in Appimages). As a mature container format, Apptainer serves as a reliable way to wrap the build result, making it portable and runnabe on network-based file systems where I/O of small files is terrably slow.

*   As a practice of the *same privilege inside and outside* philosophy of Apptainer, it is the user's responsibility to provide enough level privilege for their toolchain. This patch also enable users to build in restricted environment where there is no way to get root privilege and that no suid-ed executables are available.

*   A program should be given the minimum level of privilege needed from the security perspective, which is known as the [Principle of Least Privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege). It makes the container building (especially the `%startup` and `%files` sections) much safer.

### Function parameter changes
*   runSectionScript(name string, script types.Script) -> runSectionScript(name string, script types.Script, unprivileged bool)

*   Full(ctx context.Context) -> Full(ctx context.Context, unprivileged bool)

*   Use b.Full(ctx, false) in ConvertOCIToSIF

### Status
This patch is compiled and run locally, and it work as expected so far, but is still a draft considering the need of discussion, consensus reaching and documentation update.

### This fixes or addresses the following GitHub issues:

 - Fixes #215

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
