### PR TITLE
fix: cgroups: ensure cgroups device limits are default allow, from sylabs 790

### DIFF
--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -99,9 +99,6 @@ func (c *ctx) instanceStats(t *testing.T, profile e2e.Profile) {
 					e2e.ExpectOutput(e2e.ContainMatch, "MEM %"),
 					e2e.ExpectOutput(e2e.ContainMatch, "BLOCK I/O"),
 					e2e.ExpectOutput(e2e.ContainMatch, "PIDS"),
-					e2e.ExpectOutput(e2e.ContainMatch, "GiB"),
-					e2e.ExpectOutput(e2e.ContainMatch, "KiB"),
-					e2e.ExpectOutput(e2e.ContainMatch, "MiB"),
 				),
 			)
 			c.env.RunApptainer(

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -305,6 +305,14 @@ func (c *ctx) actionApply(t *testing.T, profile e2e.Profile) {
 			// Reason is believed to be: https://github.com/opencontainers/runc/issues/3026
 			rootless: false,
 		},
+		// Device access is allowed by default.
+		{
+			name:            "device allow default",
+			args:            []string{"--apply-cgroups", "testdata/cgroups/null.toml", c.env.ImagePath, "cat", "/dev/null"},
+			expectErrorCode: 0,
+			rootfull:        true,
+			rootless:        true,
+		},
 		// Device limits are properly applied only in rootful mode. Rootless will ignore them with a warning.
 		{
 			name:            "device deny",


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#790
which fixed
- sylabs/singularity#787

The original PR description was:
> In singularity, cgroups device limits have always defaulted to allow-all. When a cgroups config is provided with no explicit device rules, no cgroups mediated device limits have applied.
> 
> We recently switched to runc/libcontainer/cgroups as our cgroups manager (from containerd/cgroups), and this applies a default deny rule for devices.
> 
> Revert to previous behavior by asking runc/libcontainer/cgroups to skip application of device limits if no limits are provided in the spec that has been passed.