### PR TITLE
Port SingularityCE PR #245 to Apptainer with addons. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,9 +82,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   resource limits to a container directly.
 - `remote add --insecure` may be used to configure endpoints that are only
   accessible via http. Alternatively the environment variable
-  `APPTAINER_REMOTE_ADD_INSECURE` can be set to true to allow http remotes to be
+  `APPTAINER_ADD_INSECURE` can be set to true to allow http remotes to be
   added wihtout the `--insecure` flag. Specifying https in the remote URI
-  overrules both `--insecure` and `APPTAINER_REMOTE_ADD_INSECURE`.
+  overrules both `--insecure` and `APPTAINER_ADD_INSECURE`.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   setuid mode.  Does not work with a SIF partition because it requires
   privileges to mount that as an ext3 image.
 - Enabled unprivileged users to build containers without the `--fakeroot`
-  option.  Requires the fakeroot command.  
+  option.  Requires the fakeroot command.
   This is simpler to administer than the `--fakeroot` option because
   there is no need for maintaining /etc/subuid and /etc/subgid mappings.
   On the other hand, it isn't as complete an emulation and may fail under
-  some circumstances.  
+  some circumstances.
   The %post scriptlet is run with fakeroot, which is needed to allow
   package installation scripts to think they were run as root.
   Works better with unprivileged user namespaces because then everything
@@ -80,6 +80,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Add instance stats command.
 - Added `--cpu*`, `--blkio*`, `--memory*`, `--pids-limit` flags to apply cgroups
   resource limits to a container directly.
+- `remote add --insecure` may be used to configure endpoints that are only
+  accessible via http. Alternatively the environment variable
+  `APPTAINER_REMOTE_ADD_INSECURE` can be set to true to allow http remotes to be
+  added wihtout the `--insecure` flag. Specifying https in the remote URI
+  overrules both `--insecure` and `APPTAINER_REMOTE_ADD_INSECURE`.
 
 ### Bug fixes
 

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -113,6 +113,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/docker/libtrust/blob/master/LICENSE>
 
+## github.com/gosimple/unidecode
+
+**License:** Apache-2.0
+
+**License URL:** <https://github.com/gosimple/unidecode/blob/master/LICENSE>
+
 ## github.com/klauspost/compress
 
 **License:** Apache-2.0
@@ -688,6 +694,12 @@ The dependencies and their licenses are as follows:
 **License:** MIT
 
 **Project URL:** <https://go.mozilla.org/pkcs7>
+
+## github.com/gosimple/slug
+
+**License:** MPL-2.0
+
+**License URL:** <https://github.com/gosimple/slug/blob/master/LICENSE>
 
 ## github.com/hashicorp/errwrap
 

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -830,7 +830,3 @@ func getLibraryClientConfig(uri string) (*libClient.Config, error) {
 	}
 	return libClientConfig, nil
 }
-
-func URI() string {
-	return "https://" + strings.TrimSuffix(currentRemoteEndpoint.URI, "/")
-}

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -106,13 +106,17 @@ var PushCmd = &cobra.Command{
 			if err != nil {
 				sylog.Fatalf("Unable to get keyserver client configuration: %v", err)
 			}
+			feURL, err := currentRemoteEndpoint.GetURL()
+			if err != nil {
+				sylog.Fatalf("Unable to find remote web URI %v", err)
+			}
 
 			pushSpec := apptainer.LibraryPushSpec{
 				SourceFile:    file,
 				DestRef:       dest,
 				Description:   pushDescription,
 				AllowUnsigned: unsignedPush,
-				FrontendURI:   URI(),
+				FrontendURI:   feURL,
 			}
 
 			err = apptainer.LibraryPush(cmd.Context(), pushSpec, lc, co)

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -163,7 +163,8 @@ var remoteAddInsecureFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "insecure",
 	ShortHand:    "i",
-	Usage:        "allow connection to an insecure http remote; alternatively set the environment variable APPTAINER_REMOTE_ADD_INSECURE to true",
+	Usage:        "allow connection to an insecure http remote.",
+	EnvKeys:      []string{"ADD_INSECURE"},
 }
 
 func init() {
@@ -246,16 +247,13 @@ var RemoteAddCmd = &cobra.Command{
 
 		// Implicitly set --insecure if APPTAINER_REMOTE_ADD_INSECURE is true
 		localInsecure := remoteAddInsecure
-		insecureEnv := os.Getenv("APPTAINER_REMOTE_ADD_INSECURE")
-		if insecureEnv == "1" || strings.EqualFold(insecureEnv, "true") {
-			localInsecure = true
-		}
 		if strings.HasPrefix(uri, "https://") {
+			sylog.Infof("adding an https remote ignores `--insecure`.")
 			localInsecure = false
 		}
 
 		if strings.HasPrefix(uri, "http://") && !localInsecure {
-			sylog.Fatalf("Add http URI without specifying --insecure or setting APPTAINER_REMOTE_ADD_INSECURE to true.")
+			sylog.Fatalf("Add http URI without specifying --insecure or setting APPTAINER_ADD_INSECURE to true.")
 		}
 
 		if err := apptainer.RemoteAdd(remoteConfig, name, uri, global, localInsecure); err != nil {

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -245,7 +245,6 @@ var RemoteAddCmd = &cobra.Command{
 
 		uri := args[1]
 
-		// Implicitly set --insecure if APPTAINER_REMOTE_ADD_INSECURE is true
 		localInsecure := remoteAddInsecure
 		if strings.HasPrefix(uri, "https://") {
 			sylog.Infof("adding an https remote ignores `--insecure`.")

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -247,12 +247,12 @@ var RemoteAddCmd = &cobra.Command{
 
 		localInsecure := remoteAddInsecure
 		if strings.HasPrefix(uri, "https://") {
-			sylog.Infof("adding an https remote ignores `--insecure`.")
+			sylog.Infof("--insecure ignored for https remote")
 			localInsecure = false
 		}
 
 		if strings.HasPrefix(uri, "http://") && !localInsecure {
-			sylog.Fatalf("Add http URI without specifying --insecure or setting APPTAINER_ADD_INSECURE to true.")
+			sylog.Fatalf("http URI requires --insecure or APPTAINER_ADD_INSECURE=true")
 		}
 
 		if err := apptainer.RemoteAdd(remoteConfig, name, uri, global, localInsecure); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-log/log v0.2.0
 	github.com/google/uuid v1.3.0
+	github.com/gosimple/slug v1.10.0
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/moby/sys/mount v0.3.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0
@@ -93,6 +94,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gosimple/unidecode v1.0.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -615,6 +615,10 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosimple/slug v1.10.0 h1:3XbiQua1IpCdrvuntWvGBxVm+K99wCSxJjlxkP49GGQ=
+github.com/gosimple/slug v1.10.0/go.mod h1:MICb3w495l9KNdZm+Xn5b6T2Hn831f9DMxiJ1r+bAjw=
+github.com/gosimple/unidecode v1.0.0 h1:kPdvM+qy0tnk4/BrnkrbdJ82xe88xn7c9hcaipDz4dQ=
+github.com/gosimple/unidecode v1.0.0/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/internal/app/apptainer/remote_add.go
+++ b/internal/app/apptainer/remote_add.go
@@ -22,7 +22,7 @@ import (
 )
 
 // RemoteAdd adds remote to configuration
-func RemoteAdd(configFile, name, uri string, global bool) (err error) {
+func RemoteAdd(configFile, name, uri string, global bool, insecure bool) (err error) {
 	// Explicit handling of corner cases: name and uri must be valid strings
 	if strings.TrimSpace(name) == "" {
 		return fmt.Errorf("invalid name: cannot have empty name")
@@ -54,7 +54,7 @@ func RemoteAdd(configFile, name, uri string, global bool) (err error) {
 	if err != nil {
 		return err
 	}
-	e := endpoint.Config{URI: path.Join(u.Host + u.Path), System: global}
+	e := endpoint.Config{URI: path.Join(u.Host + u.Path), System: global, Insecure: insecure}
 
 	if err := c.Add(name, &e); err != nil {
 		return err

--- a/internal/app/apptainer/remote_add_test.go
+++ b/internal/app/apptainer/remote_add_test.go
@@ -109,6 +109,7 @@ func TestRemoteAdd(t *testing.T) {
 		remoteName string
 		uri        string
 		global     bool
+		insecure   bool
 		shallPass  bool
 	}{
 		{
@@ -346,6 +347,15 @@ func TestRemoteAdd(t *testing.T) {
 			global:     false,
 			shallPass:  true,
 		},
+		{
+			name:       "30: valid config file; valid remote name; valid URI; local; insecure",
+			cfgfile:    validCfgFile,
+			remoteName: validRemoteName,
+			uri:        validURI,
+			global:     false,
+			insecure:   true,
+			shallPass:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -371,7 +381,7 @@ func TestRemoteAdd(t *testing.T) {
 				remote.SystemConfigPath = tt.cfgfile
 			}
 
-			err := RemoteAdd(tt.cfgfile, tt.remoteName, tt.uri, tt.global)
+			err := RemoteAdd(tt.cfgfile, tt.remoteName, tt.uri, tt.global, tt.insecure)
 			if tt.shallPass == true && err != nil {
 				restoreSysConfig()
 				t.Fatalf("valid case failed: %s\n", err)

--- a/internal/app/apptainer/remote_list.go
+++ b/internal/app/apptainer/remote_list.go
@@ -19,7 +19,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/remote"
 )
 
-const listLine = "%s\t%s\t%s\t%s\t%s\n"
+const listLine = "%s\t%s\t%s\t%s\t%s\t%s\n"
 
 // RemoteList prints information about remote configurations
 func RemoteList(usrConfigFile string) (err error) {
@@ -68,7 +68,7 @@ func RemoteList(usrConfigFile string) (err error) {
 	fmt.Println()
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, listLine, "NAME", "URI", "ACTIVE", "GLOBAL", "EXCLUSIVE")
+	fmt.Fprintf(tw, listLine, "NAME", "URI", "ACTIVE", "GLOBAL", "EXCLUSIVE", "INSECURE")
 	for _, n := range names {
 		sys := "NO"
 		if c.Remotes[n].System {
@@ -78,11 +78,16 @@ func RemoteList(usrConfigFile string) (err error) {
 		if c.Remotes[n].Exclusive {
 			excl = "YES"
 		}
+		insec := "NO"
+		if c.Remotes[n].Insecure {
+			insec = "YES"
+		}
+
 		active := "NO"
 		if c.DefaultRemote != "" && c.DefaultRemote == n {
 			active = "YES"
 		}
-		fmt.Fprintf(tw, listLine, n, c.Remotes[n].URI, active, sys, excl)
+		fmt.Fprintf(tw, listLine, n, c.Remotes[n].URI, active, sys, excl, insec)
 	}
 	tw.Flush()
 

--- a/internal/app/apptainer/remote_login.go
+++ b/internal/app/apptainer/remote_login.go
@@ -128,7 +128,13 @@ func endPointLogin(ep *endpoint.Config, args *LoginArgs) error {
 			}
 		}
 
-		fmt.Printf("Generate an access token at https://%s/auth/tokens, and paste it here.\n", ep.URI)
+		webURL, err := ep.GetURL()
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Generate an access token at %s/auth/tokens, and paste it here.\n", webURL)
+
 		fmt.Println("Token entered will be hidden for security.")
 		token, err = interactive.AskQuestionNoEcho("Access Token: ")
 		if err != nil {

--- a/internal/app/apptainer/remote_remove_test.go
+++ b/internal/app/apptainer/remote_remove_test.go
@@ -52,7 +52,7 @@ func TestRemoteRemove(t *testing.T) {
 	}
 
 	// Add remotes based on our config file
-	err := RemoteAdd(validCfgFile, "cloud_testing", "cloud.random.io", false)
+	err := RemoteAdd(validCfgFile, "cloud_testing", "cloud.random.io", false, false)
 	if err != nil {
 		t.Fatalf("cannot add remote \"cloud\" for testing: %s\n", err)
 	}

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -11,14 +11,17 @@
 package endpoint
 
 import (
+	"errors"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/apptainer/apptainer/internal/pkg/remote/credential"
 	"github.com/apptainer/apptainer/pkg/syfs"
+	"github.com/gosimple/slug"
 )
 
 var cacheDuration = 720 * time.Hour
@@ -29,12 +32,15 @@ var DefaultEndpointConfig = &Config{
 	System: true,
 }
 
+var ErrNoURI = errors.New("no URI set for endpoint")
+
 // Config describes a single remote endpoint.
 type Config struct {
-	URI        string           `yaml:"URI,omitempty"`
+	URI        string           `yaml:"URI,omitempty"` // hostname/path - no protocol expected
 	Token      string           `yaml:"Token,omitempty"`
-	System     bool             `yaml:"System"`    // Was this EndPoint set from system config file
-	Exclusive  bool             `yaml:"Exclusive"` // true if the endpoint must be used exclusively
+	System     bool             `yaml:"System"`             // Was this EndPoint set from system config file
+	Exclusive  bool             `yaml:"Exclusive"`          // true if the endpoint must be used exclusively
+	Insecure   bool             `yaml:"Insecure,omitempty"` // Allow use of http for service discovery
 	Keyservers []*ServiceConfig `yaml:"Keyservers,omitempty"`
 
 	// for internal purpose
@@ -44,6 +50,27 @@ type Config struct {
 
 func (config *Config) SetCredentials(creds []*credential.Config) {
 	config.credentials = creds
+}
+
+// GetUrl returns a URL with the correct https or http protocol for the endpoint.
+// The protocol depends on whether the endpoint is set 'Insecure'.
+func (config *Config) GetURL() (string, error) {
+	if config.URI == "" {
+		return "", ErrNoURI
+	}
+
+	u, err := url.Parse(config.URI)
+	if err != nil {
+		return "", err
+	}
+
+	if config.Insecure {
+		u.Scheme = "http"
+	} else {
+		u.Scheme = "https"
+	}
+
+	return u.String(), nil
 }
 
 type ServiceConfig struct {
@@ -71,7 +98,9 @@ func getCachedConfig(uri string) io.ReadCloser {
 	if dir == "" {
 		return nil
 	}
-	config := filepath.Join(dir, uri+".json")
+	uriSlug := slug.Make(uri)
+	config := filepath.Join(dir, uriSlug+".json")
+
 	fi, err := os.Stat(config)
 	if err != nil {
 		return nil

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -206,7 +206,7 @@ func (config *Config) GetServiceURI(service string) (string, error) {
 		}
 	}
 
-    services, err := config.GetAllServices()
+	services, err := config.GetAllServices()
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -123,16 +123,20 @@ func (config *Config) GetAllServices() (map[string][]Service, error) {
 		Timeout: defaultTimeout,
 	}
 
-	url := "https://" + config.URI + "/assets/config/config.prod.json"
+	epURL, err := config.GetURL()
+	if err != nil {
+		return nil, err
+	}
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	configURL := epURL + "/assets/config/config.prod.json"
+	req, err := http.NewRequest(http.MethodGet, configURL, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("User-Agent", useragent.Value())
 
-	cacheReader := getCachedConfig(config.URI)
+	cacheReader := getCachedConfig(epURL)
 	reader := cacheReader
 
 	if cacheReader == nil {
@@ -158,7 +162,7 @@ func (config *Config) GetAllServices() (map[string][]Service, error) {
 	}
 
 	if reader != cacheReader {
-		updateCachedConfig(config.URI, b)
+		updateCachedConfig(epURL, b)
 	}
 
 	for k, v := range a {
@@ -202,7 +206,7 @@ func (config *Config) GetServiceURI(service string) (string, error) {
 		}
 	}
 
-	services, err := config.GetAllServices()
+    services, err := config.GetAllServices()
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
@@ -1006,6 +1007,59 @@ func TestSetDefaultRemote(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if err := test.old.SetDefault(test.id, false); err == nil {
 				t.Error("unexpected success setting default remote")
+			}
+		})
+	}
+}
+
+func TestGetURL(t *testing.T) {
+	tests := []remoteTest{
+		{
+			name: "get uri https",
+			old: Config{
+				DefaultRemote: "cloud",
+				Remotes: map[string]*endpoint.Config{
+					"cloud": {
+						URI: "cloud.example.com",
+					},
+				},
+			},
+			id: "cloud",
+		},
+		{
+			name: "get uri http",
+			old: Config{
+				DefaultRemote: "cloud",
+				Remotes: map[string]*endpoint.Config{
+					"cloud": {
+						URI:      "cloud.example.com",
+						Insecure: true,
+					},
+				},
+			},
+			id: "cloud",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var ep *endpoint.Config
+			ep, err := test.old.GetRemote(test.id)
+			if err != nil {
+				t.Fatal("failed to get endpoint from config")
+			}
+
+			u, err := ep.GetURL()
+			if err != nil {
+				t.Errorf("unexpected error from GetURL: %v", err)
+			}
+
+			if ep.Insecure && !strings.HasPrefix(u, "http://") {
+				t.Errorf("insecure GetURL scheme must be http, but found %s", u)
+			}
+
+			if !ep.Insecure && !strings.HasPrefix(u, "https://") {
+				t.Errorf("secure GetURL scheme must be https, but found %s", u)
 			}
 		})
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

*  Port SingularityCE PR [#245](https://github.com/sylabs/singularity/pull/245) to Apptainer
*  Add environment variable APPTAINER_REMOTE_ADD_INSECURE
    
    In order to allow "--insecure" to be missing in the command line,
    the APPTAINER_REMOTE_ADD_INSECURE environment variable allows to
    define this flag for all `remote add` operations with http remotes.
    If the remote URI starts with https, the `--insecure` and the
    `APPTAINER_REMOTE_ADD_INSECURE` are overruled.

Replaces PR #505 


### This fixes or addresses the following GitHub issues:

 - Fixes #502 


