### PR TITLE
Remove yum-builddep from CI

### DIFF
--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -38,7 +38,6 @@ su testuser -c '
     fi
   fi
   go version
-  sudo yum-builddep -y apptainer.spec
   # eliminate the "dist" part in the rpm name, for the release_assets
   echo "%dist %{nil}" >$HOME/.rpmmacros
   make -C builddir rpm


### PR DESCRIPTION
The yum-builddep step is failing in the rpmbuild-centos7 CI, and it isn't needed.