### PR TITLE
Enable unprivileged container builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           go-version: 1.18.2
 
       - name: Fetch deps
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         run: |
@@ -229,7 +229,7 @@ jobs:
 
       - name: Fetch deps
         if: env.run_tests
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         if: env.run_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ For older changes see the [archived Singularity change log](https://github.com/a
   filesystem (known as "sandbox" mode), which is not allowed when in
   setuid mode.  Does not work with a SIF partition because it requires
   privileges to mount that as an ext3 image.
+- Enabled unprivileged users to build containers without the `--fakeroot`
+  option.  Requires unprivileged user namespaces and the fakeroot command.
+  This is simpler to administer than the `--fakeroot` option because
+  there is no need for maintaining /etc/subuid and /etc/subgid mappings.
+  On the other hand, it isn't as complete an emulation and may fail under
+  some circumstances.  Only the %post scriptlet is run with fakeroot; the
+  other scriptlets are run in a root-mapped unprivileged user namespace,
+  the equivalent of `unshare -r`.
 - Added a `binary path` configuration variable as the default path to use
   when searching for helper executables.  May contain `$PATH:` which gets
   substituted with the user's PATH when running unprivileged.  Defaults to

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,7 @@ sudo apt-get install -y \
     squashfs-tools \
     squashfuse \
     fuse-overlayfs \
+    fakeroot \
     cryptsetup \
     curl wget git
 ```
@@ -44,6 +45,7 @@ sudo yum install -y \
     squashfs-tools \
     squashfuse \
     fuse-overlayfs \
+    fakeroot \
     cryptsetup \
     wget git
 ```

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -456,7 +456,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	// This doesn't count as a SetCustomHome(true), as we are mounting from the real
 	// user's standard $HOME -> /root and we want to respect --contain not mounting
 	// the $HOME in this case.
-	// See https://github.com/apptainer/apptainer/pull/5227
+	// See https://github.com/apptainer/singularity/pull/5227
 	if !homeFlag.Changed && IsFakeroot {
 		HomePath = fmt.Sprintf("%s:/root", HomePath)
 	}

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -25,7 +25,7 @@ Vcs-Browser: https://github.com/apptainer/apptainer
 
 Package: apptainer
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools, squashfuse, fuse-overlayfs
+Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools, squashfuse, fuse-overlayfs, fakeroot
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -72,6 +72,7 @@ Requires: squashfs-tools
 %endif
 BuildRequires: cryptsetup
 Requires: squashfuse
+Requires: fakeroot
 %if 0%{?el7}
 Requires: fuse-overlayfs
 %endif

--- a/internal/pkg/build/sources/oci_unpack.go
+++ b/internal/pkg/build/sources/oci_unpack.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	sytypes "github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/apptainer/apptainer/pkg/util/namespaces"
 	"github.com/containers/image/v5/types"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/umoci"
@@ -53,7 +54,8 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 	}
 
 	// Allow unpacking as non-root
-	if os.Geteuid() != 0 {
+	if namespaces.IsUnprivileged() {
+		sylog.Debugf("setting umoci rootless mode")
 		mapOptions.Rootless = true
 
 		uidMap, err := idtools.ParseMapping(fmt.Sprintf("0:%d:1", os.Geteuid()))

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -29,7 +29,7 @@ func FindBin(name string) (path string, err error) {
 	case "true", "mkfs.ext3", "cp", "rm", "dd":
 		return findOnPath(name)
 	// Bootstrap related executables that we assume are on PATH
-	case "mount", "mknod", "debootstrap", "pacstrap", "dnf", "yum", "rpm", "curl", "uname", "zypper", "SUSEConnect", "rpmkeys", "squashfuse", "fuse-overlayfs":
+	case "mount", "mknod", "debootstrap", "pacstrap", "dnf", "yum", "rpm", "curl", "uname", "zypper", "SUSEConnect", "rpmkeys", "squashfuse", "fuse-overlayfs", "fakeroot":
 		return findOnPath(name)
 	// Configurable executables that are found at build time, can be overridden
 	// in apptainer.conf. If config value is "" will look on PATH.
@@ -71,7 +71,7 @@ func findOnPath(name string) (path string, err error) {
 	os.Setenv("PATH", newPath)
 
 	path, err = exec.LookPath(name)
-	if err != nil {
+	if err == nil {
 		sylog.Debugf("Found %q at %q", name, path)
 	}
 	return path, err

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -49,6 +49,8 @@ type Options struct {
 	LibraryURL string `json:"libraryURL"`
 	// LibraryAuthToken contains authentication token to access specified library.
 	LibraryAuthToken string `json:"libraryAuthToken"`
+	// Path to fakeroot command will be empty if not needed or not available
+	FakerootPath string `json:"fakerootPath"`
 	// KeyServerOpts contains options for keyserver used for SIF fingerprint verification in builds.
 	KeyServerOpts []keyClient.Option
 	// contains docker credentials if specified.

--- a/pkg/util/namespaces/user_linux.go
+++ b/pkg/util/namespaces/user_linux.go
@@ -114,3 +114,17 @@ func HostUID() (int, error) {
 	// return current UID by default
 	return currentUID, nil
 }
+
+// IsUnprivileged returns true if running as an unprivileged user, even
+// if the user id is root inside an unprivileged user namespace; otherwise
+// it returns false
+func IsUnprivileged() bool {
+	if os.Geteuid() != 0 {
+		return true
+	}
+	uid, err := HostUID()
+	if err != nil {
+		return true
+	}
+	return uid != 0
+}

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -15,6 +15,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     squashfs-tools \
     squashfuse \
     fuse-overlayfs \
+    fakeroot \
     cryptsetup \
     curl wget git
 apt-get install -y \

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -10,7 +10,7 @@
 yum install -y rpm-build make yum-utils gcc binutils util-linux-ng which git
 yum install -y libseccomp-devel e2fsprogs cryptsetup
 yum install -y epel-release
-yum install -y golang squashfuse fuse-overlayfs
+yum install -y golang squashfuse fuse-overlayfs fakeroot
 
 # switch to an unprivileged user with sudo privileges
 yum install -y sudo


### PR DESCRIPTION
This enables container builds by unprivileged users.  Requires the fakeroot command and unprivileged user namespaces.

Does not add e2e tests.  I will make a separate issue for that.

- Fixes #447