### PR TITLE
fix: Use HEAD request to check remote OCI image digest, Add fall-through for missing Docker-Content-Digest, from sylabs 727 & 735

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - The Debian package now conflicts with the singularity-container package.
 - Do not truncate environment variables with commas
+- Use HEAD request when checking digest of remote OCI image sources, with GET as
+  a fall-back. Greatly reduces Apptainer's impact on Docker Hub API limits.
 
 ## v1.0.1 - \[2022-03-15\]
 

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -126,7 +126,13 @@ func ImageDigest(ctx context.Context, uri string, sys *types.SystemContext) (str
 func getRefDigest(ctx context.Context, ref types.ImageReference, sys *types.SystemContext) (digest string, err error) {
 	// Handle docker references specially, using a HEAD request to ensure we don't hit API limits
 	if ref.Transport().Name() == "docker" {
-		return getDockerRefDigest(ctx, ref, sys)
+		digest, err := getDockerRefDigest(ctx, ref, sys)
+		if err == nil {
+			return digest, err
+		}
+		// Need to have a fallback path, as the Docker-Content-Digest header is
+		// not required in oci-distribution-spec.
+		sylog.Debugf("Falling back to GetManifest digest: %s", err)
 	}
 
 	// Otherwise get the manifest and calculate sha256 over it
@@ -145,7 +151,7 @@ func getRefDigest(ctx context.Context, ref types.ImageReference, sys *types.Syst
 		return "", err
 	}
 	digest = fmt.Sprintf("%x", sha256.Sum256(man))
-	sylog.Debugf("Digest for %s is %s", transports.ImageName(ref), digest)
+	sylog.Debugf("GetManifest digest for %s is %s", transports.ImageName(ref), digest)
 	return digest, nil
 }
 
@@ -156,6 +162,6 @@ func getDockerRefDigest(ctx context.Context, ref types.ImageReference, sys *type
 		return "", err
 	}
 	digest = d.Encoded()
-	sylog.Debugf("Digest for %s is %s", transports.ImageName(ref), digest)
+	sylog.Debugf("docker.GetDigest digest for %s is %s", transports.ImageName(ref), digest)
 	return digest, nil
 }

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -20,11 +20,11 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
-	"github.com/pkg/errors"
 )
 
 // ImageReference wraps containers/image ImageReference type
@@ -42,7 +42,7 @@ func ConvertReference(ctx context.Context, imgCache *cache.Handle, src types.Ima
 	// Our cache dir is an OCI directory. We are using this as a 'blob pool'
 	// storing all incoming containers under unique tags, which are a hash of
 	// their source URI.
-	cacheTag, err := calculateRefHash(ctx, src, sys)
+	cacheTag, err := getRefDigest(ctx, src, sys)
 	if err != nil {
 		return nil, err
 	}
@@ -112,24 +112,31 @@ func parseURI(uri string) (types.ImageReference, error) {
 	return transport.ParseReference(split[1])
 }
 
-// ImageSHA calculates the SHA of a uri's manifest
-func ImageSHA(ctx context.Context, uri string, sys *types.SystemContext) (string, error) {
+// ImageDigest obtains the digest of a uri's manifest
+func ImageDigest(ctx context.Context, uri string, sys *types.SystemContext) (string, error) {
 	ref, err := parseURI(uri)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse image name %v: %v", uri, err)
 	}
 
-	return calculateRefHash(ctx, ref, sys)
+	return getRefDigest(ctx, ref, sys)
 }
 
-func calculateRefHash(ctx context.Context, ref types.ImageReference, sys *types.SystemContext) (hash string, err error) {
+// getRefDigest obtains the manifest digest for a ref.
+func getRefDigest(ctx context.Context, ref types.ImageReference, sys *types.SystemContext) (digest string, err error) {
+	// Handle docker references specially, using a HEAD request to ensure we don't hit API limits
+	if ref.Transport().Name() == "docker" {
+		return getDockerRefDigest(ctx, ref, sys)
+	}
+
+	// Otherwise get the manifest and calculate sha256 over it
 	source, err := ref.NewImageSource(ctx, sys)
 	if err != nil {
 		return "", err
 	}
 	defer func() {
 		if closeErr := source.Close(); closeErr != nil {
-			err = errors.Wrapf(err, " (src: %v)", closeErr)
+			err = fmt.Errorf("%w (src: %v)", err, closeErr)
 		}
 	}()
 
@@ -137,7 +144,18 @@ func calculateRefHash(ctx context.Context, ref types.ImageReference, sys *types.
 	if err != nil {
 		return "", err
 	}
+	digest = fmt.Sprintf("%x", sha256.Sum256(man))
+	sylog.Debugf("Digest for %s is %s", transports.ImageName(ref), digest)
+	return digest, nil
+}
 
-	hash = fmt.Sprintf("%x", sha256.Sum256(man))
-	return hash, nil
+// getDockerRefDigest obtains the manifest digest for a docker ref.
+func getDockerRefDigest(ctx context.Context, ref types.ImageReference, sys *types.SystemContext) (digest string, err error) {
+	d, err := docker.GetDigest(ctx, sys, ref)
+	if err != nil {
+		return "", err
+	}
+	digest = d.Encoded()
+	sylog.Debugf("Digest for %s is %s", transports.ImageName(ref), digest)
+	return digest, nil
 }

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -362,7 +362,7 @@ func TestImageNameAndImageSHA(t *testing.T) {
 
 		testName = "ImageSHA - " + tt.name
 		t.Run(testName, func(t *testing.T) {
-			_, err := ImageSHA(context.Background(), tt.uri, tt.ctx)
+			_, err := ImageDigest(context.Background(), tt.uri, tt.ctx)
 			if tt.shouldPass == true && err != nil {
 				t.Fatal("test expected to succeeded but failed")
 			}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -43,7 +43,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom, tmpDi
 		sysCtx.DockerInsecureSkipTLSVerify = ocitypes.NewOptionalBool(true)
 	}
 
-	hash, err := oci.ImageSHA(ctx, pullFrom, sysCtx)
+	hash, err := oci.ImageDigest(ctx, pullFrom, sysCtx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
 	}


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity#727
- sylabs/singularity#735
which fixed
- sylabs/singularity#733

The original PR descriptions were:
> Backport sylabs/singularity#723 to release-3.9
> 
> Use a HEAD request when checking digest of remote OCI image sources, via the `docker.GetDigest` function in containers/image.
> 
> Previously we were using `GetManifest` and computing the hash ourselves. This is a complete GET, and counts against Docker Hub API limits even if the cached image is up-to-date.
> 
> Note - this backport does not change the oci-tmp SIF cache filenames to include the digest algorithm, as on master. This ensures existing cache files continue to be used within the 3.9 branch, and `singularity cache clean` is not required.

> PR sylabs/singularity#727 was written while reviewing the Docker registry API v2 spec, in which it is stated a manifest HEAD request does include `Docker-Content-Digest`.
> 
> I had not considered potential differences in the oci-distribution-spec. This makes it clear that `Docker-Content-Digest` is a SHOULD header, and lists it as a field clients should not depend on.
> 
> The `containers/image` `docker.GetDigest` function doesn't handle the lack of a `Docker-Content-Digest` header, so we should fall-through to the old `GetManifest` approach on error.