### PR TITLE
Add bash to installed packages in alpine ci checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     container: golang:1.18.2-alpine
     steps:
       - name: Fetch deps
-        run: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
+        run: apk add -q --no-cache git bash alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
 
       - uses: actions/checkout@v2
 
@@ -71,7 +71,7 @@ jobs:
     container: golang:1.17-alpine
     steps:
       - name: Fetch deps
-        run: apk add -q --no-cache git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
+        run: apk add -q --no-cache git bash alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Add bash as an installed package on the alpine ci checks.  The script that checks minimum go version depends on /bin/bash and it is making PRs fail for a couple of days, for example #467.