### PR TITLE
fix: check valid path for --pwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Changed defaults / behaviours
 
+- When starting a container, if the user has specified the cwd by using
+  the `--pwd` flag, in case of problem return error instead of defaulting to
+  a different directory.
 - Added a squashfuse image driver that enables mounting SIF files as an
   unprivileged user.  Requires the separate installation of squashfuse.
 - Added the ability to use persistent overlay (`--overlay`) and

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -89,4 +89,5 @@
 - Pranathi Locula <locula@deshaw.com>
 - Pedro Alves Batista <pedro.pesquisapb@gmail.com>
 - Chen Yiyang <cyyzero@qq.com>
+- Pablo Caderno <kaderno@gmail.com>
 ```

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -642,6 +642,10 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		engineConfig.SetCwd(pwd)
 		if PwdPath != "" {
 			generator.SetProcessCwd(PwdPath)
+			if generator.Config.Annotations == nil {
+				generator.Config.Annotations = make(map[string]string)
+			}
+			generator.Config.Annotations["CustomCwd"] = "true"
 		} else {
 			if engineConfig.GetContain() {
 				generator.SetProcessCwd(engineConfig.GetHomeDest())

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -77,8 +77,14 @@ func (e *EngineOperations) StartProcess(masterConnFd int) error {
 	bootInstance := isInstance && e.EngineConfig.GetBootInstance()
 	shimProcess := false
 
+	_, customCwd := e.EngineConfig.OciConfig.Annotations["CustomCwd"]
+
 	if err := os.Chdir(e.EngineConfig.OciConfig.Process.Cwd); err != nil {
+		if customCwd {
+			return fmt.Errorf("failed to set working directory: %s", err)
+		}
 		if err := os.Chdir(e.EngineConfig.GetHomeDest()); err != nil {
+			sylog.Debugf("Error setting the working directory. Using '/' instead: %s", err)
 			os.Chdir("/")
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Pablo Caderno <kaderno@gmail.com>

## Description of the Pull Request (PR):

Changed default behavior of switching to a different directory if os.Chdir(e.EngineConfig.OciConfig.Process.Cwd) fails when starting the container.

Whilst this approach should fix the issue, it might be "too strict" for other cases.

### This fixes or addresses the following GitHub issues:

 - Fixes https://github.com/apptainer/singularity/issues/6086

