### PR TITLE
Remove more references to sylabs.io in cli docs

### DIFF
--- a/docs/content.go
+++ b/docs/content.go
@@ -601,7 +601,7 @@ Enterprise Performance Computing (EPC)`
       oras://registry/namespace/image:tag
 
   http, https: Pull an image using the http(s?) protocol
-      https://library.sylabs.io/v1/imagefile/library/default/alpine:latest`
+      https://example.com/alpine.sif`
 	PullExample string = `
   From a library
   $ apptainer pull alpine.sif library://alpine:latest
@@ -863,7 +863,7 @@ Enterprise Performance Computing (EPC)`
   For additional help, please visit our public documentation pages which are
   found at:
 
-      https://www.sylabs.io/docs/`
+      https://apptainer.org/docs/`
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// OCI

--- a/docs/plugin.go
+++ b/docs/plugin.go
@@ -98,8 +98,8 @@ const (
   The 'plugin inspect' command allows a user to inspect a plugin that is already
   installed in the system or an image containing a plugin that is yet to be installed.`
 	PluginInspectExample string = `
-  $ apptainer plugin inspect sylabs.io/test-plugin
-  Name: sylabs.io/test-plugin
+  $ apptainer plugin inspect example.com/test-plugin
+  Name: example.com/test-plugin
   Description: A test Apptainer plugin.
   Author: Sylabs
   Version: 0.1.0`


### PR DESCRIPTION
This removes the remaining references to sylabs.io in the cli help.