### PR TITLE
fix: Allow newuidmap/newgidmap using caps, not setuid root, from sylabs 710

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Add specific error for unreadable image / overlay file.
 - Pass through a literal `\n` in host environment variables to container.
+- Allow `newgidmap / newuidmap` that use capabilities instead of setuid root.
 
 ## v1.0.2 - \[2022-05-09\]
 

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -627,8 +627,9 @@ static void set_mappings_external(const char *name, char *cmdpath, pid_t pid, ch
     }
 
     /* scary !? it's fine as it's never called by setuid context */
-    if ( system(cmd) < 0 ) {
-        fatalf("'%s' execution failed", cmd);
+    debugf("Executing '%s'", cmd);
+    if ( system(cmd) != 0 ) {
+        fatalf("'%s' execution failed. Check that '%s' is setuid root, or has required capabilities.\n", name, name);
     }
 
     free(cmd);

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -281,10 +281,6 @@ func setNewIDMapPath(command string, pathPointer unsafe.Pointer) error {
 		return fmt.Errorf("%s must be owned by the root user to setup fakeroot ID mappings in an unprivileged installation", path)
 	}
 
-	if !fs.IsSuid(path) {
-		return fmt.Errorf("%s must be setuid root to setup fakeroot ID mappings in an unprivileged installation", path)
-	}
-
 	lpath := len(path)
 	size := C.size_t(lpath)
 	if lpath >= C.MAX_PATH_SIZE-1 {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#710
which fixed
- sylabs/singularity#709

It fixes #330

The original PR description was:
> Fedora 35 (and maybe other distros) uses file capabilities for `newuidmap` and `newgidmap`. We were previously checking these were setuid root. Drop the check and instead output an informative message on execution failure.
> 
> Error message is not the tidiest, due to where in the started flow any failure will occur, but is informative:
> 
> ```
> $ singularity run -u --fakeroot docker://alpine
> INFO:    Using cached SIF image
> INFO:    Converting SIF file to temporary sandbox...
> newgidmap: write to gid_map failed: Operation not permitted
> ERROR  : 'newgidmap' execution failed. Check that 'newgidmap' is setuid root, or has required capabilities.
> ERROR  : Error while waiting event for user namespace mappings: Bad file descriptor
> ```
> 
> With caps per Fedora 35 default, now works:
> 
> ```
> $ singularity run -u --fakeroot docker://alpine
> INFO:    Using cached SIF image
> INFO:    Converting SIF file to temporary sandbox...
> WARNING: Skipping mount /etc/localtime [binds]: /etc/localtime doesn't exist in container
> Singularity> 
> ```