### PR TITLE
feat: Add CLI action flags to apply cgroups limits, from sylabs 721

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   container resource usage on a system using cgroups v2 and the systemd cgroups
   manager.
 - Add instance stats command.
+- Added `--cpu*`, `--blkio*`, `--memory*`, `--pids-limit` flags to apply cgroups
+  resource limits to a container directly.
 
 ### Bug fixes
 

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -659,6 +659,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/rivo/uniseg/blob/master/LICENSE.txt>
 
+## github.com/shopspring/decimal
+
+**License:** MIT
+
+**License URL:** <https://github.com/shopspring/decimal/blob/master/LICENSE>
+
 ## github.com/sirupsen/logrus
 
 **License:** MIT

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -31,7 +31,7 @@ var (
 	NetworkArgs      []string
 	DNS              string
 	Security         []string
-	CgroupsTOML      string
+	CgroupsTOMLFile  string
 	VMRAM            string
 	VMCPU            string
 	VMIP             string
@@ -76,6 +76,18 @@ var (
 	NoPrivs   bool
 	AddCaps   string
 	DropCaps  string
+
+	BlkioWeight       int
+	BlkioWeightDevice []string
+	CPUShares         int
+	CPUs              string // decimal
+	CPUSetCPUs        string
+	CPUSetMems        string
+	Memory            string // bytes
+	MemoryReservation string // bytes
+	MemorySwap        string // bytes
+	OomKillDisable    bool
+	PidsLimit         int
 )
 
 // --app
@@ -250,7 +262,7 @@ var actionSecurityFlag = cmdline.Flag{
 // --apply-cgroups
 var actionApplyCgroupsFlag = cmdline.Flag{
 	ID:           "actionApplyCgroupsFlag",
-	Value:        &CgroupsTOML,
+	Value:        &CgroupsTOMLFile,
 	DefaultValue: "",
 	Name:         "apply-cgroups",
 	Usage:        "apply cgroups from file for container processes (root only)",
@@ -680,6 +692,116 @@ var actionDMTCPRestartFlag = cmdline.Flag{
 	EnvKeys:      []string{"DMTCP_RESTART"},
 }
 
+// --blkio-weight
+var actionBlkioWeightFlag = cmdline.Flag{
+	ID:           "actionBlkioWeight",
+	Value:        &BlkioWeight,
+	DefaultValue: 0,
+	Name:         "blkio-weight",
+	Usage:        "Block IO relative weight in range 10-1000, 0 to disable",
+	EnvKeys:      []string{"BLKIO_WEIGHT"},
+}
+
+// --blkio-weight-device
+var actionBlkioWeightDeviceFlag = cmdline.Flag{
+	ID:           "actionBlkioWeightDevice",
+	Value:        &BlkioWeightDevice,
+	DefaultValue: []string{},
+	Name:         "blkio-weight-device",
+	Usage:        "Device specific block IO relative weight",
+	EnvKeys:      []string{"BLKIO_WEIGHT_DEVICE"},
+}
+
+// --cpu-shares
+var actionCPUSharesFlag = cmdline.Flag{
+	ID:           "actionCPUShares",
+	Value:        &CPUShares,
+	DefaultValue: -1,
+	Name:         "cpu-shares",
+	Usage:        "CPU shares for container",
+	EnvKeys:      []string{"CPU_SHARES"},
+}
+
+// --cpus
+var actionCPUsFlag = cmdline.Flag{
+	ID:           "actionCPUs",
+	Value:        &CPUs,
+	DefaultValue: "",
+	Name:         "cpus",
+	Usage:        "Number of CPUs available to container",
+	EnvKeys:      []string{"CPU_SHARES"},
+}
+
+// --cpuset-cpus
+var actionCPUsetCPUsFlag = cmdline.Flag{
+	ID:           "actionCPUsetCPUs",
+	Value:        &CPUSetCPUs,
+	DefaultValue: "",
+	Name:         "cpuset-cpus",
+	Usage:        "List of host CPUs available to container",
+	EnvKeys:      []string{"CPUSET_CPUS"},
+}
+
+// --cpuset-mems
+var actionCPUsetMemsFlag = cmdline.Flag{
+	ID:           "actionCPUsetMems",
+	Value:        &CPUSetMems,
+	DefaultValue: "",
+	Name:         "cpuset-mems",
+	Usage:        "List of host memory nodes available to container",
+	EnvKeys:      []string{"CPUSET_MEMS"},
+}
+
+// --memory
+var actionMemoryFlag = cmdline.Flag{
+	ID:           "actionMemory",
+	Value:        &Memory,
+	DefaultValue: "",
+	Name:         "memory",
+	Usage:        "Memory limit in bytes",
+	EnvKeys:      []string{"MEMORY"},
+}
+
+// --memory-reservation
+var actionMemoryReservationFlag = cmdline.Flag{
+	ID:           "actionMemoryReservation",
+	Value:        &MemoryReservation,
+	DefaultValue: "",
+	Name:         "memory-reservation",
+	Usage:        "Memory soft limit in bytes",
+	EnvKeys:      []string{"MEMORY_RESERVATION"},
+}
+
+// --memory-swap
+var actionMemorySwapFlag = cmdline.Flag{
+	ID:           "actionMemorySwap",
+	Value:        &MemorySwap,
+	DefaultValue: "",
+	Name:         "memory-swap",
+	Usage:        "Swap limit, use -1 for unlimited swap",
+	EnvKeys:      []string{"MEMORY_SWAP"},
+}
+
+// --oom-kill-disable
+var actionOomKillDisableFlag = cmdline.Flag{
+	ID:           "oomKillDisable",
+	Value:        &OomKillDisable,
+	DefaultValue: false,
+	Name:         "oom-kill-disable",
+	Usage:        "Disable OOM killer",
+	EnvKeys:      []string{"OOM_KILL_DISABLE"},
+}
+
+// --pids-limit
+var actionPidsLimitFlag = cmdline.Flag{
+	ID:           "actionPidsLimit",
+	Value:        &PidsLimit,
+	DefaultValue: 0,
+	Name:         "pids-limit",
+	Usage:        "Limit number of container PIDs, use -1 for unlimited",
+	EnvKeys:      []string{"PIDS_LIMIT"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -759,5 +881,16 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionEnvFileFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoUmaskFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoEvalFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionBlkioWeightFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionBlkioWeightDeviceFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionCPUSharesFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionCPUsFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionCPUsetCPUsFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionCPUsetMemsFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionMemoryFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionMemoryReservationFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionMemorySwapFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionOomKillDisableFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionPidsLimitFlag, actionsInstanceCmd...)
 	})
 }

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -425,7 +425,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "SHELL", ShellPath)
 	}
 
-	if name != "" && uid != 0 && CgroupsTOML != "" {
+	if name != "" && uid != 0 && CgroupsTOMLFile != "" {
 		sylog.Fatalf("Instances do not currently support rootless cgroups")
 	}
 
@@ -435,7 +435,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		engineConfig.SetDbusSessionBusAddress(os.Getenv("DBUS_SESSION_BUS_ADDRESS"))
 	}
 
-	engineConfig.SetCgroupsTOML(CgroupsTOML)
+	cgJSON, err := getCgroupsJSON()
+	if err != nil {
+		sylog.Fatalf("While parsing cgroups configuration: %s", err)
+	}
+	engineConfig.SetCgroupsJSON(cgJSON)
 
 	if IsWritable && IsWritableTmpfs {
 		sylog.Warningf("Disabling --writable-tmpfs flag, mutually exclusive with --writable")

--- a/cmd/internal/cli/cgroups.go
+++ b/cmd/internal/cli/cgroups.go
@@ -1,0 +1,306 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/apptainer/apptainer/internal/pkg/cgroups"
+	"github.com/docker/go-units"
+	"github.com/shopspring/decimal"
+	"golang.org/x/sys/unix"
+)
+
+// getCgroupsJSON returns any applicable cgroups configuration in JSON serialized format.
+// It examines the CLI flags that set limits, and any TOML file set with --apply-cgroups.
+func getCgroupsJSON() (string, error) {
+	config, err := getFlagLimits()
+	if err != nil {
+		return "", err
+	}
+
+	if config != nil && CgroupsTOMLFile != "" {
+		return "", fmt.Errorf("cannot apply a cgroups TOML file while using limit flags")
+	}
+
+	if config != nil {
+		return config.MarshalJSON()
+	}
+
+	if CgroupsTOMLFile != "" {
+		config, err := cgroups.LoadConfig(CgroupsTOMLFile)
+		if err != nil {
+			return "", err
+		}
+		return config.MarshalJSON()
+	}
+	return "", nil
+}
+
+// getFlagLimits returns a cgroups.Config from the cgroup limits CLI flags.
+func getFlagLimits() (*cgroups.Config, error) {
+	config := cgroups.Config{}
+	configured := false
+
+	blkio, err := getBlkioLimits()
+	if err != nil {
+		return nil, err
+	}
+	if blkio != nil {
+		config.BlockIO = blkio
+		configured = true
+	}
+
+	cpu, err := getCPULimits()
+	if err != nil {
+		return nil, err
+	}
+	if cpu != nil {
+		config.CPU = cpu
+		configured = true
+	}
+
+	mem, err := getMemoryLimits()
+	if err != nil {
+		return nil, err
+	}
+	if mem != nil {
+		config.Memory = mem
+		configured = true
+	}
+
+	pids, err := getPidsLimits()
+	if err != nil {
+		return nil, err
+	}
+	if pids != nil {
+		config.Pids = pids
+		configured = true
+	}
+
+	if configured {
+		return &config, nil
+	}
+
+	return nil, nil
+}
+
+// getBlkioLimits handles --blkio* flags, converting values into a LinuxBlockIO structure
+func getBlkioLimits() (*cgroups.LinuxBlockIO, error) {
+	blkio := cgroups.LinuxBlockIO{}
+	configured := false
+
+	if BlkioWeight > 0 {
+		if BlkioWeight < 10 || BlkioWeight > 1000 {
+			return nil, fmt.Errorf("blkio-weight must be in range 10-1000")
+		}
+		bw := uint16(BlkioWeight)
+		blkio.Weight = &bw
+		configured = true
+	}
+
+	// Format of --blkio-device-weight CLI values is...
+	//  <device>:<weight>
+	//  /dev/sda:123
+	if len(BlkioWeightDevice) > 0 {
+		for _, val := range BlkioWeightDevice {
+			fields := strings.SplitN(val, ":", 2)
+			if len(fields) < 2 {
+				return nil, fmt.Errorf("blkio-weight-device specifications must be in <device>:<weight> format")
+			}
+
+			major, minor, err := deviceMajorMinor(fields[0])
+			if err != nil {
+				return nil, fmt.Errorf("while examining device: %w", err)
+			}
+
+			weight, err := strconv.Atoi(fields[1])
+			if err != nil {
+				return nil, fmt.Errorf("%s is not a valid device weight: %w", fields[1], err)
+			}
+
+			if weight < 10 || weight > 1000 {
+				return nil, fmt.Errorf("blkio-device-weight must be in range 10-1000")
+			}
+
+			bdw := uint16(weight)
+			blkio.WeightDevice = append(blkio.WeightDevice, cgroups.LinuxWeightDevice{
+				Major:  major,
+				Minor:  minor,
+				Weight: &bdw,
+			})
+		}
+		configured = true
+	}
+
+	if configured {
+		return &blkio, nil
+	}
+
+	return nil, nil
+}
+
+// getBlkioLimits handles --cpu* flags, converting values into a LinuxCPU structure
+func getCPULimits() (*cgroups.LinuxCPU, error) {
+	cpu := cgroups.LinuxCPU{}
+	configured := false
+
+	// Will be converted to cgroups v2 cpu.weight by manager code
+	if CPUShares > 0 {
+		cs := uint64(CPUShares)
+		cpu.Shares = &cs
+		configured = true
+	}
+
+	if CPUSetCPUs != "" {
+		cpu.Cpus = CPUSetCPUs
+		configured = true
+	}
+
+	if CPUSetMems != "" {
+		cpu.Mems = CPUSetMems
+		configured = true
+	}
+
+	if CPUs != "" {
+		// Compute fractional CPU shares in cgroups v1 quota/period form.
+		// The manager will convert to cgroups v2 cpu.max
+
+		// https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
+		// cpu.cfs_quota_us: the total available run-time within a period (in microseconds)
+		// cpu.cfs_period_us: the length of a period (in microseconds)
+		// The default values are:
+		//    cpu.cfs_period_us=100ms
+
+		// Always use default period of 100ms expressed in us (1e6)
+		period := uint64(100 * time.Millisecond / time.Microsecond)
+
+		// Parse cpus values as an arbitrary precision decimal. We will compute
+		// quota at 1e9 precision, and allow fractions of a CPU down to 0.01.
+		// Lower than this gives an invalid argument when setting cpu.max.
+		dCpus, err := decimal.NewFromString(CPUs)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cpus value: %w", err)
+		}
+
+		minCPU := decimal.New(1, -2) // 10^-2
+		maxCPU := decimal.NewFromInt(int64(runtime.NumCPU()))
+
+		if dCpus.LessThan(minCPU) || dCpus.GreaterThan(maxCPU) {
+			return nil, fmt.Errorf("cpus value must be in range %s - %s", minCPU.String(), maxCPU.String())
+		}
+
+		nanoCPUs := dCpus.Mul(decimal.NewFromInt(1e9)).IntPart()
+
+		quota := nanoCPUs * int64(period) / 1e9
+		cpu.Period = &period
+		cpu.Quota = &quota
+		configured = true
+	}
+
+	if configured {
+		return &cpu, nil
+	}
+
+	return nil, nil
+}
+
+// getMemoryLimits handles --memory* flags, converting values into a LinuxMemory structure
+func getMemoryLimits() (*cgroups.LinuxMemory, error) {
+	memory := cgroups.LinuxMemory{}
+	configured := false
+
+	if Memory != "" {
+		m, err := units.RAMInBytes(Memory)
+		if err != nil {
+			return nil, fmt.Errorf("invalid memory value: %w", err)
+		}
+		memory.Limit = &m
+		configured = true
+	}
+
+	if MemoryReservation != "" {
+		mr, err := units.RAMInBytes(MemoryReservation)
+		if err != nil {
+			return nil, fmt.Errorf("invalid memory-reservation value: %w", err)
+		}
+		memory.Reservation = &mr
+		configured = true
+	}
+
+	// -1 is valid here as 'unlimited swap'
+	if MemorySwap == "-1" {
+		ms := int64(-1)
+		memory.Swap = &ms
+		configured = true
+	} else if MemorySwap != "" {
+		ms, err := units.RAMInBytes(MemorySwap)
+		if err != nil {
+			return nil, fmt.Errorf("invalid memory-swap value: %w", err)
+		}
+		memory.Swap = &ms
+		configured = true
+	}
+
+	if OomKillDisable {
+		okd := true
+		memory.DisableOOMKiller = &okd
+		configured = true
+	}
+
+	if configured {
+		return &memory, nil
+	}
+
+	return nil, nil
+}
+
+// getPidsLimits handles --pids* flags, converting values into a LinuxPids structure
+func getPidsLimits() (*cgroups.LinuxPids, error) {
+	pids := cgroups.LinuxPids{}
+	configured := false
+
+	if PidsLimit < -1 {
+		return nil, fmt.Errorf("invalid pids-limit: %d", pids)
+	}
+
+	if PidsLimit != 0 {
+		pl := int64(PidsLimit)
+		pids.Limit = pl
+		configured = true
+	}
+
+	if configured {
+		return &pids, nil
+	}
+
+	return nil, nil
+}
+
+// deviceMajorMinor returns major and minor numbers for the device at path
+func deviceMajorMinor(path string) (major, minor int64, err error) {
+	var stat unix.Stat_t
+	err = unix.Lstat(path, &stat)
+	if err != nil {
+		return -1, -1, err
+	}
+
+	if stat.Mode&unix.S_IFBLK != unix.S_IFBLK &&
+		stat.Mode&unix.S_IFCHR != unix.S_IFCHR &&
+		stat.Mode&unix.S_IFIFO != unix.S_IFIFO {
+		return -1, -1, fmt.Errorf("%s is not a device", path)
+	}
+
+	return int64(unix.Major(stat.Rdev)), int64(unix.Minor(stat.Rdev)), nil
+}

--- a/cmd/internal/cli/cgroups.go
+++ b/cmd/internal/cli/cgroups.go
@@ -113,6 +113,7 @@ func getBlkioLimits() (*cgroups.LinuxBlockIO, error) {
 	// Format of --blkio-device-weight CLI values is...
 	//  <device>:<weight>
 	//  /dev/sda:123
+	// We need to translate the path into device major and minor numbers.
 	if len(BlkioWeightDevice) > 0 {
 		for _, val := range BlkioWeightDevice {
 			fields := strings.SplitN(val, ":", 2)

--- a/cmd/internal/cli/cgroups_test.go
+++ b/cmd/internal/cli/cgroups_test.go
@@ -1,0 +1,524 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/apptainer/apptainer/internal/pkg/cgroups"
+)
+
+func Test_getBlkioLimits(t *testing.T) {
+	tests := []struct {
+		name              string
+		blkioWeight       int
+		blkioWeightDevice []string
+		wantBlkio         bool
+		wantError         bool
+		blkioCheck        func(t *testing.T, b *cgroups.LinuxBlockIO)
+	}{
+		{
+			name:      "None",
+			wantBlkio: false,
+			wantError: false,
+		},
+		{
+			name:        "GoodWeight",
+			blkioWeight: 123,
+			wantBlkio:   true,
+			wantError:   false,
+			blkioCheck: func(t *testing.T, b *cgroups.LinuxBlockIO) {
+				if b.Weight == nil {
+					t.Fatalf("weight not set")
+				}
+				if *b.Weight != 123 {
+					t.Errorf("expected 123, got %d", *b.Weight)
+				}
+			},
+		},
+		{
+			name:        "WeightTooLow",
+			blkioWeight: 1,
+			wantBlkio:   false,
+			wantError:   true,
+		},
+		{
+			name:        "WeightTooHigh",
+			blkioWeight: 1000000,
+			wantBlkio:   false,
+			wantError:   true,
+		},
+		{
+			name:              "GoodWeightDevice",
+			blkioWeightDevice: []string{"/dev/zero:123"},
+			wantBlkio:         true,
+			wantError:         false,
+			blkioCheck: func(t *testing.T, b *cgroups.LinuxBlockIO) {
+				if len(b.WeightDevice) != 1 {
+					t.Errorf("expected 1 device entry, got %d", len(b.WeightDevice))
+				}
+				if b.WeightDevice[0].Major != 1 {
+					t.Errorf("expected major 1 , got %d", b.WeightDevice[0].Major)
+				}
+				if b.WeightDevice[0].Minor != 5 {
+					t.Errorf("expected minor 5 , got %d", b.WeightDevice[0].Minor)
+				}
+				if b.WeightDevice[0].Weight == nil {
+					t.Fatalf("weight not set")
+				}
+				if *b.WeightDevice[0].Weight != 123 {
+					t.Errorf("expected weight 123 , got %d", *b.WeightDevice[0].Weight)
+				}
+			},
+		},
+		{
+			name:              "WeightDeviceBadPath",
+			blkioWeightDevice: []string{"/not/a/file:123"},
+			wantBlkio:         false,
+			wantError:         true,
+		},
+		{
+			name:              "WeightDeviceNotDevice",
+			blkioWeightDevice: []string{"/etc/hosts:123"},
+			wantBlkio:         false,
+			wantError:         true,
+		},
+		{
+			name:              "WeightDeviceWeightTooLow",
+			blkioWeightDevice: []string{"/dev/zero:1"},
+			wantBlkio:         false,
+			wantError:         true,
+		},
+		{
+			name:              "WeightDeviceWeightTooHigh",
+			blkioWeightDevice: []string{"/dev/zero:100000"},
+			wantBlkio:         false,
+			wantError:         true,
+		},
+		{
+			name:              "MultipleWeightDevice",
+			blkioWeightDevice: []string{"/dev/zero:123", "/dev/null:123"},
+			wantBlkio:         true,
+			wantError:         false,
+			blkioCheck: func(t *testing.T, b *cgroups.LinuxBlockIO) {
+				if len(b.WeightDevice) != 2 {
+					t.Errorf("expected 2 device entries, got %d", len(b.WeightDevice))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			BlkioWeight = tt.blkioWeight
+			BlkioWeightDevice = tt.blkioWeightDevice
+
+			blkio, err := getBlkioLimits()
+
+			if err != nil && !tt.wantError {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			if err == nil && tt.wantError {
+				t.Errorf("unexpected success: %s", err)
+			}
+
+			if tt.wantBlkio && blkio == nil {
+				t.Errorf("expected blkio struct, got nil")
+			}
+
+			if !tt.wantBlkio && blkio != nil {
+				t.Errorf("expected nil, got %v", blkio)
+			}
+
+			if tt.blkioCheck != nil && blkio != nil {
+				tt.blkioCheck(t, blkio)
+			}
+		})
+	}
+}
+
+func Test_getCpuLimits(t *testing.T) {
+	tests := []struct {
+		name       string
+		cpuShares  int
+		cpusetCPUs string
+		cpusetMems string
+		cpus       string
+		wantCPU    bool
+		wantError  bool
+		cpuCheck   func(t *testing.T, c *cgroups.LinuxCPU)
+	}{
+		{
+			name:      "None",
+			wantCPU:   false,
+			wantError: false,
+		},
+		{
+			name:      "GoodShares",
+			cpuShares: 123,
+			wantCPU:   true,
+			wantError: false,
+			cpuCheck: func(t *testing.T, c *cgroups.LinuxCPU) {
+				s := c.Shares
+				if s == nil {
+					t.Fatalf("shares not set")
+				}
+				if *s != 123 {
+					t.Errorf("expected 123, got %d", *s)
+				}
+			},
+		},
+		{
+			name:       "GoodCpuset",
+			cpusetCPUs: "1-4",
+			cpusetMems: "1-4",
+			wantCPU:    true,
+			wantError:  false,
+			cpuCheck: func(t *testing.T, c *cgroups.LinuxCPU) {
+				if c.Cpus != "1-4" {
+					t.Errorf("expected 1-4, got %s", c.Cpus)
+				}
+				if c.Mems != "1-4" {
+					t.Errorf("expected 1-4, got %s", c.Mems)
+				}
+			},
+		},
+		{
+			name:      "GoodCpus",
+			cpus:      "0.5",
+			wantCPU:   true,
+			wantError: false,
+			cpuCheck: func(t *testing.T, c *cgroups.LinuxCPU) {
+				if c.Period == nil {
+					t.Fatalf("period not set")
+				}
+				if *c.Period != 100000 {
+					t.Errorf("period should always be 100000 (us), got %d", *c.Period)
+				}
+				if c.Quota == nil {
+					t.Fatalf("quota not set")
+				}
+				if *c.Quota != 50000 {
+					t.Errorf("quota should be 50000 (us), got %d", *c.Quota)
+				}
+			},
+		},
+		{
+			name:      "CpusInvalid",
+			cpus:      "abc",
+			wantCPU:   false,
+			wantError: true,
+		},
+		{
+			name:      "CpusTooLow",
+			cpus:      "0.001",
+			wantCPU:   false,
+			wantError: true,
+		},
+		{
+			name:      "CpusTooHigh",
+			cpus:      strconv.Itoa(runtime.NumCPU() + 1),
+			wantCPU:   false,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			CPUShares = tt.cpuShares
+			CPUSetCPUs = tt.cpusetCPUs
+			CPUSetMems = tt.cpusetMems
+			CPUs = tt.cpus
+
+			cpu, err := getCPULimits()
+
+			if err != nil && !tt.wantError {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			if err == nil && tt.wantError {
+				t.Errorf("unexpected success: %s", err)
+			}
+
+			if tt.wantCPU && cpu == nil {
+				t.Errorf("expected cpu struct, got nil")
+			}
+
+			if !tt.wantCPU && cpu != nil {
+				t.Errorf("expected nil, got %v", cpu)
+			}
+
+			if tt.cpuCheck != nil && cpu != nil {
+				tt.cpuCheck(t, cpu)
+			}
+		})
+	}
+}
+
+func Test_getMemoryLimits(t *testing.T) {
+	tests := []struct {
+		name              string
+		memory            string
+		memoryReservation string
+		memorySwap        string
+		oomKillDisable    bool
+		wantMem           bool
+		wantError         bool
+		memCheck          func(t *testing.T, m *cgroups.LinuxMemory)
+	}{
+		{
+			name:      "None",
+			wantMem:   false,
+			wantError: false,
+		},
+		{
+			name:      "InvalidMemory",
+			memory:    "abc",
+			wantMem:   false,
+			wantError: true,
+		},
+		{
+			name:      "NegativeMemory",
+			memory:    "-1",
+			wantMem:   false,
+			wantError: true,
+		},
+		{
+			name:      "NumericMemory",
+			memory:    "1073741824",
+			wantMem:   true,
+			wantError: false,
+			memCheck: func(t *testing.T, m *cgroups.LinuxMemory) {
+				if m.Limit == nil {
+					t.Fatalf("limit not set")
+				}
+				if *m.Limit != 1073741824 {
+					t.Errorf("expected 1073741824, got %d", *m.Limit)
+				}
+			},
+		},
+		{
+			name:      "SuffixMemory",
+			memory:    "1024M",
+			wantMem:   true,
+			wantError: false,
+			memCheck: func(t *testing.T, m *cgroups.LinuxMemory) {
+				if m.Limit == nil {
+					t.Fatalf("limit not set")
+				}
+				if *m.Limit != 1073741824 {
+					t.Errorf("expected 1073741824, got %d", *m.Limit)
+				}
+			},
+		},
+		{
+			name:      "InvalidMemoryReservation",
+			memory:    "abc",
+			wantMem:   false,
+			wantError: true,
+		},
+		{
+			name:      "NegativeMemoryReservation",
+			memory:    "-1",
+			wantMem:   false,
+			wantError: true,
+		},
+		{
+			name:              "NumericMemoryReservation",
+			memoryReservation: "1073741824",
+			wantMem:           true,
+			wantError:         false,
+			memCheck: func(t *testing.T, m *cgroups.LinuxMemory) {
+				if m.Reservation == nil {
+					t.Fatalf("reservation not set")
+				}
+				if *m.Reservation != 1073741824 {
+					t.Errorf("expected 1073741824, got %d", *m.Reservation)
+				}
+			},
+		},
+		{
+			name:              "SuffixMemoryReservation",
+			memoryReservation: "1024M",
+			wantMem:           true,
+			wantError:         false,
+			memCheck: func(t *testing.T, m *cgroups.LinuxMemory) {
+				if m.Reservation == nil {
+					t.Fatalf("reservation not set")
+				}
+				if *m.Reservation != 1073741824 {
+					t.Errorf("expected 1073741824, got %d", *m.Reservation)
+				}
+			},
+		},
+		{
+			name:       "NumericMemorySwap",
+			memorySwap: "1073741824",
+			wantMem:    true,
+			wantError:  false,
+			memCheck: func(t *testing.T, m *cgroups.LinuxMemory) {
+				if m.Swap == nil {
+					t.Fatalf("swap not set")
+				}
+				if *m.Swap != 1073741824 {
+					t.Errorf("expected 1073741824, got %d", *m.Swap)
+				}
+			},
+		},
+		{
+			name:       "SuffixMemorySwap",
+			memorySwap: "1024M",
+			wantMem:    true,
+			wantError:  false,
+			memCheck: func(t *testing.T, m *cgroups.LinuxMemory) {
+				if m.Swap == nil {
+					t.Fatalf("swap not set")
+				}
+				if *m.Swap != 1073741824 {
+					t.Errorf("expected 1073741824, got %d", *m.Swap)
+				}
+			},
+		},
+		{
+			name:       "UnlimitedMemorySwap",
+			memorySwap: "-1",
+			wantMem:    true,
+			wantError:  false,
+			memCheck: func(t *testing.T, m *cgroups.LinuxMemory) {
+				if m.Swap == nil {
+					t.Fatalf("swap not set")
+				}
+				if *m.Swap != -1 {
+					t.Errorf("expected -1, got %d", *m.Swap)
+				}
+			},
+		},
+		{
+			name:           "OomKillDsiable",
+			oomKillDisable: true,
+			wantMem:        true,
+			wantError:      false,
+			memCheck: func(t *testing.T, m *cgroups.LinuxMemory) {
+				if m.DisableOOMKiller == nil {
+					t.Fatalf("DisableOOMKiller not set")
+				}
+				if *m.DisableOOMKiller != true {
+					t.Errorf("DisableOOMKiller not true")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Memory = tt.memory
+			MemoryReservation = tt.memoryReservation
+			MemorySwap = tt.memorySwap
+			OomKillDisable = tt.oomKillDisable
+
+			mem, err := getMemoryLimits()
+
+			if err != nil && !tt.wantError {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			if err == nil && tt.wantError {
+				t.Errorf("unexpected success: %s", err)
+			}
+
+			if tt.wantMem && mem == nil {
+				t.Errorf("expected mem struct, got nil")
+			}
+
+			if !tt.wantMem && mem != nil {
+				t.Errorf("expected nil, got %v", mem)
+			}
+
+			if tt.memCheck != nil && mem != nil {
+				tt.memCheck(t, mem)
+			}
+		})
+	}
+}
+
+func Test_getPidsLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		pidsLimit int
+		wantPids  bool
+		wantError bool
+		pidsCheck func(t *testing.T, p *cgroups.LinuxPids)
+	}{
+		{
+			name:      "None",
+			wantPids:  false,
+			wantError: false,
+		},
+		{
+			name:      "GoodPidsLimit",
+			pidsLimit: 123,
+			wantPids:  true,
+			wantError: false,
+			pidsCheck: func(t *testing.T, p *cgroups.LinuxPids) {
+				if p.Limit != 123 {
+					t.Errorf("expected 123, got %d", p.Limit)
+				}
+			},
+		},
+		{
+			name:      "UnlimitedPidsLimit",
+			pidsLimit: -1,
+			wantPids:  true,
+			wantError: false,
+			pidsCheck: func(t *testing.T, p *cgroups.LinuxPids) {
+				if p.Limit != -1 {
+					t.Errorf("expected -1, got %d", p.Limit)
+				}
+			},
+		},
+		{
+			name:      "InvalidPidsLimit",
+			pidsLimit: -99,
+			wantPids:  false,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			PidsLimit = tt.pidsLimit
+
+			pids, err := getPidsLimits()
+
+			if err != nil && !tt.wantError {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			if err == nil && tt.wantError {
+				t.Errorf("unexpected success: %s", err)
+			}
+
+			if tt.wantPids && pids == nil {
+				t.Errorf("expected cpu struct, got nil")
+			}
+
+			if !tt.wantPids && pids != nil {
+				t.Errorf("expected nil, got %v", pids)
+			}
+
+			if tt.pidsCheck != nil && pids != nil {
+				tt.pidsCheck(t, pids)
+			}
+		})
+	}
+}

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/e2e/internal/testhelper"
+	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
 	"github.com/google/uuid"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
 //  NOTE
@@ -363,6 +365,226 @@ func (c *ctx) actionApplyRootless(t *testing.T) {
 	}
 }
 
+type actionFlagTest struct {
+	name            string
+	args            []string
+	expectErrorCode int
+	// cgroupsV1 - cgroupfs controller/resource to check, and content we expect to see
+	controllerV1 string
+	resourceV1   string
+	expectV1     string
+	// cgroupsV2 - delegation required when rootless
+	delegationV2 string
+	// cgroupsV2 - resource to check, and content we expect to see
+	resourceV2 string
+	expectV2   string
+	skipV2     bool
+}
+
+func (c *ctx) actionFlags(t *testing.T, profile e2e.Profile) {
+	e2e.EnsureImage(t, c.env)
+	tests := []actionFlagTest{
+		{
+			name:            "blkio-weight",
+			args:            []string{"--blkio-weight", "50"},
+			expectErrorCode: 0,
+			controllerV1:    "blkio",
+			// This is the new path. Older kernels may have only `blkio.weight`
+			resourceV1:   "blkio.bfq.weight",
+			expectV1:     "50",
+			delegationV2: "io",
+			resourceV2:   "io.bfq.weight",
+			expectV2:     "default 50",
+		},
+		{
+			name:            "cpus",
+			args:            []string{"--cpus", "0.5"},
+			expectErrorCode: 0,
+			// 0.5 cpus = quota of 50000 with default period 100000
+			controllerV1: "cpu",
+			resourceV1:   "cpu.cfs_quota_us",
+			expectV1:     "50000",
+			delegationV2: "cpu",
+			resourceV2:   "cpu.max",
+			expectV2:     "50000 100000",
+		},
+		{
+			name:            "cpu-shares",
+			args:            []string{"--cpu-shares", "123"},
+			expectErrorCode: 0,
+			controllerV1:    "cpu",
+			resourceV1:      "cpu.shares",
+			expectV1:        "123",
+			// Cgroups v2 has a conversion from shares to weight
+			// weight = (1 + ((cpuShares-2)*9999)/262142)
+			delegationV2: "cpu",
+			resourceV2:   "cpu.weight",
+			expectV2:     "5",
+		},
+		{
+			name:            "cpuset-cpus",
+			args:            []string{"--cpuset-cpus", "0", "--cpuset-mems", "0"},
+			expectErrorCode: 0,
+			controllerV1:    "cpuset",
+			resourceV1:      "cpuset.cpus",
+			expectV1:        "0",
+			delegationV2:    "cpuset",
+			resourceV2:      "cpuset.cpus",
+			expectV2:        "0",
+		},
+		{
+			name:            "cpuset-mems",
+			args:            []string{"--cpuset-cpus", "0", "--cpuset-mems", "0"},
+			expectErrorCode: 0,
+			controllerV1:    "cpuset",
+			resourceV1:      "cpuset.mems",
+			expectV1:        "0",
+			delegationV2:    "cpuset",
+			resourceV2:      "cpuset.mems",
+			expectV2:        "0",
+		},
+		{
+			name:            "memory",
+			args:            []string{"--memory", "500M"},
+			expectErrorCode: 0,
+			controllerV1:    "memory",
+			resourceV1:      "memory.limit_in_bytes",
+			expectV1:        "524288000",
+			delegationV2:    "memory",
+			resourceV2:      "memory.max",
+			expectV2:        "524288000",
+		},
+		{
+			name:            "memory-reservation",
+			args:            []string{"--memory-reservation", "500M"},
+			expectErrorCode: 0,
+			controllerV1:    "memory",
+			resourceV1:      "memory.soft_limit_in_bytes",
+			expectV1:        "524288000",
+			delegationV2:    "memory",
+			resourceV2:      "memory.low",
+			expectV2:        "524288000",
+		},
+		{
+			// The CLI memory-swap value is v1 memory + swap... so this means 250M of swap
+			name:            "memory-swap",
+			args:            []string{"--memory-swap", "500M", "--memory", "250M"},
+			expectErrorCode: 0,
+			controllerV1:    "memory",
+			resourceV1:      "memory.memsw.limit_in_bytes",
+			// V1 shows the 500M combined
+			expectV1: "524288000",
+			// V2 treats the mem & swap separately... shows only 250M of swap (500M memory-swap - 250M memory)
+			delegationV2: "memory",
+			resourceV2:   "memory.swap.max",
+			expectV2:     "262144000",
+		},
+		{
+			name:            "oom-kill-disable",
+			args:            []string{"--oom-kill-disable"},
+			expectErrorCode: 0,
+			controllerV1:    "memory",
+			resourceV1:      "memory.oom_control",
+			expectV1:        "oom_kill_disable 1",
+			// v2 relies on oom_score_adj on /proc/pid instead
+			skipV2: true,
+		},
+		{
+			name:            "pids-limit",
+			args:            []string{"--pids-limit", "123"},
+			expectErrorCode: 0,
+			controllerV1:    "pids",
+			resourceV1:      "pids.max",
+			expectV1:        "123",
+			delegationV2:    "pids",
+			resourceV2:      "pids.max",
+			expectV2:        "123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if cgroups.IsCgroup2UnifiedMode() {
+				c.actionFlagV2(t, tt, profile)
+				return
+			}
+			c.actionFlagV1(t, tt, profile)
+		})
+	}
+}
+
+func (c *ctx) actionFlagV1(t *testing.T, tt actionFlagTest, profile e2e.Profile) {
+	// Don't try to test a resource that doesn't exist in our caller cgroup.
+	// E.g. some systems don't have memory.memswp, and might not have blkio.bfq
+	require.CgroupsResourceExists(t, tt.controllerV1, tt.resourceV1)
+
+	// Use shell in the container to find container cgroup and cat the value for the tested controller & resource.
+	// /proc/self/cgroup is : delimited
+	// controller is the 2nd field in `/proc/self/cgroup`
+	// cgroup path relative to root cgroup mount is the 3rd field in `/proc/self/cgroup`
+	shellCmd := fmt.Sprintf("cat /sys/fs/cgroup/%s$(cat /proc/self/cgroup | grep '[,:]%s[,:]' | cut -d ':' -f 3)/%s", tt.controllerV1, tt.controllerV1, tt.resourceV1)
+
+	exitFunc := []e2e.ApptainerCmdResultOp{}
+	if tt.expectV1 != "" {
+		exitFunc = []e2e.ApptainerCmdResultOp{e2e.ExpectOutput(e2e.ContainMatch, tt.expectV1)}
+	}
+
+	args := tt.args
+	args = append(args, "-B", "/sys/fs/cgroup", c.env.ImagePath, "/bin/sh", "-c", shellCmd)
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(profile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(args...),
+		e2e.ExpectExit(tt.expectErrorCode, exitFunc...),
+	)
+}
+
+func (c *ctx) actionFlagV2(t *testing.T, tt actionFlagTest, profile e2e.Profile) {
+	if tt.skipV2 {
+		t.Skip()
+	}
+	// In rootless mode, can only test subsystems that have been delegated
+	if !profile.Privileged() {
+		require.CgroupsV2Delegated(t, tt.delegationV2)
+	}
+
+	exitFunc := []e2e.ApptainerCmdResultOp{}
+	if tt.expectV2 != "" {
+		exitFunc = []e2e.ApptainerCmdResultOp{e2e.ExpectOutput(e2e.ContainMatch, tt.expectV2)}
+	}
+
+	// Use shell in the container to find container cgroup and cat the value for the tested controller & resource.
+	// /proc/self/cgroup is : delimited
+	// For V2 the controller is null (field 2), at index 0 (field 1)
+	// cgroup path relative to root cgroup mount is the 3rd field in `/proc/self/cgroup`
+	shellCmd := fmt.Sprintf("cat /sys/fs/cgroup$(cat /proc/self/cgroup | grep '^0::' | cut -d ':' -f 3)/%s", tt.resourceV2)
+
+	args := tt.args
+	args = append(args, "-B", "/sys/fs/cgroup", c.env.ImagePath, "/bin/sh", "-c", shellCmd)
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(profile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(args...),
+		e2e.ExpectExit(tt.expectErrorCode, exitFunc...),
+	)
+}
+
+func (c *ctx) actionFlagsRoot(t *testing.T) {
+	c.actionFlags(t, e2e.RootProfile)
+}
+
+func (c *ctx) actionFlagsRootless(t *testing.T) {
+	for _, profile := range []e2e.Profile{e2e.UserProfile, e2e.UserNamespaceProfile, e2e.FakerootProfile} {
+		t.Run(profile.String(), func(t *testing.T) {
+			c.actionFlags(t, profile)
+		})
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := &ctx{
@@ -372,10 +594,12 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	np := testhelper.NoParallel
 
 	return testhelper.Tests{
-		"instance stats":            np(env.WithRootManagers(c.instanceStatsRoot)),
-		"instance root cgroups":     np(env.WithRootManagers(c.instanceApplyRoot)),
-		"instance rootless cgroups": np(env.WithRootlessManagers(c.instanceApplyRootless)),
-		"action root cgroups":       np(env.WithRootManagers(c.actionApplyRoot)),
-		"action rootless cgroups":   np(env.WithRootlessManagers(c.actionApplyRootless)),
+		"instance stats":                np(env.WithRootManagers(c.instanceStatsRoot)),
+		"instance root cgroups":         np(env.WithRootManagers(c.instanceApplyRoot)),
+		"instance rootless cgroups":     np(env.WithRootlessManagers(c.instanceApplyRootless)),
+		"action root cgroups":           np(env.WithRootManagers(c.actionApplyRoot)),
+		"action rootless cgroups":       np(env.WithRootlessManagers(c.actionApplyRootless)),
+		"action flags root cgroups":     np(env.WithRootManagers(c.actionFlagsRoot)),
+		"action flags rootless cgroups": np(env.WithRootlessManagers(c.actionFlagsRootless)),
 	}
 }

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -135,7 +135,7 @@ func (c *ctx) instanceApply(t *testing.T, profile e2e.Profile) {
 			startErrorCode: 255,
 			// e2e test currently only captures the error from the CLI process, not the error displayed by the
 			// starter process, so we check for the generic CLI error.
-			startErrorOut: "failed to start instance",
+			startErrorOut: "no such file or directory",
 			rootfull:      true,
 			rootless:      true,
 		},
@@ -145,7 +145,7 @@ func (c *ctx) instanceApply(t *testing.T, profile e2e.Profile) {
 			startErrorCode: 255,
 			// e2e test currently only captures the error from the CLI process, not the error displayed by the
 			// starter process, so we check for the generic CLI error.
-			startErrorOut: "failed to start instance",
+			startErrorOut: "parsing error",
 			rootfull:      true,
 			rootless:      true,
 		},

--- a/examples/plugins/config-plugin/main_linux.go
+++ b/examples/plugins/config-plugin/main_linux.go
@@ -11,7 +11,6 @@ package main
 
 import (
 	"log"
-	"path/filepath"
 
 	"github.com/apptainer/apptainer/internal/pkg/cgroups"
 	pluginapi "github.com/apptainer/apptainer/pkg/plugin"
@@ -48,17 +47,11 @@ func callbackCgroups(common *config.Common) {
 		},
 	}
 
-	path, err := filepath.Abs("test-cgroups")
+	data, err := cfg.MarshalJSON()
 	if err != nil {
-		sylog.Errorf("Could not get cgroups path: %s", path)
+		sylog.Errorf("While Marshalling cgroups config to JSON: %s", err)
+		return
 	}
-	err = cgroups.SaveConfig(cfg, path)
-	if err != nil {
-		log.Printf("Put c error: %v", err)
-	}
-	if path := c.GetCgroupsTOML(); path != "" {
-		sylog.Infof("Old cgroups path: %s", path)
-	}
-	sylog.Infof("Setting cgroups path to %s", path)
-	c.SetCgroupsTOML(path)
+	sylog.Infof("Overriding cgroups config")
+	c.SetCgroupsJSON(data)
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/creack/pty v1.1.18
 	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/docker/docker v20.10.16+incompatible
+	github.com/docker/go-units v0.4.0
 	github.com/fatih/color v1.13.0
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-log/log v0.2.0
@@ -37,6 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/seccomp/containers-golang v0.6.0
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921
+	github.com/shopspring/decimal v1.3.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/sylabs/json-resp v0.8.1
@@ -52,8 +54,6 @@ require (
 	mvdan.cc/sh/v3 v3.5.0
 	oras.land/oras-go v1.1.1
 )
-
-require github.com/docker/go-units v0.4.0
 
 require (
 	github.com/AdamKorcz/go-fuzz-headers v0.0.0-20210319161527-f761c2329661 // indirect

--- a/go.sum
+++ b/go.sum
@@ -975,6 +975,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/internal/pkg/cgroups/config_linux.go
+++ b/internal/pkg/cgroups/config_linux.go
@@ -175,7 +175,26 @@ type Config struct {
 	Unified map[string]string `toml:"unified" json:"unified,omitempty"`
 }
 
-// LoadConfig loads a cgroups config file into our native cgroups.Config struct
+// MarshalJSON marshals a cgroups.Config struct to a JSON string
+func (c *Config) MarshalJSON() (string, error) {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// UnmarshalJSON unmarshals a JSON string into a LinuxResources struct
+func UnmarshalJSONResources(data string) (*specs.LinuxResources, error) {
+	res := specs.LinuxResources{}
+	err := json.Unmarshal([]byte(data), &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// LoadConfig loads a TOML cgroups config file into our native cgroups.Config struct
 func LoadConfig(confPath string) (config Config, err error) {
 	path, err := filepath.Abs(confPath)
 	if err != nil {

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -360,6 +360,17 @@ func NewManagerWithSpec(spec *specs.LinuxResources, pid int, group string, syste
 	return mgr, nil
 }
 
+// NewManagerWithJSON creates a Manager, applies the JSON configuration supplied, and adds pid to the cgroup.
+// If a group name is supplied, it will be used by the manager.
+// If group = "" then "/apptainer/<pid>" is used as a default.
+func NewManagerWithJSON(jsonSpec string, pid int, group string, systemd bool) (manager *Manager, err error) {
+	spec, err := UnmarshalJSONResources(jsonSpec)
+	if err != nil {
+		return nil, fmt.Errorf("while loading cgroups spec: %w", err)
+	}
+	return NewManagerWithSpec(spec, pid, group, systemd)
+}
+
 // NewManagerWithFile creates a Manager, applies the configuration at specPath, and adds pid to the cgroup.
 // If a group name is supplied, it will be used by the manager.
 // If group = "" then "/apptainer/<pid>" is used as a default.

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -293,8 +293,8 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		}
 	}
 
-	cgTOML := engine.EngineConfig.GetCgroupsTOML()
-	if cgTOML != "" {
+	cgJSON := engine.EngineConfig.GetCgroupsJSON()
+	if cgJSON != "" {
 		// Rootless cgroups setup interacts with systemd over D-Bus.
 		// The session bus address and XDG runtime dir must be set in the environment.
 		if os.Getuid() != 0 {
@@ -302,7 +302,8 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 			os.Setenv("XDG_RUNTIME_DIR", engine.EngineConfig.GetXdgRuntimeDir())
 			os.Setenv("DBUS_SESSION_BUS_ADDRESS", engine.EngineConfig.GetDbusSessionBusAddress())
 		}
-		cgroupsManager, err = cgroups.NewManagerWithFile(cgTOML, pid, "", engine.EngineConfig.File.SystemdCgroups)
+
+		cgroupsManager, err = cgroups.NewManagerWithJSON(cgJSON, pid, "", engine.EngineConfig.File.SystemdCgroups)
 		if err != nil {
 			return fmt.Errorf("while applying cgroups config: %v", err)
 		}

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -412,7 +412,7 @@ func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error 
 
 		// If we are using cgroups with this instance then mark that in the instance config.
 		// We don't store the path, as we will get the cgroup manager by Pid.
-		if e.EngineConfig.GetCgroupsTOML() != "" {
+		if e.EngineConfig.GetCgroupsJSON() != "" {
 			file.Cgroup = true
 		}
 

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -81,7 +81,7 @@ func (m *flagManager) registerFlagForCmd(flag *Flag, cmds ...*cobra.Command) err
 	if flag.EnvHandler == nil {
 		flag.EnvHandler = EnvSetValue
 	}
-	switch t := flag.DefaultValue.(type) {
+	switch flag.DefaultValue.(type) {
 	case string:
 		m.registerStringVar(flag, cmds)
 	case map[string]string:
@@ -97,7 +97,7 @@ func (m *flagManager) registerFlagForCmd(flag *Flag, cmds ...*cobra.Command) err
 	case uint32:
 		m.registerUint32Var(flag, cmds)
 	default:
-		return fmt.Errorf("flag of type %s is not supported", t)
+		return fmt.Errorf("flag %s of type %T is not supported", flag.Name, flag.DefaultValue)
 	}
 	m.flags[flag.ID] = flag
 	return nil

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -87,7 +87,7 @@ type JSONConfig struct {
 	Image                 string            `json:"image"`
 	ImageArg              string            `json:"imageArg"`
 	Workdir               string            `json:"workdir,omitempty"`
-	CgroupsTOML           string            `json:"cgroupsTOML,omitempty"`
+	CgroupsJSON           string            `json:"cgroupsJSON,omitempty"`
 	HomeSource            string            `json:"homedir,omitempty"`
 	HomeDest              string            `json:"homeDest,omitempty"`
 	Command               string            `json:"command,omitempty"`
@@ -605,14 +605,14 @@ func (e *EngineConfig) GetSecurity() []string {
 	return e.JSON.Security
 }
 
-// SetCgroupsTOML sets path to cgroups TOML file to apply.
-func (e *EngineConfig) SetCgroupsTOML(path string) {
-	e.JSON.CgroupsTOML = path
+// SetCgroupsJSON sets cgroups configuration to apply.
+func (e *EngineConfig) SetCgroupsJSON(data string) {
+	e.JSON.CgroupsJSON = data
 }
 
-// GetCgroupsTOML returns path to cgroups TOML file to apply.
-func (e *EngineConfig) GetCgroupsTOML() string {
-	return e.JSON.CgroupsTOML
+// GetCgroupsTOML returns cgroups configuration to apply.
+func (e *EngineConfig) GetCgroupsJSON() string {
+	return e.JSON.CgroupsJSON
 }
 
 // SetTargetUID sets target UID to execute the container process as user ID.


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#721
which fixed
- sylabs/singularity#717

The original PR description was:
> **feat: Add CLI action flags to apply cgroups limits**
> 
> Add CLI action flags that apply cgroups limits without needing the user to write a cgroups TOML file.
> 
> Most of the flags supported by Docker are now present, with the exception of `--device-` flags which will be considered later.
> 
> Note that only the long form of these flags is supported. The short form of e.g. `--cpus` is `-c` which would clash with existing use in singularity.
> 
> To implement, a JSON serialization of the LinuxResources structures is now passed through the engine configuration. Where a TOML file is used with `--apply-cgroups` it is now read and serialized to JSON, rather than passing the path to the file through to the engine.
> 
> At a later date we can/should rationalize our handing of the structures. We should likely accept JSON files as well as TOML, avoid duplicating the LinuxResources structures in our own code, etc.
> 
> **e2e: add tests for cgroups limits CLI flags**
> 
> Run a container with cgroups limits flags, and check that the cgroup the container sits in has the limit set correctly.
> 
> Covering as much of the functionality as is straightforward on v1 and v2 systems. Note that due to v2 delegation differences between distros, systemd version differences, and changes in the resource names over time, different tests will skip on different distros.
> 
> `--blkio-weight-device` is not currently tested here, as it is not straightforward to find a block device across different environments. e.g. `/dev/sda` vs `/dev/nvme0n1p1` vs `/dev/vda` etc. The flag -> resource specification translation is, however, tested in the CLI unit tests.
> 
> CI checks cgroups v1. cgroups v2 was verified on Fedora 35 with default delegation.