### PR TITLE
updating --env flags to be a map[string]string, from sylabs 684

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 ### Bug fixes
 
 - The Debian package now conflicts with the singularity-container package.
+- Do not truncate environment variables with commas
 
 ## v1.0.1 - \[2022-03-15\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,7 +80,7 @@
 - Tim Wright <7im.Wright@protonmail.com>
 - Tru Huynh <tru@pasteur.fr>
 - Tyson Whitehead <twhitehead@gmail.com>
-- Vanessa Sochat <vsochat@stanford.edu>
+- Vanessa Sochat <vsoch@users.noreply.github.com>
 - Westley Kurtzer <westley@sylabs.io>, <westleyk@nym.hush.com>
 - Yannick Cote <y@sylabs.io>, <yhcote@gmail.com>
 - Yaroslav Halchenko <debian@onerussian.com>

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -37,7 +37,7 @@ var (
 	VMIP             string
 	ContainLibsPath  []string
 	FuseMount        []string
-	ApptainerEnv     []string
+	ApptainerEnv     map[string]string
 	ApptainerEnvFile string
 	NoMount          []string
 	DMTCPLaunch      string
@@ -624,7 +624,7 @@ var actionAllowSetuidFlag = cmdline.Flag{
 var actionEnvFlag = cmdline.Flag{
 	ID:           "actionEnvFlag",
 	Value:        &ApptainerEnv,
-	DefaultValue: []string{},
+	DefaultValue: map[string]string{},
 	Name:         "env",
 	Usage:        "pass environment variable to contained process",
 }

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -601,18 +601,34 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		// --env variables will take precedence over variables
 		// defined by the environment file
 		sylog.Debugf("Setting environment variables from file %s", ApptainerEnvFile)
-		ApptainerEnv = append(envvars, ApptainerEnv...)
+
+		// Update ApptainerEnv with those from file
+		for _, envar := range envvars {
+			e := strings.SplitN(envar, "=", 2)
+			if len(e) != 2 {
+				sylog.Warningf("Ignore environment variable %q: '=' is missing", envar)
+				continue
+			}
+
+			// Ensure we don't overwrite --env variables with environment file
+			if _, ok := ApptainerEnv[e[0]]; ok {
+				sylog.Warningf("Ignore environment variable %s from %s: override from --env", e[0], ApptainerEnvFile)
+			} else {
+				ApptainerEnv[e[0]] = e[1]
+			}
+		}
 	}
 
 	// process --env and --env-file variables for injection
 	// into the environment by prefixing them with APPTAINERENV_
-	for _, envvar := range ApptainerEnv {
-		e := strings.SplitN(envvar, "=", 2)
-		if len(e) != 2 {
-			sylog.Warningf("Ignore environment variable %q: '=' is missing", envvar)
+	for envName, envValue := range ApptainerEnv {
+
+		// We can allow envValue to be empty (explicit set to empty) but not name!
+		if envName == "" {
+			sylog.Warningf("Ignore environment variable %s=%s: variable name missing", envName, envValue)
 			continue
 		}
-		os.Setenv(env.ApptainerEnvPrefix+e[0], e[1])
+		os.Setenv("APPTAINERENV_"+envName, envValue)
 	}
 
 	// Copy and cache environment

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -49,6 +49,9 @@ func (c ctx) apptainerEnv(t *testing.T) {
 
 	// Overwrite the path with this one.
 	overwrittenPath := "/usr/bin:/bin"
+
+	// A path with a trailing comma
+	trailingCommaPath := "/usr/bin:/bin,"
 
 	tests := []struct {
 		name  string
@@ -103,6 +106,12 @@ func (c ctx) apptainerEnv(t *testing.T) {
 			image: customImage,
 			path:  overwrittenPath,
 			env:   []string{"APPTAINERENV_PATH=" + overwrittenPath},
+		},
+		{
+			name:  "OverwriteTrailingCommaPath",
+			image: defaultImage,
+			path:  trailingCommaPath,
+			env:   []string{"APPTAINERENV_PATH=" + trailingCommaPath},
 		},
 	}
 
@@ -294,6 +303,13 @@ func (c ctx) apptainerEnvOption(t *testing.T) {
 			matchVal: apptainerLibs,
 		},
 		{
+			name:     "TestCustomTrailingCommaPath",
+			image:    c.env.ImagePath,
+			envOpt:   []string{"LD_LIBRARY_PATH=/foo,"},
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo,:" + apptainerLibs,
+		},
+		{
 			name:     "TestCustomLdLibraryPath",
 			image:    c.env.ImagePath,
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo"},
@@ -409,6 +425,13 @@ func (c ctx) apptainerEnvFile(t *testing.T) {
 			envFile:  "LD_LIBRARY_PATH=/foo",
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo:" + apptainerLibs,
+		},
+		{
+			name:     "CustomTrailingCommaPath",
+			image:    c.env.ImagePath,
+			envFile:  "LD_LIBRARY_PATH=/foo,",
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo,:" + apptainerLibs,
 		},
 	}
 

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -84,6 +84,8 @@ func (m *flagManager) registerFlagForCmd(flag *Flag, cmds ...*cobra.Command) err
 	switch t := flag.DefaultValue.(type) {
 	case string:
 		m.registerStringVar(flag, cmds)
+	case map[string]string:
+		m.registerStringMapVar(flag, cmds)
 	case []string:
 		m.registerStringSliceVar(flag, cmds)
 	case StringArray:
@@ -131,6 +133,19 @@ func (m *flagManager) registerStringArrayVar(flag *Flag, cmds []*cobra.Command) 
 			c.Flags().StringArrayVarP(flag.Value.(*[]string), flag.Name, flag.ShortHand, ([]string)(flag.DefaultValue.(StringArray)), flag.Usage)
 		} else {
 			c.Flags().StringArrayVar(flag.Value.(*[]string), flag.Name, ([]string)(flag.DefaultValue.(StringArray)), flag.Usage)
+		}
+		m.setFlagOptions(flag, c)
+	}
+	return nil
+}
+
+// registerStringArrayCommas uses StringToStringVarP, a variant to allow commas (and a map of string/string)
+func (m *flagManager) registerStringMapVar(flag *Flag, cmds []*cobra.Command) error {
+	for _, c := range cmds {
+		if flag.ShortHand != "" {
+			c.Flags().StringToStringVarP(flag.Value.(*map[string]string), flag.Name, flag.ShortHand, flag.DefaultValue.(map[string]string), flag.Usage)
+		} else {
+			c.Flags().StringToStringVar(flag.Value.(*map[string]string), flag.Name, flag.DefaultValue.(map[string]string), flag.Usage)
 		}
 		m.setFlagOptions(flag, c)
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#684

The original PR description was:
> Cherry pick sylabs/singularity#674
> 
> Commit message:
> 
> the current flag using a splice type will truncate on commas. In order to better support commas in --env variables we should have support for types of map[string]string. This change will add this new option and fix the current --env bug described in slack that splits name=val1,val2 into just name=val1 and outputs a warning. I saw some custom parsing code in a different file that maybe was intended to handle this, but it never gets called because the envar is skipped. If it is not skipped the comma would already be truncated by the flag parser.
> 
> Apologies for mistakes - have not looked at Singularity source code in years it seems!
> 
> Signed-off-by: vsoch [vsoch@users.noreply.github.com](mailto:vsoch@users.noreply.github.com)