### PR TITLE
feat: add environment APPTAINER_AUTH_FILE to change registry auth file

### DIFF
--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -81,6 +81,9 @@ func RemoteCacheDir() string {
 }
 
 func DockerConf() string {
+	if authFile := os.Getenv("APPTAINER_AUTH_FILE"); authFile != "" {
+		return authFile
+	}
 	return filepath.Join(ConfigDir(), DockerConfFile)
 }
 


### PR DESCRIPTION
Signed-off-by: Taizeng Wu wutaizeng@gmail.com

## Description of the Pull Request (PR):

In some scenarios we run Apptainer using a custom authentication file rather than changing the content of the authentication file in the default location.

So we need override the default path of the authentication file by setting the `APPTAINER_AUTH_FILE` which like podman `REGISTRY_AUTH_FILE` https://docs.podman.io/en/latest/markdown/podman-login.1.html#authfile-path


