### PR TITLE
Require fuse-overlayfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           go-version: 1.18.1
 
       - name: Fetch deps
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         run: |
@@ -229,7 +229,7 @@ jobs:
 
       - name: Fetch deps
         if: env.run_tests
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         if: env.run_tests

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,7 @@ sudo apt-get install -y \
     pkg-config \
     squashfs-tools \
     squashfuse \
+    fuse-overlayfs \
     cryptsetup \
     curl wget git
 ```
@@ -42,6 +43,7 @@ sudo yum install -y \
     libseccomp-devel \
     squashfs-tools \
     squashfuse \
+    fuse-overlayfs \
     cryptsetup \
     wget git
 ```

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -25,7 +25,7 @@ Vcs-Browser: https://github.com/apptainer/apptainer
 
 Package: apptainer
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools, squashfuse
+Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools, squashfuse, fuse-overlayfs
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -71,6 +71,9 @@ Requires: squashfs-tools
 %endif
 BuildRequires: cryptsetup
 Requires: squashfuse
+%if 0%{?el7}
+Requires: fuse-overlayfs
+%endif
 
 %description
 Apptainer provides functionality to make portable

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -14,6 +14,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     pkg-config \
     squashfs-tools \
     squashfuse \
+    fuse-overlayfs \
     cryptsetup \
     curl wget git
 apt-get install -y \

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -10,7 +10,7 @@
 yum install -y rpm-build make yum-utils gcc binutils util-linux-ng which git
 yum install -y libseccomp-devel e2fsprogs cryptsetup
 yum install -y epel-release
-yum install -y golang squashfuse
+yum install -y golang squashfuse fuse-overlayfs
 
 # switch to an unprivileged user with sudo privileges
 yum install -y sudo


### PR DESCRIPTION
This builds on #411 by requiring fuse-overlayfs on Debian and on el7.  It's not needed on el8 (and above) because that supports unprivileged overlayfs.  Newer versions of Debian & Ubuntu don't need it either but there aren't conditionals in Debian packaging like there are in rpm.