### PR TITLE
feat: --no-mount for 'bind path' entries, from sylabs 626

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Apptainer now supports the `riscv64` architecture.
 - Native cgroups v2 resource limits can be specified using the `[unified]` key
   in a cgroups toml file applied via `--apply-cgroups`.
+- The `--no-mount` flag & `APPTAINER_NO_MOUNT` env var can now be used to
+  disable a `bind path` entry from `apptainer.conf` by specifying the
+  absolute path to the destination of the bind.
 
 ### Bug fixes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -451,7 +451,7 @@ var actionNoMountFlag = cmdline.Flag{
 	Value:        &NoMount,
 	DefaultValue: []string{},
 	Name:         "no-mount",
-	Usage:        "disable one or more mount xxx options set in apptainer.conf",
+	Usage:        "disable one or more 'mount xxx' options set in apptainer.conf and/or specify absolute destination path to disable a 'bind path' entry",
 	EnvKeys:      []string{"NO_MOUNT"},
 }
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -138,6 +138,7 @@ func hidepidProc() bool {
 // Set engine flags to disable mounts, to allow overriding them if they are set true
 // in the apptainer.conf
 func setNoMountFlags(c *apptainerConfig.EngineConfig) {
+	skipBinds := []string{}
 	for _, v := range NoMount {
 		switch v {
 		case "proc":
@@ -157,9 +158,14 @@ func setNoMountFlags(c *apptainerConfig.EngineConfig) {
 		case "cwd":
 			c.SetNoCwd(true)
 		default:
+			if filepath.IsAbs(v) {
+				skipBinds = append(skipBinds, v)
+				continue
+			}
 			sylog.Warningf("Ignoring unknown mount type '%s'", v)
 		}
 	}
+	c.SetSkipBinds(skipBinds)
 }
 
 // TODO: Let's stick this in another file so that that CLI is just CLI

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2304,6 +2304,27 @@ func (c actionTests) actionNoMount(t *testing.T) {
 			cwd:           "/srv",
 			exit:          0,
 		},
+		// /etc/hosts & /etc/localtime are default 'bind path' entries we should
+		// be able to disable by abs path. Although other 'bind path' entries
+		// are ignored under '--contain' these two are handled specially in
+		// addBindsMount(), so make sure that `--no-mount` applies properly
+		// under contain also.
+		{
+			name:          "/etc/hosts",
+			noMount:       "/etc/hosts",
+			noMatch:       "on /etc/hosts",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
+		{
+			name:          "/etc/localtime",
+			noMount:       "/etc/localtime",
+			noMatch:       "on /etc/localtime",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -1525,7 +1525,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 		localtimePath = "/etc/localtime"
 	)
 
-	noBinds := c.engine.EngineConfig.GetNoBinds()
+	skipBinds := c.engine.EngineConfig.GetSkipBinds()
 
 	if c.engine.EngineConfig.GetContain() {
 		hosts := hostsPath
@@ -1546,7 +1546,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 			hosts, _ = c.session.GetPath(hostsPath)
 		}
 
-		if !slice.ContainsString(noBinds, hostsPath) {
+		if !slice.ContainsString(skipBinds, hostsPath) {
 			// #5465 If hosts/localtime mount fails, it should not be fatal so skip-on-error
 			if err := system.Points.AddBind(mount.BindsTag, hosts, hostsPath, flags, "skip-on-error"); err != nil {
 				return fmt.Errorf("unable to add %s to mount list: %s", hosts, err)
@@ -1555,7 +1555,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 				return fmt.Errorf("unable to add %s for remount: %s", hostsPath, err)
 			}
 		}
-		if !slice.ContainsString(noBinds, localtimePath) {
+		if !slice.ContainsString(skipBinds, localtimePath) {
 			if err := system.Points.AddBind(mount.BindsTag, localtimePath, localtimePath, flags, "skip-on-error"); err != nil {
 				return fmt.Errorf("unable to add %s to mount list: %s", localtimePath, err)
 			}
@@ -1578,7 +1578,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 
 		sylog.Verbosef("Found 'bind path' = %s, %s", src, dst)
 
-		if slice.ContainsString(noBinds, dst) {
+		if slice.ContainsString(skipBinds, dst) {
 			sylog.Debugf("Skipping bind to %s at user request", dst)
 			continue
 		}

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -129,6 +129,7 @@ type JSONConfig struct {
 	NoTmp             bool              `json:"noTmp,omitempty"`
 	NoHostfs          bool              `json:"noHostfs,omitempty"`
 	NoCwd             bool              `json:"noCwd,omitempty"`
+	SkipBinds         []string          `json:"skipBinds,omitempty"`
 	NoInit            bool              `json:"noInit,omitempty"`
 	Fakeroot          bool              `json:"fakeroot,omitempty"`
 	SignalPropagation bool              `json:"signalPropagation,omitempty"`
@@ -496,6 +497,16 @@ func (e *EngineConfig) SetNoCwd(val bool) {
 // GetNoCwd returns if no-cwd flag is set or not.
 func (e *EngineConfig) GetNoCwd() bool {
 	return e.JSON.NoCwd
+}
+
+// SetSkipBinds sets bind paths to skip
+func (e *EngineConfig) SetSkipBinds(val []string) {
+	e.JSON.SkipBinds = val
+}
+
+// GetSkipBinds gets bind paths to skip
+func (e *EngineConfig) GetNoBinds() []string {
+	return e.JSON.SkipBinds
 }
 
 // SetNoInit set noinit flag to not start shim init process.

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -505,7 +505,7 @@ func (e *EngineConfig) SetSkipBinds(val []string) {
 }
 
 // GetSkipBinds gets bind paths to skip
-func (e *EngineConfig) GetNoBinds() []string {
+func (e *EngineConfig) GetSkipBinds() []string {
 	return e.JSON.SkipBinds
 }
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#626
which fixed
- sylabs/singularity#625

The original PR description was:
> Allow one or more `bind path` entries in `singularity.conf` to be
> ignored by specifying the absolute path of the destination as a
> `--no-mount` or `SINGULARITY_NO_MOUNT` value.
> 
> This allows finer-grained control of bind mounts than `--contain`,
> which will disable all.
> 
> It is useful in situations where e.g. a directory `/project` in a
> container clashes with a `bind path = /project` entry, but other
> default binds from the host are still required.
> 
> Note that `/etc/hosts` and `/etc/localtime` were always specially
> injected with `--contain`, but the new `--no-mount` handling now
> allows this to be overridden also.