### PR TITLE
Fix file descriptor used by squashfuse

### DIFF
--- a/internal/pkg/image/driver/squashfuse/driver.go
+++ b/internal/pkg/image/driver/squashfuse/driver.go
@@ -73,7 +73,12 @@ func (d *squashfuseDriver) Features() image.DriverFeature {
 
 func (d *squashfuseDriver) Mount(params *image.MountParams, _ image.MountFunc) error {
 	optsStr := "offset=" + strconv.FormatUint(params.Offset, 10)
-	d.cmd = exec.Command(d.cmdpath, "-f", "-o", optsStr, params.Source, params.Target)
+	srcPath := params.Source
+	if path.Dir(params.Source) == "/proc/self/fd" {
+		// this will be passed as the first ExtraFile below, always fd 3
+		srcPath = "/proc/self/fd/3"
+	}
+	d.cmd = exec.Command(d.cmdpath, "-f", "-o", optsStr, srcPath, params.Target)
 	sylog.Debugf("Executing %v", d.cmd.String())
 	var stderr bytes.Buffer
 	d.cmd.Stderr = &stderr


### PR DESCRIPTION
This hard-codes the file descriptor passed to squashfuse as fd 3 because it is always the first 'ExtraFile' passed to it.  It fixes a problem noticed when an additional file descriptor was open because the current working directory was controlled by autofs.

- Fixes #403 