### PR TITLE
Remove python as a debian dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Correct library bindings for `unsquashfs` containment. Fixes errors where
   resolved library filename does not match library filename in binary (e.g. EL8,
   POWER9 with glibc-hwcaps).
+- Remove python as a dependency of the debian package.
 
 ## v1.0.0 Release Candidate 2 - \[2022-02-08\]
 

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -13,7 +13,6 @@ Build-Depends:
  help2man,
  libarchive-dev,
  libssl-dev,
- python,
  uuid-dev,
  devscripts,
  libseccomp-dev,
@@ -27,7 +26,7 @@ Vcs-Browser: https://github.com/apptainer/apptainer
 # "apptainer" is a packaged game (but the contents don't clash)
 Package: apptainer
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, python, squashfs-tools
+Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model
  where developers can work in an environment of their choosing and


### PR DESCRIPTION
This removes python as a dependency on the debian package.  It is not needed for anything, and it causes a headache when trying to install it because it implies python2 which doesn't install automatically.

- Fixes #261