### PR TITLE
remove obsolete comment from debian control

### DIFF
--- a/dist/debian/control
+++ b/dist/debian/control
@@ -23,7 +23,6 @@ Homepage: http://apptainer.org
 Vcs-Git: https://github.com/apptainer/apptainer.git
 Vcs-Browser: https://github.com/apptainer/apptainer
 
-# "apptainer" is a packaged game (but the contents don't clash)
 Package: apptainer
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools


### PR DESCRIPTION
This comment was about the singularity game included in Debian.

## Description of the Pull Request (PR):

This is a purely cosmetic commit that removes an old comment.

### This fixes or addresses the following GitHub issues:


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
