### PR TITLE
Fix: #502 - Store the URI scheme in the remote config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   setuid mode.  Does not work with a SIF partition because it requires
   privileges to mount that as an ext3 image.
 - Enabled unprivileged users to build containers without the `--fakeroot`
-  option.  Requires the fakeroot command.  
+  option.  Requires the fakeroot command.
   This is simpler to administer than the `--fakeroot` option because
   there is no need for maintaining /etc/subuid and /etc/subgid mappings.
   On the other hand, it isn't as complete an emulation and may fail under
-  some circumstances.  
+  some circumstances.
   The %post scriptlet is run with fakeroot, which is needed to allow
   package installation scripts to think they were run as root.
   Works better with unprivileged user namespaces because then everything
@@ -65,6 +65,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
     source. *Applies to newly built containers only, use `apptainer inspect`
     to check version that container was built with*.
 - Added `--no-eval` to the list of flags set by the OCI/Docker `--compat` mode.
+- Remotes can now be added with http URLs. In this case all communication with
+  the remote will use http as well. The `--no-https` option for pull/exec/...
+  is no longer necessary in this case.
 
 ### New features / functionalities
 

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -832,5 +832,9 @@ func getLibraryClientConfig(uri string) (*libClient.Config, error) {
 }
 
 func URI() string {
-	return "https://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
+    if len(currentRemoteEndpoint.Scheme) > 0 {
+	    return currentRemoteEndpoint.Scheme + "://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
+    } else {
+        return "https://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
+    }
 }

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -832,9 +832,9 @@ func getLibraryClientConfig(uri string) (*libClient.Config, error) {
 }
 
 func URI() string {
-    if len(currentRemoteEndpoint.Scheme) > 0 {
-	    return currentRemoteEndpoint.Scheme + "://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
-    } else {
-        return "https://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
-    }
+	if len(currentRemoteEndpoint.Scheme) > 0 {
+		return currentRemoteEndpoint.Scheme + "://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
+	} else {
+		return "https://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
+	}
 }

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -834,7 +834,6 @@ func getLibraryClientConfig(uri string) (*libClient.Config, error) {
 func URI() string {
 	if len(currentRemoteEndpoint.Scheme) > 0 {
 		return currentRemoteEndpoint.Scheme + "://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
-	} else {
-		return "https://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
 	}
+    return "https://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
 }

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -44,6 +44,7 @@ func (c ctx) remoteAdd(t *testing.T) {
 	}{
 		{"AddCloud", "cloud", "cloud.sylabs.io"},
 		{"AddOtherCloud", "other", "cloud.sylabs.io"},
+		{"LocalHTTPCloud", "localhttp", "http://localhost"},
 	}
 
 	for _, tt := range testPass {
@@ -100,6 +101,7 @@ func (c ctx) remoteRemove(t *testing.T) {
 	}{
 		{"addCloud", "cloud", "cloud.sylabs.io"},
 		{"addOther", "other", "cloud.sylabs.io"},
+		{"LocalHTTPCloud", "localhttp", "http://localhost"},
 	}
 
 	for _, tt := range add {
@@ -120,6 +122,7 @@ func (c ctx) remoteRemove(t *testing.T) {
 	}{
 		{"RemoveCloud", "cloud"},
 		{"RemoveOther", "other"},
+		{"removeLocalHTTP", "localhttp"},
 	}
 
 	for _, tt := range testPass {
@@ -192,6 +195,7 @@ func (c ctx) remoteUse(t *testing.T) {
 	}{
 		{"addCloud", "cloud", "cloud.sylabs.io"},
 		{"addOther", "other", "cloud.sylabs.io"},
+		{"LocalHTTPCloud", "localhttp", "http://localhost"},
 	}
 
 	for _, tt := range add {
@@ -212,6 +216,7 @@ func (c ctx) remoteUse(t *testing.T) {
 	}{
 		{"UseFromNothingToRemote", "cloud"},
 		{"UseFromRemoteToRemote", "other"},
+		{"UseFromLocalHTTP", "localhttp"},
 	}
 
 	for _, tt := range testPass {

--- a/internal/app/apptainer/remote_add.go
+++ b/internal/app/apptainer/remote_add.go
@@ -54,7 +54,7 @@ func RemoteAdd(configFile, name, uri string, global bool) (err error) {
 	if err != nil {
 		return err
 	}
-    e := endpoint.Config{URI: path.Join(u.Host + u.Path), Scheme: u.Scheme, System: global}
+	e := endpoint.Config{URI: path.Join(u.Host + u.Path), Scheme: u.Scheme, System: global}
 
 	if err := c.Add(name, &e); err != nil {
 		return err

--- a/internal/app/apptainer/remote_add.go
+++ b/internal/app/apptainer/remote_add.go
@@ -54,7 +54,7 @@ func RemoteAdd(configFile, name, uri string, global bool) (err error) {
 	if err != nil {
 		return err
 	}
-	e := endpoint.Config{URI: path.Join(u.Host + u.Path), System: global}
+    e := endpoint.Config{URI: path.Join(u.Host + u.Path), Scheme: u.Scheme, System: global}
 
 	if err := c.Add(name, &e); err != nil {
 		return err

--- a/internal/app/apptainer/remote_login.go
+++ b/internal/app/apptainer/remote_login.go
@@ -128,12 +128,12 @@ func endPointLogin(ep *endpoint.Config, args *LoginArgs) error {
 			}
 		}
 
-        var epScheme string
-        if len(ep.Scheme) > 0 {
-            epScheme = ep.Scheme
-        } else {
-            epScheme = "https"
-        }
+		var epScheme string
+		if len(ep.Scheme) > 0 {
+			epScheme = ep.Scheme
+		} else {
+			epScheme = "https"
+		}
 
 		fmt.Printf("Generate an access token at %s://%s/auth/tokens, and paste it here.\n", epScheme, ep.URI)
 		fmt.Println("Token entered will be hidden for security.")

--- a/internal/app/apptainer/remote_login.go
+++ b/internal/app/apptainer/remote_login.go
@@ -128,7 +128,14 @@ func endPointLogin(ep *endpoint.Config, args *LoginArgs) error {
 			}
 		}
 
-		fmt.Printf("Generate an access token at https://%s/auth/tokens, and paste it here.\n", ep.URI)
+        var epScheme string
+        if len(ep.Scheme) > 0 {
+            epScheme = ep.Scheme
+        } else {
+            epScheme = "https"
+        }
+
+		fmt.Printf("Generate an access token at %s://%s/auth/tokens, and paste it here.\n", epScheme, ep.URI)
 		fmt.Println("Token entered will be hidden for security.")
 		token, err = interactive.AskQuestionNoEcho("Access Token: ")
 		if err != nil {

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -33,6 +33,7 @@ var DefaultEndpointConfig = &Config{
 type Config struct {
 	URI        string           `yaml:"URI,omitempty"`
 	Token      string           `yaml:"Token,omitempty"`
+    Scheme     string           `yaml:"Scheme,omitempty"`
 	System     bool             `yaml:"System"`    // Was this EndPoint set from system config file
 	Exclusive  bool             `yaml:"Exclusive"` // true if the endpoint must be used exclusively
 	Keyservers []*ServiceConfig `yaml:"Keyservers,omitempty"`

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -33,7 +33,7 @@ var DefaultEndpointConfig = &Config{
 type Config struct {
 	URI        string           `yaml:"URI,omitempty"`
 	Token      string           `yaml:"Token,omitempty"`
-    Scheme     string           `yaml:"Scheme,omitempty"`
+	Scheme     string           `yaml:"Scheme,omitempty"`
 	System     bool             `yaml:"System"`    // Was this EndPoint set from system config file
 	Exclusive  bool             `yaml:"Exclusive"` // true if the endpoint must be used exclusively
 	Keyservers []*ServiceConfig `yaml:"Keyservers,omitempty"`

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -123,9 +123,16 @@ func (config *Config) GetAllServices() (map[string][]Service, error) {
 		Timeout: defaultTimeout,
 	}
 
-	url := "https://" + config.URI + "/assets/config/config.prod.json"
+    // Add the Scheme to the URL if exists
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+    var url string
+    if len(config.Scheme) > 0 {
+        url = config.Scheme + "://" + config.URI + "/assets/config/config.prod.json"
+    } else {
+        url = "https://" + config.URI + "/assets/config/config.prod.json"
+    }
+
+    req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -123,16 +123,16 @@ func (config *Config) GetAllServices() (map[string][]Service, error) {
 		Timeout: defaultTimeout,
 	}
 
-    // Add the Scheme to the URL if exists
+	// Add the Scheme to the URL if exists
 
-    var url string
-    if len(config.Scheme) > 0 {
-        url = config.Scheme + "://" + config.URI + "/assets/config/config.prod.json"
-    } else {
-        url = "https://" + config.URI + "/assets/config/config.prod.json"
-    }
+	var url string
+	if len(config.Scheme) > 0 {
+		url = config.Scheme + "://" + config.URI + "/assets/config/config.prod.json"
+	} else {
+		url = "https://" + config.URI + "/assets/config/config.prod.json"
+	}
 
-    req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The remotes are stored without the scheme in the configuration.
Due to some hard coded https string, this prevents using insecure
registries. The patch enables storing the scheme as additional value
in the configuration. If the scheme is not present, https is used
as before.

## Description of the Pull Request (PR):

The PR closes the bug #502 by storing the scheme in addition to the URI. This enables using local registries without https access. 


### This fixes or addresses the following GitHub issues:

 - Fixes #502 


