### PR TITLE
Merge release-1.0 for v1.0.0 tag into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,55 +7,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes Since Last Release
 
-### Bug fixes
+## v1.0.0 - \[2022-03-02\]
 
-- Correct library bindings for `unsquashfs` containment. Fixes errors where
-  resolved library filename does not match library filename in binary (e.g. EL8,
-  POWER9 with glibc-hwcaps).
-- Remove python as a dependency of the debian package.
-- Increased the TLS Handshake Timeout for the busybox bootstrap agent in
-  build definition files to 60 seconds.
-- Restored bash completion for the `singularity` command alias.
-
-## v1.0.0 Release Candidate 2 - \[2022-02-08\]
-
-### Changes since v1.0.0 Release Candidate 1
-
-This release candidate includes bug fixes that went into SingularityCE
-3.9.5.
-
-#### Changes related to long-standing issues
-
-- Auto-generate release assets including the distribution tarball and
-  rpm (built on CentOS 7) and deb (built on Debian 11) x86_64 packages.
-- Honor image binds and user binds in the order they're given instead of
-  always doing image binds first.
-- Update dependency to correctly unset variables in container startup
-  environment processing. Fixes regression introduced in singularity-3.8.5.
-- Remove subshell overhead when processing large environments on container
-  startup.
-- `make install` now installs man pages. A separate `make man` is not
-  required.  As a consequence, man pages are now included in deb packages.
-
-#### Changes related to issues introduced in release candidate 1
-
-- Several environment variables that had been converted to start with
-  only `APPTAINER_` are now also recognizing their `SINGULARITY_` counterparts.
-- Fixed compilation of plugin examples.
-- Fixed direct exection of .sif files; the shebang header for executing
-  run-singularity was missing.
-- Changed the Apptainer Copyright to be for "Contributors to the Apptainer
-  project" and removed the year.
-- Renamed the `~/.apptainer/sypgp` directory to `~/.apptainer/keys` and change
-  the corresponding environment variable from `APPTAINER_SYPGPDIR` to
-  `APPTAINER_KEYSDIR`.
-
-## v1.0.0 Release Candidate 1 - \[2022-01-19\]
-
-### Comparision to SingularityCE
+### Comparison to SingularityCE
 
 This release candidate has most of the new features, bug fixes, and
-changes that went into SingularityCE up through their version 3.9.4,
+changes that went into SingularityCE up through their version 3.9.5,
 except where the maintainers of Apptainer disagreed with what went into
 SingularityCE since the project fork.  The biggest difference is that
 Apptainer does not support the --nvccli option in privileged mode.  This
@@ -96,12 +53,9 @@ in the next section.
   variable and the value is different then a warning is also printed.
 - The default SylabsCloud remote endpoint has been removed and replaced
   by one called DefaultRemote which has no defined server for the
-  `library://` URI.  System administrators may restore the old default
-  if they wish by adding it to `/etc/apptainer/remote.yaml` with a URI
-  of `cloud.sylabs.io` and setting it there as the `Active` remote, or
-  users can add it to their own configuration with the commands
-  `apptainer remote add SylabsCloud cloud.sylabs.io` and
-  `apptainer remote use SylabsCloud`.
+  `library://` URI.  The previous default can be restored by following
+  the directions in the
+  [documentation](https://apptainer.org/docs/user/1.0/endpoint.html#restoring-pre-apptainer-library-behavior).
 - The DefaultRemote's key server is `https://keys.openpgp.org`
   instead of the Sylabs key server.
 - The `apptainer build --remote` option has been removed because there
@@ -109,6 +63,8 @@ in the next section.
 
 ### Other changed defaults / behaviours since Singularity 3.8.x
 
+- Auto-generate release assets including the distribution tarball and
+  rpm (built on CentOS 7) and deb (built on Debian 11) x86_64 packages.
 - LABELs from Docker/OCI images are now inherited. This fixes a longstanding
   regression from Singularity 2.x. Note that you will now need to use `--force`
   in a build to override a label that already exists in the source Docker/OCI
@@ -161,6 +117,12 @@ in the next section.
   they must be explicitely requested via command line.
 - Build `--bind` option allows to set multiple bind mounts without specifying
   the `--bind` option for each bindings.
+- Honor image binds and user binds in the order they're given instead of
+  always doing image binds first.
+- Remove subshell overhead when processing large environments on container
+  startup.
+- `make install` now installs man pages. A separate `make man` is not
+  required.  As a consequence, man pages are now included in deb packages.
 
 ### New features / functionalities
 
@@ -217,6 +179,15 @@ in the next section.
 - Restructure loop device discovery to address `EAGAIN` issue.
 - Ensure a local build does not fail unnecessarily if a keyserver
   config cannot be retrieved from the remote endpoint.
+- Update dependency to correctly unset variables in container startup
+  environment processing. Fixes regression introduced in singularity-3.8.5.
+- Correct library bindings for `unsquashfs` containment. Fixes errors where
+  resolved library filename does not match library filename in binary
+  (e.g. EL8, POWER9 with glibc-hwcaps).
+- Remove python as a dependency of the debian package.
+- Increase the TLS Handshake Timeout for the busybox bootstrap agent in
+  build definition files to 60 seconds.
+- Add binutils-gold to the build requirements on SUSE rpm builds.
 
 ### Changes for Testing / Development
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -201,7 +201,7 @@ and use it to install the RPM like this:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-VERSION=1.0.0-rc.2  # this is the apptainer version, change as you need
+VERSION=1.0.0  # this is the apptainer version, change as you need
 # Fetch the source
 wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/apptainer-${VERSION}.tar.gz
 # Build the rpm from the source tar.gz
@@ -223,7 +223,7 @@ in your PATH:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-VERSION=1.0.0-rc.2  # this is the latest apptainer version, change as you need
+VERSION=1.0.0  # this is the latest apptainer version, change as you need
 ./mconfig
 make -C builddir rpm
 sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/apptainer-$(echo $VERSION|tr - \~)*.x86_64.rpm 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 [![CI](https://github.com/apptainer/apptainer/actions/workflows/ci.yml/badge.svg)](https://github.com/apptainer/apptainer/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/pkg.golang.dev/github.com/apptainer/apptainer.svg)](https://pkg.go.dev/github.com/apptainer/apptainer)
 
-> *NOTE*: The apptainer repo is currently up to a v1.0.0 release candidate and
-  not ready for production in its current state. Until then, use the
-  [Singularity Repo](https://github.com/apptainer/singularity) for a production
-  ready version.
-
 - [Documentation](https://apptainer.org/docs/)
 - [Support](#support)
 - [Community Meetings / Minutes / Roadmap](https://drive.google.com/drive/u/0/folders/1npfBhIDxqeJIUHZ0tMeuHPvc_iB4T2B6)

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -59,10 +59,21 @@ covered by tests.
 
 1. Ensure the user and admin documentation is up-to-date for the new
    version, branched, and tagged.
-   - [User Docs](https://apptainer.org/user-docs/main/) can be
-     edited [here](https://github.com/apptainer/apptainer-userdocs)
-   - [Admin Docs](https://apptainer.org/admin-docs/main/) can be
+   - [User Docs](https://apptainer.org/docs/user/main/) can be
+     edited [here](https://github.com/apptainer/apptainer-userdocs).
+     Be sure that the `apptainer_source` submodule is up to date by
+     doing the following commands followed by making an update with
+     a pull request:
+      - `git submodule deinit -f .`
+      - `git submodule update --init`
+      - `cd apptainer_source`
+      - `git checkout main`
+      - `cd ..`
+      - `git add apptainer_source`
+   - [Admin Docs](https://apptainer.org/docs/admin/main/) can be
      edited [here](https://github.com/apptainer/apptainer-admindocs)
+   - If a new branch was created, add it to the docsVersion list in the
+     [web page](https://github.com/apptainer/apptainer.org/blob/master/src/pages/docs.js)
 1. Ensure the user and admin documentation has been deployed to the
    apptainer.org website.
 1. Modify the `README.md`, `INSTALL.md`, `CHANGELOG.md` via PR against


### PR DESCRIPTION
This merges the release-1.0 branch into main.  Even though there are a lot of commits, it only touches four `.md` files.