### PR TITLE
Clone http.DefaultTransport when changing default options

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -98,10 +98,10 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 
 	// Increase the TLS handshake timeout because the busybox server
 	//   is often slow to connect.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSHandshakeTimeout = 60 * time.Second
 	client := &http.Client{
-		Transport: &http.Transport{
-			TLSHandshakeTimeout: 60 * time.Second,
-		},
+		Transport: transport,
 	}
 
 	resp, err := client.Get(mirrorurl)

--- a/internal/pkg/remote/endpoint/keyserver.go
+++ b/internal/pkg/remote/endpoint/keyserver.go
@@ -214,23 +214,19 @@ func (c *keyserverTransport) RoundTrip(req *http.Request) (*http.Response, error
 	return nil, fmt.Errorf("no keyserver configured")
 }
 
-var defaultClient = &http.Client{
-	Timeout: 5 * time.Second,
-	Transport: &http.Transport{
-		DisableKeepAlives: true,
-		// Note - when overriding transport we need to explicitly setup the
-		// proxy parsing from env vars that http.DefaultTransport does.
-		Proxy:           http.ProxyFromEnvironment,
-		TLSClientConfig: &tls.Config{},
-	},
-}
-
 func newClient(keyservers []*ServiceConfig, op KeyserverOp) *http.Client {
+	innerTransport := http.DefaultTransport.(*http.Transport).Clone()
+	innerTransport.DisableKeepAlives = true
+	innerTransport.TLSClientConfig = &tls.Config{}
+	innerClient := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: innerTransport,
+	}
 	return &http.Client{
 		Transport: &keyserverTransport{
 			keyservers: keyservers,
 			op:         op,
-			client:     defaultClient,
+			client:     innerClient,
 		},
 	}
 }


### PR DESCRIPTION
The change to a Transport option in #274 wasn't done correctly because it didn't include options from the DefaultTransport.  This does that with the http.Transport.Clone() function.  

At the same time, change the other one other case of modifying transport options (in keyservers.go) to do the same rather than manually copying one option.