### PR TITLE
Use $HOME to find configuration by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `$PATH:` followed by standard system paths.  Configuration variables
   for paths to individual programs that were in apptainer.conf are still
   supported but deprecated.
+- $HOME is now used to find the user's configuration and cache by default.
+  If that is not set it will fall back to the previous behavior of looking
+  up the home directory in the password file.  The value of $HOME inside
+  the container still defaults to the home directory in the password file
+  and can still be overridden by the ``--home`` option.
 - `oci mount` sets `Process.Terminal: true` when creating an OCI `config.json`,
   so that `oci run` provides expected interactive behavior by default.
 - Default hostname for `oci mount` containers is now `apptainer` instead of

--- a/e2e/internal/e2e/apptainercmd.go
+++ b/e2e/internal/e2e/apptainercmd.go
@@ -590,6 +590,9 @@ func (env TestEnv) RunApptainer(t *testing.T, cmdOps ...ApptainerCmdOp) {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("PWD=%s", cmd.Dir))
 		}
 
+		// Set $HOME
+		cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", CurrentUser(t).Dir))
+
 		// propagate proxy environment variables
 		for _, env := range []string{"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"} {
 			val := os.Getenv(env)

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -52,20 +52,24 @@ func ConfigDir() string {
 }
 
 func configDir(dir string) string {
-	user, err := user.Current()
-	if err != nil {
-		sylog.Warningf("Could not lookup the current user's information: %s", err)
-
-		cwd, err := os.Getwd()
+	homedir := os.Getenv("HOME")
+	if homedir == "" {
+		user, err := user.Current()
 		if err != nil {
-			sylog.Warningf("Could not get current working directory: %s", err)
-			return dir
-		}
+			sylog.Warningf("Could not lookup the current user's information: %s", err)
 
-		return filepath.Join(cwd, dir)
+			cwd, err := os.Getwd()
+			if err != nil {
+				sylog.Warningf("Could not get current working directory: %s", err)
+				return dir
+			}
+			homedir = cwd
+		} else {
+			homedir = user.HomeDir
+		}
 	}
 
-	return filepath.Join(user.HomeDir, dir)
+	return filepath.Join(homedir, dir)
 }
 
 func RemoteConf() string {


### PR DESCRIPTION
This uses the $HOME environment variable setting to find the configuration and caches, if it is set.  This enables unprivileged users to move that location, where previously it wasn't possible.

- Fixes #471