### PR TITLE
Debian package: add a conflict with singularity-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Native cgroups v2 resource limits can be specified using the `[unified]` key
   in a cgroups toml file applied via `--apply-cgroups`.
 
+### Bug fixes
+
+- The Debian package now conflicts with the singularity-container package.
+
 ## v1.0.1 - \[2022-03-15\]
 
 ### Bug fixes

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -26,6 +26,7 @@ Vcs-Browser: https://github.com/apptainer/apptainer
 Package: apptainer
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools
+Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model
  where developers can work in an environment of their choosing and


### PR DESCRIPTION
Signed-off-by: Götz Waschk <goetz.waschk@desy.de>

## Description of the Pull Request (PR):

Both the singularity-container and the apptainer packages contain binary files of the same name so the packages must conflict. The user must uninstall one for the other.

### This fixes or addresses the following GitHub issues:

 - Fixes #359


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
