### PR TITLE
fix: gpu: support nvidia-container-cli >=1.8.0, from sylabs 643 (release-1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   environment.
 - Fix race condition where newly created loop devices can sometimes not
   be opened.
+- Support nvidia-container-cli v1.8.0 and above, via fix to capability set.
 
 ## v1.0.0 - \[2022-03-02\]
 

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -399,6 +399,7 @@ static void set_rpc_privileges(void) {
         priv->capabilities.bounding |= capflag(CAP_FOWNER);
         priv->capabilities.bounding |= capflag(CAP_KILL);
         priv->capabilities.bounding |= capflag(CAP_MKNOD);
+        priv->capabilities.bounding |= capflag(CAP_NET_ADMIN);
         priv->capabilities.bounding |= capflag(CAP_SETGID);
         priv->capabilities.bounding |= capflag(CAP_SETPCAP);
         priv->capabilities.bounding |= capflag(CAP_SETUID);


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#643
which fixed
- sylabs/singularity#641

The original PR description was:

> nvidia-container-cli v1.8.0+ requires CAP_NET_ADMIN due to cgroups
> v2 (eBPF) related functionality in libnvidia-container.