### PR TITLE
Increase busybox TLS handshake timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   resolved library filename does not match library filename in binary (e.g. EL8,
   POWER9 with glibc-hwcaps).
 - Remove python as a dependency of the debian package.
+- Increased the TLS Handshake Timeout for the busybox bootstrap agent in
+  build definition files to 60 seconds.
 
 ## v1.0.0 Release Candidate 2 - \[2022-02-08\]
 

--- a/examples/busybox/Apptainer
+++ b/examples/busybox/Apptainer
@@ -1,5 +1,5 @@
 BootStrap: busybox
-MirrorURL: https://www.busybox.net/downloads/binaries/1.26.2-defconfig-multiarch/busybox-x86_64
+MirrorURL: https://www.busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox
 
 %post
     echo "Hello from inside the container"

--- a/examples/scratch/Apptainer.busybox
+++ b/examples/scratch/Apptainer.busybox
@@ -1,7 +1,7 @@
 Bootstrap: scratch
 
 %setup
-    busybox_url='https://www.busybox.net/downloads/binaries/1.28.2-defconfig-multiarch/busybox-x86_64'
+    busybox_url='https://www.busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox'
 
     # Create necessary config files.
     printf 'root:!:0:0:root:/root:/bin/sh\n' > "${APPTAINER_ROOTFS}/etc/passwd"


### PR DESCRIPTION
This increases the busybox bootstrap agent's TLS handshake timeout, because I have seen many "TLS handshake timeout" errors in CI tests.

It also updates the busybox examples to the latest x86_64 download version.

- Fixes #272 