### PR TITLE
Enable unprivileged builds without unprivileged user namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,17 @@ For older changes see the [archived Singularity change log](https://github.com/a
   setuid mode.  Does not work with a SIF partition because it requires
   privileges to mount that as an ext3 image.
 - Enabled unprivileged users to build containers without the `--fakeroot`
-  option.  Requires unprivileged user namespaces and the fakeroot command.
+  option.  Requires the fakeroot command.  
   This is simpler to administer than the `--fakeroot` option because
   there is no need for maintaining /etc/subuid and /etc/subgid mappings.
   On the other hand, it isn't as complete an emulation and may fail under
-  some circumstances.  Only the %post scriptlet is run with fakeroot; the
-  other scriptlets are run in a root-mapped unprivileged user namespace,
-  the equivalent of `unshare -r`.
+  some circumstances.  
+  The %post scriptlet is run with fakeroot, which is needed to allow
+  package installation scripts to think they were run as root.
+  Works better with unprivileged user namespaces because then everything
+  is also run in a root-mapped unprivileged user namespace, the
+  equivalent of `unshare -r`.  Without unprivileged user namespaces, the
+  `--fix-perms` option is implied to allow writing into directories.
 - Added a `binary path` configuration variable as the default path to use
   when searching for helper executables.  May contain `$PATH:` which gets
   substituted with the user's PATH when running unprivileged.  Defaults to

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -406,6 +406,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	engineConfig.SetAddCaps(AddCaps)
 	engineConfig.SetDropCaps(DropCaps)
 	engineConfig.SetConfigurationFile(configurationFile)
+	engineConfig.SetUseBuildConfig(useBuildConfig)
 
 	checkPrivileges(AllowSUID, "--allow-setuid", func() {
 		engineConfig.SetAllowSUID(AllowSUID)

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -62,6 +62,7 @@ var (
 	promptForPassphrase bool
 	forceOverwrite      bool
 	noHTTPS             bool
+	useBuildConfig      bool
 	tmpDir              string
 )
 
@@ -226,6 +227,15 @@ var singConfigFileFlag = cmdline.Flag{
 	ShortHand:    "c",
 	Usage:        "specify a configuration file (for root or unprivileged installation only)",
 	EnvKeys:      []string{"CONFIG_FILE"},
+}
+
+// --build-config
+var singBuildConfigFlag = cmdline.Flag{
+	ID:           "singBuildConfigFlag",
+	Value:        &useBuildConfig,
+	DefaultValue: false,
+	Name:         "build-config",
+	Usage:        "use configuration needed for building containers",
 }
 
 func getCurrentUser() *user.User {
@@ -444,22 +454,29 @@ func persistentPreRun(*cobra.Command, []string) {
 	setSylogMessageLevel()
 	sylog.Debugf("Apptainer version: %s", buildcfg.PACKAGE_VERSION)
 
-	if os.Geteuid() != 0 && buildcfg.APPTAINER_SUID_INSTALL == 1 {
-		if configurationFile != singConfigFileFlag.DefaultValue {
-			sylog.Fatalf("--config requires to be root or an unprivileged installation")
+	var config *apptainerconf.File
+	var err error
+	if useBuildConfig {
+		sylog.Debugf("Using container build configuration")
+		config = apptainerconf.GetBuildConfig()
+	} else {
+		if os.Geteuid() != 0 && buildcfg.APPTAINER_SUID_INSTALL == 1 {
+			if configurationFile != singConfigFileFlag.DefaultValue {
+				sylog.Fatalf("--config requires to be root or an unprivileged installation")
+			}
 		}
-	}
 
-	oldconfdir := filepath.Dir(filepath.Dir(configurationFile)) + "/singularity/"
+		oldconfdir := filepath.Dir(filepath.Dir(configurationFile)) + "/singularity/"
 
-	if _, err := os.Stat(oldconfdir); err == nil {
-		sylog.Warningf("%s exists, migration to apptainer by system administrator is not complete", oldconfdir)
-	}
+		if _, err := os.Stat(oldconfdir); err == nil {
+			sylog.Warningf("%s exists, migration to apptainer by system administrator is not complete", oldconfdir)
+		}
 
-	sylog.Debugf("Parsing configuration file %s", configurationFile)
-	config, err := apptainerconf.Parse(configurationFile)
-	if err != nil {
-		sylog.Fatalf("Couldn't parse configuration file %s: %s", configurationFile, err)
+		sylog.Debugf("Parsing configuration file %s", configurationFile)
+		config, err = apptainerconf.Parse(configurationFile)
+		if err != nil {
+			sylog.Fatalf("Couldn't parse configuration file %s: %s", configurationFile, err)
+		}
 	}
 	apptainerconf.SetCurrentConfig(config)
 	// Include the user's PATH for now.
@@ -510,6 +527,7 @@ func Init(loadPlugins bool) {
 	cmdManager.RegisterFlagForCmd(&singQuietFlag, apptainerCmd)
 	cmdManager.RegisterFlagForCmd(&singVerboseFlag, apptainerCmd)
 	cmdManager.RegisterFlagForCmd(&singConfigFileFlag, apptainerCmd)
+	cmdManager.RegisterFlagForCmd(&singBuildConfigFlag, apptainerCmd)
 
 	cmdManager.RegisterCmd(VersionCmd)
 

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -458,7 +458,12 @@ func persistentPreRun(*cobra.Command, []string) {
 	var err error
 	if useBuildConfig {
 		sylog.Debugf("Using container build configuration")
-		config = apptainerconf.GetBuildConfig()
+		// Base this on a default configuration.
+		config, err = apptainerconf.Parse("")
+		if err != nil {
+			sylog.Fatalf("Failure getting default config: %v", err)
+		}
+		apptainerconf.ApplyBuildConfig(config)
 	} else {
 		if os.Geteuid() != 0 && buildcfg.APPTAINER_SUID_INSTALL == 1 {
 			if configurationFile != singConfigFileFlag.DefaultValue {

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -53,10 +53,6 @@ func (s *stage) Assemble(path string) error {
 // runSectionScript executes the stage's pre and setup scripts on host.
 func (s *stage) runSectionScript(name string, script types.Script) error {
 	if s.b.RunSection(name) && script.Script != "" {
-		if syscall.Getuid() != 0 {
-			return fmt.Errorf("internal error -- uid does not appear to be root for build section %v", name)
-		}
-
 		aRootfs := "APPTAINER_ROOTFS=" + s.b.RootfsPath
 		sRootfs := "SINGULARITY_ROOTFS=" + s.b.RootfsPath
 
@@ -86,9 +82,9 @@ func (s *stage) runSectionScript(name string, script types.Script) error {
 	return nil
 }
 
-func (s *stage) runPostScript(configFile, sessionResolv, sessionHosts string) error {
+func (s *stage) runPostScript(sessionResolv, sessionHosts string) error {
 	if s.b.Recipe.BuildData.Post.Script != "" {
-		cmdArgs := []string{"-s", "-c", configFile, "exec", "--pwd", "/", "--writable"}
+		cmdArgs := []string{"-s", "--build-config", "exec", "--pwd", "/", "--writable"}
 		cmdArgs = append(cmdArgs, "--cleanenv", "--env", aEnvironment, "--env", sEnvironment, "--env", aLabels, "--env", sLabels)
 
 		if sessionResolv != "" {
@@ -150,9 +146,9 @@ func (s *stage) runPostScript(configFile, sessionResolv, sessionHosts string) er
 	return nil
 }
 
-func (s *stage) runTestScript(configFile, sessionResolv, sessionHosts string) error {
+func (s *stage) runTestScript(sessionResolv, sessionHosts string) error {
 	if !s.b.Opts.NoTest && s.b.Recipe.BuildData.Test.Script != "" {
-		cmdArgs := []string{"-s", "-c", configFile, "test", "--pwd", "/"}
+		cmdArgs := []string{"-s", "--build-config", "test", "--pwd", "/"}
 
 		if sessionResolv != "" {
 			cmdArgs = append(cmdArgs, "-B", sessionResolv+":/etc/resolv.conf")

--- a/internal/pkg/runtime/engine/apptainer/engine_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/engine_linux.go
@@ -33,9 +33,13 @@ func (e *EngineOperations) InitConfig(cfg *config.Common, privStageOne bool) {
 	if privStageOne {
 		// override the contents of File for security reasons
 		var err error
-		e.EngineConfig.File, err = apptainerconf.Parse(buildcfg.APPTAINER_CONF_FILE)
-		if err != nil {
-			sylog.Fatalf("unable to parse apptainer.conf file: %s", err)
+		if e.EngineConfig.GetUseBuildConfig() {
+			e.EngineConfig.File = apptainerconf.GetBuildConfig()
+		} else {
+			e.EngineConfig.File, err = apptainerconf.Parse(buildcfg.APPTAINER_CONF_FILE)
+			if err != nil {
+				sylog.Fatalf("unable to parse apptainer.conf file: %s", err)
+			}
 		}
 		apptainerconf.SetCurrentConfig(e.EngineConfig.File)
 		apptainerconf.SetBinaryPath(false)

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -101,6 +101,7 @@ type JSONConfig struct {
 	Cwd                   string            `json:"cwd,omitempty"`
 	SessionLayer          string            `json:"sessionLayer,omitempty"`
 	ConfigurationFile     string            `json:"configurationFile,omitempty"`
+	UseBuildConfig        bool              `json:"useBuildConfig,omitempty"`
 	EncryptionKey         []byte            `json:"encryptionKey,omitempty"`
 	TargetUID             int               `json:"targetUID,omitempty"`
 	WritableImage         bool              `json:"writableImage,omitempty"`
@@ -797,6 +798,16 @@ func (e *EngineConfig) SetConfigurationFile(filename string) {
 // GetConfigurationFile returns the apptainer configuration file to use.
 func (e *EngineConfig) GetConfigurationFile() string {
 	return e.JSON.ConfigurationFile
+}
+
+// SetUseBuildConfig defines whether to use the build configuration or not.
+func (e *EngineConfig) SetUseBuildConfig(useBuildConfig bool) {
+	e.JSON.UseBuildConfig = useBuildConfig
+}
+
+// GetUseBuildConfig returns if the build configuration should be used or not.
+func (e *EngineConfig) GetUseBuildConfig() bool {
+	return e.JSON.UseBuildConfig
 }
 
 // SetRestoreUmask returns whether to restore Umask for the container launched process.

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -31,6 +31,20 @@ func GetCurrentConfig() *File {
 	return currentConfig
 }
 
+// GetBuildConfig returns the configuration to be used for building containers
+func GetBuildConfig() *File {
+	// Use default configuration except without default binds
+	config, err := Parse("")
+	if err != nil {
+		sylog.Fatalf("failure getting default config: %v", err)
+	}
+	config.BindPath = nil
+	config.ConfigResolvConf = false
+	config.MountHome = false
+	config.MountDevPts = false
+	return config
+}
+
 // SetBinaryPath sets the value of the binary path, substituting the
 // user's $PATH plus ":" for "$PATH:" in BinaryPath if subPath is true.
 func SetBinaryPath(subPath bool) {
@@ -420,7 +434,6 @@ memory fs type = {{ .MemoryFSType }}
 # DEFAULT: Undefined
 # DEPRECATED
 # Path to the ldconfig executable, used to find GPU libraries.
-# Must be set to use --nv / --nvccli.
 # When run as root, executable must be owned by root for security reasons.
 # If not set, Apptainer will search the directories set in binary path.
 # ldconfig path =
@@ -454,7 +467,6 @@ mksquashfs procs = {{ .MksquashfsProcs }}
 # DEFAULT: Undefined
 # DEPRECATED
 # Path to the nvidia-container-cli executable, used to find GPU libraries.
-# Must be set to use --nvccli.
 # When run as root, executable must be owned by root for security reasons
 # If not set, Apptainer will search the directories set in binary path.
 # nvidia-container-cli path =

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -32,17 +32,12 @@ func GetCurrentConfig() *File {
 }
 
 // GetBuildConfig returns the configuration to be used for building containers
-func GetBuildConfig() *File {
-	// Use default configuration except without default binds
-	config, err := Parse("")
-	if err != nil {
-		sylog.Fatalf("failure getting default config: %v", err)
-	}
+func ApplyBuildConfig(config *File) {
+	// Remove default binds when doing builds
 	config.BindPath = nil
 	config.ConfigResolvConf = false
 	config.MountHome = false
 	config.MountDevPts = false
-	return config
 }
 
 // SetBinaryPath sets the value of the binary path, substituting the


### PR DESCRIPTION
This adds to #475 to also allow unprivileged container builds even when unprivileged user namespaces is not available.

Inspired by a discussion in #215.