### PR TITLE
fix: bind libs to correct .so file for unsquashfs containment, from sylabs 575

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes Since Last Release
+
+### Bug fixes
+
+- Correct library bindings for `unsquashfs` containment. Fixes errors where
+  resolved library filename does not match library filename in binary (e.g. EL8,
+  POWER9 with glibc-hwcaps).
+
 ## v1.0.0 Release Candidate 2 - \[2022-02-08\]
 
 ### Changes since v1.0.0 Release Candidate 1

--- a/internal/pkg/image/unpacker/squashfs_apptainer_test.go
+++ b/internal/pkg/image/unpacker/squashfs_apptainer_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+//go:build apptainer_engine
+// +build apptainer_engine
+
+package unpacker
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Library listing on Fedora 35 AMD64 - simple case
+// $ /lib64/ld-linux-x86-64.so.2 --list /usr/sbin/unsquashfs
+const ldListSimple = `        linux-vdso.so.1 (0x00007ffe9ebcb000)
+        libm.so.6 => /lib64/libm.so.6 (0x00007f5dd1e6a000)
+        libz.so.1 => /lib64/libz.so.1 (0x00007f5dd1e50000)
+        liblzma.so.5 => /lib64/liblzma.so.5 (0x00007f5dd1e24000)
+        liblzo2.so.2 => /lib64/liblzo2.so.2 (0x00007f5dd1e03000)
+        liblz4.so.1 => /lib64/liblz4.so.1 (0x00007f5dd1ddf000)
+        libzstd.so.1 => /lib64/libzstd.so.1 (0x00007f5dd1d30000)
+        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f5dd1d13000)
+        libc.so.6 => /lib64/libc.so.6 (0x00007f5dd1b09000)
+        /lib64/ld-linux-x86-64.so.2 (0x00007f5dd2104000)`
+
+// Library listing on EL8 POWER8 - complex case
+// glibc-hwcaps and dependency filename not matching resolved filename
+// $ /lib64/ld64.so.2 --list /usr/sbin/unsquashfs
+const ldListComplex = `        linux-vdso64.so.1 (0x00007fff80d70000)
+        libpthread.so.0 => /lib64/glibc-hwcaps/power9/libpthread-2.28.so (0x00007fff80b50000)
+        libm.so.6 => /lib64/glibc-hwcaps/power9/libm-2.28.so (0x00007fff80a20000)
+        libz.so.1 => /lib64/libz.so.1 (0x00007fff809e0000)
+        liblzma.so.5 => /lib64/liblzma.so.5 (0x00007fff80980000)
+        liblzo2.so.2 => /lib64/liblzo2.so.2 (0x00007fff80930000)
+        liblz4.so.1 => /lib64/liblz4.so.1 (0x00007fff808e0000)
+        libc.so.6 => /lib64/glibc-hwcaps/power9/libc-2.28.so (0x00007fff806d0000)
+        /lib64/ld64.so.2 (0x00007fff80d90000)`
+
+func Test_parseLibraryBinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		ldList  string
+		want    []libBind
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			ldList:  "",
+			want:    []libBind{},
+			wantErr: false,
+		},
+		{
+			name:   "simple",
+			ldList: ldListSimple,
+			want: []libBind{
+				{"/lib64/libm.so.6", "/lib64/libm.so.6"},
+				{"/lib64/libz.so.1", "/lib64/libz.so.1"},
+				{"/lib64/liblzma.so.5", "/lib64/liblzma.so.5"},
+				{"/lib64/liblzo2.so.2", "/lib64/liblzo2.so.2"},
+				{"/lib64/liblz4.so.1", "/lib64/liblz4.so.1"},
+				{"/lib64/libzstd.so.1", "/lib64/libzstd.so.1"},
+				{"/lib64/libgcc_s.so.1", "/lib64/libgcc_s.so.1"},
+				{"/lib64/libc.so.6", "/lib64/libc.so.6"},
+				{"/lib64/ld-linux-x86-64.so.2", "/lib64/ld-linux-x86-64.so.2"},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "complex",
+			ldList: ldListComplex,
+			want: []libBind{
+				{
+					"/lib64/glibc-hwcaps/power9/libpthread-2.28.so",
+					"/lib64/glibc-hwcaps/power9/libpthread.so.0",
+				},
+				{"/lib64/glibc-hwcaps/power9/libm-2.28.so", "/lib64/glibc-hwcaps/power9/libm.so.6"},
+				{"/lib64/libz.so.1", "/lib64/libz.so.1"},
+				{"/lib64/liblzma.so.5", "/lib64/liblzma.so.5"},
+				{"/lib64/liblzo2.so.2", "/lib64/liblzo2.so.2"},
+				{"/lib64/liblz4.so.1", "/lib64/liblz4.so.1"},
+				{"/lib64/glibc-hwcaps/power9/libc-2.28.so", "/lib64/glibc-hwcaps/power9/libc.so.6"},
+				{"/lib64/ld64.so.2", "/lib64/ld64.so.2"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := strings.NewReader(tt.ldList)
+			got, err := parseLibraryBinds(buf)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseLibraryBinds() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseLibraryBinds() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#575
which fixed
- sylabs/singularity#571

The original PR description was:

> Cherry pick of sylabs/singularity#572
> 
> When running `unsquashfs` in a minimal container, we need to bind
> in the libraries that it requires. In some circumstances, the filename of
> `.so` that the loader is looking for may not much the filename of the
> resolved library through symlinks etc.
> 
> E.g. on EL8, POWER9 with glibc-hwcaps we have:
> 
> ```
> libpthread.so.0 => /lib64/glibc-hwcaps/power9/libpthread-2.28.so (0x00007fff96a20000)
> ```
> 
> In this case we have to bind `libpthread-2.28.so` into the container
> as `libpthread.so.0` as we are not creating symlinks, and the loader
> is looking for `libpthread.so.0` and won't find `libpthread-2.28.so`.