### PR TITLE
Remove yum-builddep from CI (release-1.0)

### DIFF
--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -38,7 +38,6 @@ su testuser -c '
     fi
   fi
   go version
-  sudo yum-builddep -y apptainer.spec
   # eliminate the "dist" part in the rpm name, for the release_assets
   echo "%dist %{nil}" >$HOME/.rpmmacros
   make -C builddir rpm


### PR DESCRIPTION
This backports #252 to the release-1.0 branch.