### PR TITLE
Preload NSS libraries prior to mount namespace creation (or join) and pivot_root

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <poll.h>
+#include <pwd.h>
 #include <grp.h>
 #include <link.h>
 #include <dirent.h>
@@ -1402,6 +1403,20 @@ __attribute__((constructor)) static void init(void) {
         if ( socketpair(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC, 0, rpc_socket) < 0 ) {
             fatalf("Failed to create communication socket: %s\n", strerror(errno));
         }
+    }
+
+    /*
+     * preload and cache of nss libraries for os/user golang CGO implementation,
+     * when libraries are not loaded prior to pivot_root in the container mount
+     * namespace, they are loaded from the container image when the stage 2 process
+     * is calling os/user golang package, and it might cause compatibility issues with
+     * the host libc library used by this starter binary.
+     */
+    if (getpwuid(0) == NULL) {
+        fatalf("Failed to retrieve root user information: %s\n", strerror(errno));
+    }
+    if (getgrgid(0) == NULL) {
+        fatalf("Failed to retrieve root group information: %s\n", strerror(errno));
     }
 
     userns = user_namespace_init(&sconfig->container.namespace);

--- a/e2e/testdata/regressions/issue_4203.def
+++ b/e2e/testdata/regressions/issue_4203.def
@@ -39,6 +39,10 @@ bootstrap: docker
 from: ubuntu:16.04
 stage: final
 
+%environment
+    # to trigger the regression from https://github.com/apptainer/apptainer/issues/304
+    cd /usr
+
 %files from build
     /bad.so /lib/x86_64-linux-gnu/libnss_bad.so.2
     /nsswitch.conf /etc/nsswitch.conf


### PR DESCRIPTION
## Description of the Pull Request (PR):

Preload NSS libraries prior to mount namespace creation (or join) and pivot_root to mitigate schyzo loading of NSS libraries from container image rather than from host filesystem.

### This fixes or addresses the following GitHub issues:

 - Fixes #304 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
