### PR TITLE
CI Updates, from sylabs604

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   check_go_mod:
     name: check_go_mod
     runs-on: ubuntu-20.04
-    container: golang:1.17.6
+    container: golang:1.17.7
     steps:
       - uses: actions/checkout@v2
 
@@ -51,7 +51,7 @@ jobs:
   alpine:
     name: alpine
     runs-on: ubuntu-20.04
-    container: golang:1.17.6-alpine
+    container: golang:1.17.7-alpine
     steps:
       - name: Fetch deps
         run: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
@@ -82,7 +82,7 @@ jobs:
   check_license_dependencies:
     name: check_license_dependencies
     runs-on: ubuntu-20.04
-    container: golang:1.17.6
+    container: golang:1.17.7
     steps:
       - uses: actions/checkout@v2
 
@@ -149,7 +149,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.6
+          go-version: 1.17.7
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
@@ -179,7 +179,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.6
+          go-version: 1.17.7
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
@@ -223,7 +223,7 @@ jobs:
         if: env.run_tests
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.6
+          go-version: 1.17.7
 
       - name: Fetch deps
         if: env.run_tests
@@ -260,7 +260,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.6
+          go-version: 1.17.7
 
       - name: Check pkg/... doesn't depend on buildcfg
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   check_source:
     name: check_source
     runs-on: ubuntu-20.04
-    container: golangci/golangci-lint:v1.43
+    container: golangci/golangci-lint:v1.44
     steps:
       - uses: actions/checkout@v2
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,11 +7,13 @@ linters:
   enable:
     - contextcheck
     - deadcode
+    - decorder
     - dupl
     - gofumpt
     - goimports
     - gosimple
     - govet
+    - grouper
     - ineffassign
     - misspell
     - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - govet
     - grouper
     - ineffassign
+    - maintidx
     - misspell
     - nakedret
     - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   disable-all: true
   enable-all: false
   enable:
+    - containedctx
     - contextcheck
     - deadcode
     - decorder

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export GOVERSION=1.17.6 OS=linux ARCH=amd64  # change this as you need
+export GOVERSION=1.17.7 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${GOVERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${GOVERSION}.${OS}-${ARCH}.tar.gz

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -163,6 +163,7 @@ func setNoMountFlags(c *apptainerConfig.EngineConfig) {
 }
 
 // TODO: Let's stick this in another file so that that CLI is just CLI
+//nolint:maintidx
 func execStarter(cobraCmd *cobra.Command, image string, args []string, name string) {
 	var err error
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -1069,6 +1069,7 @@ func (c actionTests) actionNetwork(t *testing.T) {
 	}
 }
 
+//nolint:maintidx
 func (c actionTests) actionBinds(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
@@ -1821,6 +1822,7 @@ func (c actionTests) fuseMount(t *testing.T) {
 	}
 }
 
+//nolint:maintidx
 func (c actionTests) bindImage(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -99,6 +99,7 @@ func (c *configTests) prepImages(t *testing.T) (cleanup func(t *testing.T)) {
 	return cleanup
 }
 
+//nolint:maintidx
 func (c configTests) configGlobal(t *testing.T) {
 	cleanup := c.prepImages(t)
 	defer cleanup(t)

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -30,6 +30,7 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
+//nolint:maintidx
 func (c *ctx) eclConfig(t *testing.T) {
 	tmpDir, remove := e2e.MakeTempDir(t, "", "ecl-", "ECL")
 	pgpDir, _ := e2e.MakeKeysDir(t, tmpDir)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -544,6 +544,7 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 	}
 }
 
+//nolint:maintidx
 func (c imgBuildTests) buildDefinition(t *testing.T) {
 	tmpfile, err := e2e.WriteTempFile(c.env.TestDir, "testFile-", testFileContent)
 	if err != nil {

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -34,6 +34,7 @@ const (
 	containerTesterDEF = "testdata/inspector_container.def"
 )
 
+//nolint:maintidx
 func (c ctx) apptainerInspect(t *testing.T) {
 	testDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "inspect-", "")
 	defer cleanup(t)

--- a/e2e/internal/e2e/apptainercmd.go
+++ b/e2e/internal/e2e/apptainercmd.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -469,6 +469,7 @@ func ExpectExit(code int, resultOps ...ApptainerCmdResultOp) ApptainerCmdOp {
 // cmdPath specifies the path to the apptainer binary and cmdOps
 // provides a list of operations to be executed before or after running
 // the command.
+//nolint:maintidx
 func (env TestEnv) RunApptainer(t *testing.T, cmdOps ...ApptainerCmdOp) {
 	t.Helper()
 

--- a/internal/app/apptainer/remote_add_test.go
+++ b/internal/app/apptainer/remote_add_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -92,6 +92,7 @@ func createValidCfgFile(t *testing.T) string {
 	return path
 }
 
+//nolint:maintidx
 func TestRemoteAdd(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -86,6 +86,7 @@ func TestMakeParentDir(t *testing.T) {
 
 // TestCopyFromHost tests that copying non-nested source dirs, files, links to various
 // destinations works. CopyFromHost should always resolve symlinks.
+//nolint:maintidx
 func TestCopyFromHost(t *testing.T) {
 	// create tmpdir
 	dir, err := ioutil.TempDir("", "copy-test-src-")
@@ -484,6 +485,7 @@ func TestCopyFromHostNested(t *testing.T) {
 // TestCopyFromStage tests that copying non-nested source dirs, files, links to various
 // destinations works. CopyFromStage should resolve top-level symlinks for sources it is
 // called against.
+//nolint:maintidx
 func TestCopyFromStage(t *testing.T) {
 	// create tmpdir
 	srcRoot, err := ioutil.TempDir("", "copy-test-src-")

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -384,7 +384,7 @@ func TestNewImageSource(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		ctx       context.Context
+		ctx       context.Context //nolint:containedctx
 		sys       *types.SystemContext
 		shallPass bool
 	}{

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -54,6 +54,7 @@ func machine() (string, error) {
 }
 
 // Get downloads container information from the specified source
+//nolint:maintidx
 func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err error) {
 	var suseconnectProduct, suseconnectModver string
 	var suseconnectPath string

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -91,6 +91,7 @@ type container struct {
 	imageBind     map[string]string
 }
 
+//nolint:maintidx
 func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, pid int) error {
 	var err error
 
@@ -1297,6 +1298,7 @@ func (c *container) addSessionDevMount(system *mount.System) error {
 	return nil
 }
 
+//nolint:maintidx
 func (c *container) addDevMount(system *mount.System) error {
 	sylog.Debugf("Checking configuration file for 'mount dev'")
 

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -654,6 +654,7 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 
 // prepareInstanceJoinConfig is responsible for getting and
 // applying configuration to join a running instance.
+//nolint:maintidx
 func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Config) error {
 	name := instance.ExtractName(e.EngineConfig.GetImage())
 	file, err := instance.Get(name, instance.AppSubDir)

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -60,6 +60,7 @@ const defaultShell = "/bin/sh"
 // No additional privileges can be gained during this call (unless container
 // is executed as root intentionally) as starter will set uid/euid/suid
 // to the targetUID (PrepareConfig will set it by calling starter.Config.SetTargetUID).
+//nolint:maintidx
 func (e *EngineOperations) StartProcess(masterConnFd int) error {
 	// Manage all signals.
 	// Queue them until they're ready to be handled below.

--- a/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -22,6 +22,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+//nolint:maintidx
 func TestGenerate(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/internal/pkg/runtime/engine/oci/create_linux.go
+++ b/internal/pkg/runtime/engine/oci/create_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -160,6 +160,7 @@ var statusChan = make(chan string, 1)
 //
 // However, most likely this still will be executed as root since `apptainer oci`
 // command set requires privileged execution.
+//nolint:maintidx
 func (e *EngineOperations) CreateContainer(ctx context.Context, pid int, rpcConn net.Conn) error {
 	var err error
 

--- a/internal/pkg/runtime/engine/oci/prepare_linux.go
+++ b/internal/pkg/runtime/engine/oci/prepare_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -37,6 +37,7 @@ var (
 // dropped by the time PrepareConfig is called. However, most likely this
 // still will be executed as root since `apptainer oci` command set
 // requires privileged execution.
+//nolint:maintidx
 func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	if e.CommonConfig.EngineName != Name {
 		return fmt.Errorf("incorrect engine")

--- a/internal/pkg/util/env/create_test.go
+++ b/internal/pkg/util/env/create_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/test"
 )
 
+//nolint:maintidx
 func TestSetContainerEnv(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/internal/pkg/util/fs/mount/mount_linux_test.go
+++ b/internal/pkg/util/fs/mount/mount_linux_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -317,6 +317,7 @@ func TestAddPropagation(t *testing.T) {
 	points.RemoveAll()
 }
 
+//nolint:maintidx
 func TestImport(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/pkg/sypgp/keyring.go
+++ b/pkg/sypgp/keyring.go
@@ -31,7 +31,7 @@ func PublicKeyRing() (openpgp.KeyRing, error) {
 // the openpgp.KeyRing interface.
 type hybridKeyRing struct {
 	local openpgp.KeyRing // Local keyring.
-	ctx   context.Context // Context, for use when retrieving keys remotely.
+	ctx   context.Context //nolint:containedctx // Context, for use when retrieving keys remotely.
 	c     *client.Client  // Keyserver client.
 }
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#604

The original PR description was:

> Bump Go to 1.17.7. Use latest `ubuntu-machine` image. Bump Node to 17.x. Bump `golangci-lint` to 1.44, and enable `containedctx`, `decorder`, `grouper` and `maintidx` linters.