### PR TITLE
feat: Add --no-eval for OCI compatible argument and env var handling, from sylabs 704

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ For older changes see the [archived Singularity change log](https://github.com/a
   support.
 - Apptainer now requires squashfs-tools >=4.3, which is satisfied by
   current EL / Ubuntu / Debian and other distributions.
+- New action flag `--no-eval` which:
+  - Prevents shell evaluation of `APPTAINERENV_ / --env / --env-file`
+    environment variables as they are injected in the container, to match OCI
+    behavior. *Applies to all containers*.
+  - Prevents shell evaluation of the values of `CMD / ENTRYPOINT` and command
+    line arguments for containers run or built directly from an OCI/Docker
+    source. *Applies to newly built containers only, use `apptainer inspect`
+    to check version that container was built with*.
+- Added `--no-eval` to the list of flags set by the OCI/Docker `--compat` mode.
 
 ### New features / functionalities
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -54,6 +54,7 @@ var (
 	Nvidia          bool
 	NvCCLI          bool
 	Rocm            bool
+	NoEval          bool
 	NoHome          bool
 	NoInit          bool
 	NoNvidia        bool
@@ -358,7 +359,7 @@ var actionCompatFlag = cmdline.Flag{
 	Value:        &IsCompat,
 	DefaultValue: false,
 	Name:         "compat",
-	Usage:        "apply settings for increased OCI/Docker compatibility. Infers --containall, --no-init, --no-umask, --writable-tmpfs.",
+	Usage:        "apply settings for increased OCI/Docker compatibility. Infers --containall, --no-init, --no-umask, --no-eval, --writable-tmpfs.",
 	EnvKeys:      []string{"COMPAT"},
 }
 
@@ -641,12 +642,22 @@ var actionEnvFileFlag = cmdline.Flag{
 
 // --no-umask
 var actionNoUmaskFlag = cmdline.Flag{
-	ID:           " actionNoUmask",
+	ID:           "actionNoUmask",
 	Value:        &NoUmask,
 	DefaultValue: false,
 	Name:         "no-umask",
 	Usage:        "do not propagate umask to the container, set default 0022 umask",
 	EnvKeys:      []string{"NO_UMASK"},
+}
+
+// --no-eval
+var actionNoEvalFlag = cmdline.Flag{
+	ID:           "actionNoEval",
+	Value:        &NoEval,
+	DefaultValue: false,
+	Name:         "no-eval",
+	Usage:        "do not shell evaluate env vars or OCI container CMD/ENTRYPOINT/ARGS",
+	EnvKeys:      []string{"NO_EVAL"},
 }
 
 // --dmtcp-launch
@@ -747,5 +758,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionEnvFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionEnvFileFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoUmaskFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoEvalFlag, actionsInstanceCmd...)
 	})
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -67,6 +67,7 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 		IsWritableTmpfs = true
 		NoInit = true
 		NoUmask = true
+		NoEval = true
 	}
 }
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -223,6 +223,11 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		engineConfig.SetRestoreUmask(true)
 	}
 
+	if NoEval {
+		engineConfig.SetNoEval(true)
+		generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "NO_EVAL", "1")
+	}
+
 	uidParam := security.GetParam(Security, "uid")
 	gidParam := security.GetParam(Security, "gid")
 

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -454,6 +454,7 @@ func (c ctx) testDockerLabels(t *testing.T) {
 	)
 }
 
+//nolint:dupl
 func (c ctx) testDockerCMD(t *testing.T) {
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
 	defer cleanup(t)
@@ -552,6 +553,178 @@ func (c ctx) testDockerCMD(t *testing.T) {
 	}
 }
 
+//nolint:dupl
+func (c ctx) testDockerENTRYPOINT(t *testing.T) {
+	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
+	defer cleanup(t)
+	imagePath := filepath.Join(imageDir, "container")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("while getting $HOME: %s", err)
+	}
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs(imagePath, "docker://sylabsio/docker-entrypoint"),
+		e2e.ExpectExit(0),
+	)
+
+	tests := []struct {
+		name         string
+		args         []string
+		noeval       bool
+		expectOutput string
+	}{
+		// Apptainer historic behavior (without --no-eval)
+		// These do not all match Docker, due to evaluation, consumption of quoting.
+		{
+			name:         "default",
+			args:         []string{},
+			noeval:       false,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s`,
+		},
+		{
+			name:         "override",
+			args:         []string{"echo", "test"},
+			noeval:       false,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s echo test`,
+		},
+		{
+			name:         "override env var",
+			args:         []string{"echo", "$HOME"},
+			noeval:       false,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s echo ` + home,
+		},
+		// Docker/OCI behavior (with --no-eval)
+		{
+			name:         "no-eval/default",
+			args:         []string{},
+			noeval:       false,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s`,
+		},
+		{
+			name:         "no-eval/override",
+			args:         []string{"echo", "test"},
+			noeval:       true,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s echo test`,
+		},
+		{
+			name:         "no-eval/override env var",
+			noeval:       true,
+			args:         []string{"echo", "$HOME"},
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s echo $HOME`,
+		},
+	}
+
+	for _, tt := range tests {
+		cmdArgs := []string{}
+		if tt.noeval {
+			cmdArgs = append(cmdArgs, "--no-eval")
+		}
+		cmdArgs = append(cmdArgs, imagePath)
+		cmdArgs = append(cmdArgs, tt.args...)
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("run"),
+			e2e.WithArgs(cmdArgs...),
+			e2e.ExpectExit(0,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.expectOutput),
+			),
+		)
+	}
+}
+
+//nolint:dupl
+func (c ctx) testDockerCMDENTRYPOINT(t *testing.T) {
+	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "docker-", "")
+	defer cleanup(t)
+	imagePath := filepath.Join(imageDir, "container")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("while getting $HOME: %s", err)
+	}
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs(imagePath, "docker://sylabsio/docker-cmd-entrypoint"),
+		e2e.ExpectExit(0),
+	)
+
+	tests := []struct {
+		name         string
+		args         []string
+		noeval       bool
+		expectOutput string
+	}{
+		// Apptainer historic behavior (without --no-eval)
+		// These do not all match Docker, due to evaluation, consumption of quoting.
+		{
+			name:         "default",
+			args:         []string{},
+			noeval:       false,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s CMD 'quotes' "quotes" $DOLLAR s p a c e s`,
+		},
+		{
+			name:         "override",
+			args:         []string{"echo", "test"},
+			noeval:       false,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s echo test`,
+		},
+		{
+			name:         "override env var",
+			args:         []string{"echo", "$HOME"},
+			noeval:       false,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s echo ` + home,
+		},
+		// Docker/OCI behavior (with --no-eval)
+		{
+			name:         "no-eval/default",
+			args:         []string{},
+			noeval:       false,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s CMD 'quotes' "quotes" $DOLLAR s p a c e s`,
+		},
+		{
+			name:         "no-eval/override",
+			args:         []string{"echo", "test"},
+			noeval:       true,
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s echo test`,
+		},
+		{
+			name:         "no-eval/override env var",
+			noeval:       true,
+			args:         []string{"echo", "$HOME"},
+			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s echo $HOME`,
+		},
+	}
+
+	for _, tt := range tests {
+		cmdArgs := []string{}
+		if tt.noeval {
+			cmdArgs = append(cmdArgs, "--no-eval")
+		}
+		cmdArgs = append(cmdArgs, imagePath)
+		cmdArgs = append(cmdArgs, tt.args...)
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("run"),
+			e2e.WithArgs(cmdArgs...),
+			e2e.ExpectExit(0,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.expectOutput),
+			),
+		)
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
@@ -566,6 +739,8 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"registry":         c.testDockerRegistry,
 		"whiteout symlink": c.testDockerWhiteoutSymlink,
 		"cmd":              c.testDockerCMD,
+		"entrypoint":       c.testDockerENTRYPOINT,
+		"cmdentrypoint":    c.testDockerCMDENTRYPOINT,
 		"cmd quotes":       c.testDockerCMDQuotes,
 		"labels":           c.testDockerLabels,
 	}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -14,7 +14,9 @@ package apptainerenv
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -461,6 +463,191 @@ func (c ctx) apptainerEnvFile(t *testing.T) {
 	}
 }
 
+// Check for evaluation of env vars with / without `--no-eval`. By default,
+// Apptainer will evaluate the value of injected env vars when sourcing the
+// shell script that injects them. With --no-eval it should match Docker, with
+// no evaluation:
+//
+//   WHO='$(id -u)' docker run -it --env WHO --rm alpine sh -c 'echo $WHO'
+//   $(id -u)
+//
+func (c ctx) apptainerEnvEval(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	testArgs := []string{"/bin/sh", "-c", "echo $WHO"}
+
+	tests := []struct {
+		name         string
+		env          []string
+		args         []string
+		noeval       bool
+		expectOutput string
+	}{
+		// Apptainer historic behavior (without --no-eval)
+		{
+			name:         "no env",
+			args:         testArgs,
+			env:          []string{},
+			noeval:       false,
+			expectOutput: "",
+		},
+		{
+			name:         "string env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=ME"},
+			noeval:       false,
+			expectOutput: "ME",
+		},
+		{
+			name:         "env var",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=$UID"},
+			noeval:       false,
+			expectOutput: strconv.Itoa(os.Getuid()),
+		},
+		{
+			name:         "double quoted env var",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=\"$UID\""},
+			noeval:       false,
+			expectOutput: "\"" + strconv.Itoa(os.Getuid()) + "\"",
+		},
+		{
+			name:         "single quoted env var",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO='$UID'"},
+			noeval:       false,
+			expectOutput: "'" + strconv.Itoa(os.Getuid()) + "'",
+		},
+		{
+			name:         "escaped env var",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=\\$UID"},
+			noeval:       false,
+			expectOutput: "$UID",
+		},
+		{
+			name:         "subshell env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=$(id -u)"},
+			noeval:       false,
+			expectOutput: strconv.Itoa(os.Getuid()),
+		},
+		{
+			name:         "double quoted subshell env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=\"$(id -u)\""},
+			noeval:       false,
+			expectOutput: "\"" + strconv.Itoa(os.Getuid()) + "\"",
+		},
+		{
+			name:         "single quoted subshell env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO='$(id -u)'"},
+			noeval:       false,
+			expectOutput: "'" + strconv.Itoa(os.Getuid()) + "'",
+		},
+		{
+			name:         "escaped subshell env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=\\$(id -u)"},
+			noeval:       false,
+			expectOutput: "$(id -u)",
+		},
+		// Docker/OCI behavior (with --no-eval)
+		{
+			name:         "no-eval/no env",
+			args:         testArgs,
+			env:          []string{},
+			noeval:       false,
+			expectOutput: "",
+		},
+		{
+			name:         "no-eval/string env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=ME"},
+			noeval:       false,
+			expectOutput: "ME",
+		},
+		{
+			name:         "no-eval/env var",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=$UID"},
+			noeval:       true,
+			expectOutput: "$UID",
+		},
+		{
+			name:         "no-eval/double quoted env var",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=\"$UID\""},
+			noeval:       true,
+			expectOutput: "\"$UID\"",
+		},
+		{
+			name:         "no-eval/single quoted env var",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO='$UID'"},
+			noeval:       true,
+			expectOutput: "'$UID'",
+		},
+		{
+			name:         "no-eval/escaped env var",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=\\$UID"},
+			noeval:       true,
+			expectOutput: "\\$UID",
+		},
+		{
+			name:         "no-eval/subshell env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=$(id -u)"},
+			noeval:       true,
+			expectOutput: "$(id -u)",
+		},
+		{
+			name:         "no-eval/double quoted subshell env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=\"$(id -u)\""},
+			noeval:       true,
+			expectOutput: "\"$(id -u)\"",
+		},
+		{
+			name:         "no-eval/single quoted subshell env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO='$(id -u)'"},
+			noeval:       true,
+			expectOutput: "'$(id -u)'",
+		},
+		{
+			name:         "no-eval/escaped subshell env",
+			args:         testArgs,
+			env:          []string{"APPTAINERENV_WHO=\\$(id -u)"},
+			noeval:       true,
+			expectOutput: "\\$(id -u)",
+		},
+	}
+
+	for _, tt := range tests {
+		cmdArgs := []string{}
+		if tt.noeval {
+			cmdArgs = append(cmdArgs, "--no-eval")
+		}
+		cmdArgs = append(cmdArgs, c.env.ImagePath)
+		cmdArgs = append(cmdArgs, tt.args...)
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithEnv(tt.env),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(cmdArgs...),
+			e2e.ExpectExit(0,
+				e2e.ExpectOutput(e2e.ExactMatch, tt.expectOutput),
+			),
+		)
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
@@ -471,8 +658,9 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"environment manipulation": c.apptainerEnv,
 		"environment option":       c.apptainerEnvOption,
 		"environment file":         c.apptainerEnvFile,
-		"issue 5057":               c.issue5057, // https://github.com/hpcng/issues/5057
-		"issue 5426":               c.issue5426, // https://github.com/hpcng/issues/5426
+		"env eval":                 c.apptainerEnvEval,
+		"issue 5057":               c.issue5057, // https://github.com/apptainer/singularity/issues/5057
+		"issue 5426":               c.issue5426, // https://github.com/apptainer/singularity/issues/5426
 		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
 		"issue 274":                c.issue274,  // https://github.com/sylabs/singularity/issues/274
 	}

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -631,7 +631,12 @@ func (b *bufferCloser) Close() error {
 // after /.singularity.d/env/99-base.sh or /environment.
 // This handler turns all SINGUALRITYENV_KEY=VAL defined variables into their form:
 // export KEY=VAL. It can be sourced only once otherwise it returns an empty content.
-func injectEnvHandler(senv map[string]string) interpreter.OpenHandler {
+// If noEval is true then exports are single quoted so their content is not evaluated
+// when the script is sourced (OCI compatible behavior).
+// If noEval is false then exports are double quoted, and their content is evaluated,
+// consuming one level of shell escaping and performing any unescaped var substitution,
+// subshell execution etc (Apptainer historic behavior).
+func injectEnvHandler(senv map[string]string, noEval bool) interpreter.OpenHandler {
 	var once sync.Once
 
 	return func(_ string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
@@ -645,25 +650,27 @@ func injectEnvHandler(senv map[string]string) interpreter.OpenHandler {
 			`
 			b.WriteString(fmt.Sprintf(defaultPathSnippet, env.DefaultPath))
 
-			// We wrap the value of the export in double quotes manually, and do not use
-			// go's %q format string as it prevents passing an escaped literal $ in
-			// a APPTAINERENV_ as \$
 			snippet := `
 			if test -v %[1]s; then
 				sylog debug "Overriding %[1]s environment variable"
 			fi
-			export %[1]s="%[2]s"
+			export %[1]s=%[2]s
 			`
 			for key, value := range senv {
-				switch key {
-				case "UID", "GID":
-				case "LD_LIBRARY_PATH":
-					if value != "" {
-						b.WriteString(fmt.Sprintf(snippet, key, value+":/.singularity.d/libs"))
-					}
-				default:
-					b.WriteString(fmt.Sprintf(snippet, key, shell.EscapeDoubleQuotes(value)))
+				if key == "UID" || key == "GID" {
+					continue
 				}
+				if key == "LD_LIBRARY_PATH" && value != "" {
+					value = value + ":/.singularity.d/libs"
+				}
+				if noEval {
+					// No evaluation when the export is sourced
+					value = "'" + shell.EscapeSingleQuotes(value) + "'"
+				} else {
+					// Shell evaluation when the export is sourced
+					value = "\"" + shell.EscapeDoubleQuotes(value) + "\""
+				}
+				b.WriteString(fmt.Sprintf(snippet, key, value))
 			}
 		})
 
@@ -814,7 +821,7 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 
 	// inject APPTAINERENV_ defined variables
 	senv := engineConfig.GetApptainerEnv()
-	shell.RegisterOpenHandler("/.inject-apptainer-env.sh", injectEnvHandler(senv))
+	shell.RegisterOpenHandler("/.inject-apptainer-env.sh", injectEnvHandler(senv, engineConfig.GetNoEval()))
 
 	shell.RegisterOpenHandler("/.singularity.d/env/99-runtimevars.sh", runtimeVarsHandler(senv))
 

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -136,6 +136,7 @@ type JSONConfig struct {
 	DMTCPConfig           DMTCPConfig       `json:"dmtcpConfig,omitempty"`
 	XdgRuntimeDir         string            `json:"xdgRuntimeDir,omitempty"`
 	DbusSessionBusAddress string            `json:"dbusSessionBusAddress,omitempty"`
+	NoEval                bool              `json:"noEval,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -846,4 +847,16 @@ func (e *EngineConfig) SetDbusSessionBusAddress(address string) {
 // GetDbusSessionBusAddress gets the DBUS_SESSION_BUS_ADDRESS value for rootless operations
 func (e *EngineConfig) GetDbusSessionBusAddress() string {
 	return e.JSON.DbusSessionBusAddress
+}
+
+// SetNoEval sets whether to avoid a shell eval on APPTAINERENV_ and in
+// runscripts generated from OCI containers CMD/ENTRYPOINT.
+func (e *EngineConfig) SetNoEval(noEval bool) {
+	e.JSON.NoEval = noEval
+}
+
+// GetNoEval sets whether to avoid a shell eval on APPTAINERENV_ and in
+// runscripts generated from OCI containers CMD/ENTRYPOINT.
+func (e *EngineConfig) GetNoEval() bool {
+	return e.JSON.NoEval
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#704
which fixed
- sylabs/singularity#487

The original PR description was:
> Address sylabs/singularity#487 by adding a `--no-eval` actions flag, which does the following:
> 
> 1. Quotes environment variable values in the `inject-singularity-env.sh` generated script using single quotes to
>        ensure the values are not evaluated when the injection script is sourced.
>        _This behavior applies to existing and newly created images._
> 
> 2. Uses an alternate path in the generated runscript for images built from OCI sources, that avoids evaluating CMD / ENTRYPOINT parts, and args in the shell.
>        _This behavior only applies to newly created images, that contain the new form of the generated OCI runscript._
> 
> 
> The `--no-eval` flag is implictly added by the Docker/OCI `--compat` mode.
> 
> Also adds test cases that cover this new functionality, the historic behavior, and general handling of CMD / ENTRYPOINT/ CMD+ENTRYPOINT handling and overrides in Docker/OCI images. This should help us a lot in catching any changes to the 'historic' behaviour, that has been modified inadvertently in the past.
> 
> There is no change to the historic behavior of Singularity (run without `--no-eval` or `--compat`) at this time. OCI / Docker compatible handling by default may be considered for a future release.