### PR TITLE
fix: set OCI Process.Terminal: true in oci mount, from sylabs 534

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes Since Last Release
 
+### Changed defaults / behaviours
+
+- `oci mount` sets `Process.Terminal: true` when creating an OCI `config.json`,
+  so that `oci run` provides expected interactive behavior by default.
+- Default hostname for `oci mount` containers is now `apptainer` instead of
+  `mrsdalloway`.
+
 ### Bug fixes
 
 - Don't prompt for y/n to overwrite an existing file when build is

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -12,13 +12,10 @@ package oci
 import (
 	"encoding/json"
 	"io/ioutil"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/e2e/internal/testhelper"
-	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci"
 	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
 	"github.com/apptainer/apptainer/pkg/ociruntime"
 	"github.com/google/uuid"
@@ -71,31 +68,11 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 		err = errors.Wrapf(err, "creating temporary bundle directory at %q", c.env.TestDir)
 		t.Fatalf("failed to create bundle directory: %+v", err)
 	}
-	ociConfig := filepath.Join(bundleDir, "config.json")
-
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("oci mount"),
 		e2e.WithArgs(c.env.ImagePath, bundleDir),
-		e2e.PostRun(func(t *testing.T) {
-			if t.Failed() {
-				t.Fatalf("failed to mount OCI bundle image")
-			}
-
-			g, err := oci.DefaultConfig()
-			if err != nil {
-				err = errors.Wrapf(err, "generating default OCI config for %q", runtime.GOOS)
-				t.Fatalf("failed to generate default OCI config: %+v", err)
-			}
-			g.SetProcessTerminal(true)
-
-			err = g.SaveToFile(ociConfig)
-			if err != nil {
-				err = errors.Wrapf(err, "saving OCI config at %q", ociConfig)
-				t.Fatalf("failed to save OCI config: %+v", err)
-			}
-		}),
 		e2e.ExpectExit(0),
 	)
 
@@ -129,7 +106,7 @@ func (c ctx) testOciRun(t *testing.T) {
 		e2e.WithArgs("-b", bundleDir, containerID),
 		e2e.ConsoleRun(
 			e2e.ConsoleSendLine("hostname"),
-			e2e.ConsoleExpect("mrsdalloway"),
+			e2e.ConsoleExpect("apptainer"),
 			e2e.ConsoleSendLine("id -un"),
 			e2e.ConsoleExpect("root"),
 			e2e.ConsoleSendLine("exit"),
@@ -194,7 +171,7 @@ func (c ctx) testOciAttach(t *testing.T) {
 		e2e.WithArgs(containerID),
 		e2e.ConsoleRun(
 			e2e.ConsoleSendLine("hostname"),
-			e2e.ConsoleExpect("mrsdalloway"),
+			e2e.ConsoleExpect("apptainer"),
 			e2e.ConsoleSendLine("exit"),
 		),
 		e2e.PostRun(func(t *testing.T) {

--- a/internal/pkg/runtime/engine/config/oci/config.go
+++ b/internal/pkg/runtime/engine/config/oci/config.go
@@ -56,7 +56,7 @@ func DefaultConfigV1() (*generate.Generator, error) {
 
 	config := specs.Spec{
 		Version:  specs.Version,
-		Hostname: "mrsdalloway",
+		Hostname: "apptainer",
 	}
 
 	config.Root = &specs.Root{
@@ -64,7 +64,7 @@ func DefaultConfigV1() (*generate.Generator, error) {
 		Readonly: false,
 	}
 	config.Process = &specs.Process{
-		Terminal: false,
+		Terminal: true,
 		Args: []string{
 			"sh",
 		},


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#534
which fixed
- sylabs/singularity#532

The original PR description was:

> When OCI mount creates a bundle it adds a default `config.json`. In this file, `Process.Terminal` was set to `false`. This means that an `oci run` of a container will not result in sensible interactive behavior, and the user's terminal will be broken.
> 
> `runc spec` and `crun spec` both set `Process.Terminal` to `true`, when creating a default config for a rootfs. I believe we should do the same so that sensible interactive behavior is the default.
> 
> Note that our e2e tests were already overriding the default config in this manner.
> 
> Also change the `mrsdalloway` default hostname to `singularity`.