### PR TITLE
Require binutils-gold when build is targeting SUSE

### DIFF
--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -57,12 +57,9 @@ Provides: singularity-runtime = 1:%{version}-%{release}
 Obsoletes: singularity-runtime < 3.0
 
 %if "%{_target_vendor}" == "suse"
-%if "%{sles_version}" != "11"
-BuildRequires: go
+BuildRequires: binutils-gold
 %endif
-%else
 BuildRequires: golang
-%endif
 BuildRequires: git
 BuildRequires: gcc
 BuildRequires: make


### PR DESCRIPTION
## Description of the Pull Request (PR):

With the current spec, builds targeting SUSE will fail with `collect2: fatal error: cannot find 'ld'` even after installing build dependencies (for example with `dnf builddep`). Adding `binutils-gold` as a build dependency fixes this issue.

This PR simply adds `binutils-gold` as a build dependency if the target vendor is SUSE.
