### PR TITLE
Require binutils-gold when build is targeting SUSE (release-1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Increased the TLS Handshake Timeout for the busybox bootstrap agent in
   build definition files to 60 seconds.
 - Restored bash completion for the `singularity` command alias.
+- Added binutils-gold to the build requirements on SUSE rpm builds.
 
 ## v1.0.0 Release Candidate 2 - \[2022-02-08\]
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -58,12 +58,9 @@ Provides: singularity-runtime = 1:%{version}-%{release}
 Obsoletes: singularity-runtime < 3.0
 
 %if "%{_target_vendor}" == "suse"
-%if "%{sles_version}" != "11"
-BuildRequires: go
+BuildRequires: binutils-gold
 %endif
-%else
 BuildRequires: golang
-%endif
 BuildRequires: git
 BuildRequires: gcc
 BuildRequires: make


### PR DESCRIPTION
This cherry-picks #289 to the release-1.0 branch, and adds a changelog entry.