### PR TITLE
[Enhancement/Feature] Add masked paths to mounted home

### DIFF
--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -170,6 +170,7 @@ var internalOptions = []string{"loop", "offset", "sizelimit", "key", "skip-on-er
 type Point struct {
 	specs.Mount
 	InternalOptions []string `json:"internalOptions"`
+    MaskedPaths []string `json:"maskedPaths"`
 }
 
 // Points defines and stores a set of mount points by tag


### PR DESCRIPTION
Signed-off-by: Jason Yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

### Motivation:
When end-users create multiple containers (especially based on the same container image) and mount the very same host home directory into them, there exist chances that programs running inside those multiple containers will try writing/reading to/from the same configurations exist in the mounted home directory, which will cause potential conflicts, because there are no separated copies of these configurations. Besides, using `--no-home`  bind won't resolve this issue if multiple containers have to/need to access to the host home directory. So the dilemma is that:
1. containers need to mount the host home directory
2. containers need to hide(mask) some dirs/files from mounted host home directory and create their own dirs/files if needed

As shown in this figure:
![maskedpaths](https://user-images.githubusercontent.com/2051711/174694701-8c1d4fe9-8a85-4fe3-bdb2-0cab76bb56a3.png)

similar feature (not that similar):
runc provides `maskedPaths` option (mask paths and make it unreadable inside container)
```
// For files, maskPath bind mounts /dev/null over the top of the specified path.
// For directories, maskPath mounts read-only tmpfs over the top of the specified path.
```
https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#masked-paths 
https://github.com/opencontainers/runc/blob/8b9452f75cbc5159a76de4e75848185ab58d3365/libcontainer/rootfs_linux.go#L1020 

### Potential Implementaitons:
1. calling `addHomeStagingDir` and `addHomeMount` as usual to add the host home directory into the mount point list
```
DEBUG   [U=1000,P=18897]   addHomeStagingDir()           Staging home directory (/home/jason) at /usr/local/var/apptainer/mnt/session/home/jason
DEBUG   [U=1000,P=18897]   addHomeMount()                Adding home directory mount [/usr/local/var/apptainer/mnt/session/home/jason:/home/jason] to list using layer: underlay
```
2. when calling `mountGeneric`, after mounting the target mount point, we need to check additional field `MaskedPaths` in the Point struct and apply necessary mask ops if there exist any value in `MaskedPaths`
https://github.com/JasonYangShadow/apptainer/blob/7add3046f12227d1d94a5401a8a6588cbfce4dd2/internal/pkg/runtime/engine/apptainer/container_linux.go#L568
```
DEBUG   [U=1000,P=18897]   mountGeneric()                Mounting /home/jason to /usr/local/var/apptainer/mnt/session/home/jason
``` 
3. For mask ops
For both files/dirs, we need to create whiteout file in the upper layer to hide any target files/dirs existing in any lower layer. 

Issues we need to discuss and investigate:
1. Where do we save the `whiteout files`?
2. For newly created files/dirs inside container (sharing the same names with masked dirs/files), where we save the data? and how to remount the saved data between different runs?

### Others:
1. Do we need this feature/enhancement? 
> This feature/enhancement is directly raised from my lab member, when they use the https://software.broadinstitute.org/software/igv/ . They complained that this app will write/read the configuration from one fixed location, when they have multiple instance (in the host and containers) they need to rename existing configuration for backup to avoid conflicts.
2. Is it achievable?
> only supports overlayfs-style system (https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html#whiteouts-and-opaque-directories), not sure about the detailed implementation yet, need to do further verification.
3. How to pass `MaskedPaths` value into apptainer
> (CLI, json file (.gitignore), env variable) 

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
