### PR TITLE
fix: Don't prompt y/n to overwrite output in noninteractive build (release-1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes Since Last Release
+
+### Bug fixes
+
+- Don't prompt for y/n to overwrite an existing file when build is
+  called from a non-interactive environment. Fail with an error.
+
 ## v1.0.0 - \[2022-03-02\]
 
 ### Comparison to SingularityCE

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"syscall"
 
 	"github.com/apptainer/apptainer/docs"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
@@ -22,6 +23,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/image"
 	ocitypes "github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var buildArgs struct {
@@ -315,6 +317,10 @@ func checkBuildTarget(path string) error {
 			}
 		}
 		if !buildArgs.update && !forceOverwrite {
+			// If non-interactive, die... don't try to prompt the user y/n
+			if !term.IsTerminal(syscall.Stdin) {
+				return fmt.Errorf("build target '%s' already exists. Use --force if you want to overwrite it", f.Name())
+			}
 
 			question := fmt.Sprintf("Build target '%s' already exists and will be deleted during the build process. Do you want to continue? [N/y] ", f.Name())
 


### PR DESCRIPTION
This cherry-picks #301 to the release-1.0 branch.