### PR TITLE
Generalize the --fakeroot option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - When starting a container, if the user has specified the cwd by using
   the `--pwd` flag, in case of problem return error instead of defaulting to
   a different directory.
+- The warning about more than 50 bind mounts required for an underlay bind
+  has been changed to an info message.
 - `oci mount` sets `Process.Terminal: true` when creating an OCI `config.json`,
   so that `oci run` provides expected interactive behavior by default.
 - Default hostname for `oci mount` containers is now `apptainer` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,21 +29,40 @@ For older changes see the [archived Singularity change log](https://github.com/a
   setuid mode.
   Does not work with a SIF partition because that requires privileges to
   mount as an ext3 image.
-- Enabled unprivileged users to build containers without the `--fakeroot`
-  option.  Requires the fakeroot command.
-  This is simpler to administer than the `--fakeroot` option because
-  there is no need for maintaining /etc/subuid and /etc/subgid mappings.
-  On the other hand, it isn't as complete an emulation and may fail under
-  some circumstances.
-  The %post scriptlet is run with fakeroot, which is needed to allow
-  package installation scripts to think they were run as root.
-  Works better with unprivileged user namespaces because then everything
-  is also run in a root-mapped unprivileged user namespace, the
-  equivalent of `unshare -r`.  Without unprivileged user namespaces, the
-  `--fix-perms` option is implied to allow writing into directories.
+- Extended the `--fakeroot` option to be useful when `/etc/subuid` and
+  `/etc/subgid` mappings have not been set up.
+  If they have not been set up, a root-mapped unprivileged user namespace
+  (the equivalent of `unshare -r`) and/or the fakeroot command from the
+  host will be tried.
+  Together they emulate the mappings pretty well but they are simpler to
+  administer.
+  This feature is especially useful with the `--overlay` and
+  `--writable-tmpfs` options and for building containers unprivileged,
+  because they allow installing packages that assume they're running
+  as root.
+  The feature works nested inside of an apptainer container, where
+  another apptainer command will also be in the fakeroot environment
+  without requesting the `--fakeroot` option again, or it can be used
+  inside an apptainer container that was not started with `--fakeroot`.
+  However, the fakeroot command uses LD_PRELOAD and so needs to be bound
+  into the container which requires a compatible libc.
+  For that reason it doesn't work when the host and container operating
+  systems are of very different vintages.
+  If that's a problem and you want to use only an unprivileged
+  root-mapped namespace even when the fakeroot command is installed,
+  just run apptainer with `unshare -r`.
+- Made the `--fakeroot` option be implied when an unprivileged user
+  builds a container from a definition file.
+  When `/etc/subuid` and `/etc/subgid` mappings are not available,
+  all scriptlets are run in a root-mapped unprivileged namespace (when
+  possible) and the %post scriptlet is additionally run with the fakeroot
+  command.
+  When unprivileged user namespaces are not available, such that only
+  the fakeroot command can be used, the `--fix-perms` option is implied
+  to allow writing into directories.
 - Added a `binary path` configuration variable as the default path to use
   when searching for helper executables.  May contain `$PATH:` which gets
-  substituted with the user's PATH when running unprivileged.  Defaults to
+  substituted with the user's PATH when running without suid.  Defaults to
   `$PATH:` followed by standard system paths.  Configuration variables
   for paths to individual programs that were in apptainer.conf are still
   supported but deprecated.
@@ -55,6 +74,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - When starting a container, if the user has specified the cwd by using
   the `--pwd` flag, in case of problem return error instead of defaulting to
   a different directory.
+- Nesting of bind mounts now works even when a `--bind` option specified
+  a different source and destination with a colon between them.  Now the
+  APPTAINER_BIND environment variable makes sure the bind source is
+  from the bind destination so it will be succesfully re-bound into a
+  nested apptainer container.
 - The warning about more than 50 bind mounts required for an underlay bind
   has been changed to an info message.
 - `oci mount` sets `Process.Terminal: true` when creating an OCI `config.json`,

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -350,7 +350,7 @@ var actionFakerootFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "fakeroot",
 	ShortHand:    "f",
-	Usage:        "run container in new user namespace as uid 0",
+	Usage:        "run container with the appearance of running as root",
 	EnvKeys:      []string{"FAKEROOT"},
 }
 

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -68,7 +68,7 @@ var inspectDeffileFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "deffile",
 	ShortHand:    "d",
-	Usage:        "show the Apptainer recipe file that was used to generate the image",
+	Usage:        "show the Apptainer definition file that was used to generate the image",
 }
 
 // -j|--json

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -108,7 +108,7 @@ fi
 
 # Not all of these parameters currently have an effect, but they might be
 #  used someday.  They are the same parameters as in the configure macro.
-./mconfig -P debug -V %{version}-%{release} --with-suid \
+./mconfig %{?mconfig_opts} -V %{version}-%{release} --with-suid \
         --prefix=%{_prefix} \
         --exec-prefix=%{_exec_prefix} \
         --bindir=%{_bindir} \

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -10,7 +10,6 @@
 package actions
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -568,7 +567,7 @@ func (c actionTests) issue5599(t *testing.T) {
 	envBind := tmpDir + ":/srv"
 	bindEnv := "APPTAINER_BIND=" + envBind
 	flagBind := tmpDir + ":/mnt"
-	expectedEnv := fmt.Sprintf("APPTAINER_BIND=%s,%s", flagBind, envBind)
+	expectedEnv := "/mnt,/srv"
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -1,0 +1,155 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+// This file is for "fake fakeroot", that is, root-mapped unprivileged
+//   user namespaces (unshare -r) and the fakeroot command
+
+package fakeroot
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	osExec "os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/apptainer/apptainer/internal/pkg/util/bin"
+	"github.com/apptainer/apptainer/pkg/sylog"
+)
+
+// re-exec the command effectively under unshare -r
+func UnshareRootMapped(args []string) error {
+	cmd := osExec.Command(args[0], args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWUSER
+	cmd.SysProcAttr.UidMappings = []syscall.SysProcIDMap{
+		{ContainerID: 0, HostID: syscall.Getuid(), Size: 1},
+	}
+	cmd.SysProcAttr.GidMappings = []syscall.SysProcIDMap{
+		{ContainerID: 0, HostID: syscall.Getgid(), Size: 1},
+	}
+	sylog.Debugf("Re-executing to root-mapped unprivileged user namespace")
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("Error re-executing in root-mapped unprivileged user namespace: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		if exiterr, ok := err.(*osExec.ExitError); ok {
+			// exit with the non-zero exit code
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				os.Exit(status.ExitStatus())
+			}
+		}
+		sylog.Fatalf("error waiting for root-mapped unprivileged command: %v", err)
+	}
+	return nil
+}
+
+// This just adds debug messages around bin.FindBin("fakeroot")
+func FindFake() (string, error) {
+	sylog.Debugf("looking for the fakeroot command")
+	fakerootPath, err := bin.FindBin("fakeroot")
+	if err != nil {
+		sylog.Debugf("failure finding fakeroot: %v", err)
+		return "", err
+	}
+	sylog.Debugf("fakeroot found at %v", fakerootPath)
+	return fakerootPath, nil
+}
+
+// Get the args needed to execute the fakeroot mapped into the container
+func GetFakeArgs() []string {
+	return []string{
+		"/.singularity.d/libs/fakeroot",
+		"-f",
+		"/.singularity.d/libs/faked",
+		"-l",
+		"/.singularity.d/libs/libfakeroot.so",
+	}
+}
+
+// Get the binds needed to map the fakeroot command into the container
+// The incoming parameter is the path to fakeroot
+func GetFakeBinds(fakerootPath string) ([]string, error) {
+	args := GetFakeArgs()
+	binds := []string{
+		args[0],
+		args[2],
+		args[4],
+	}
+
+	// Start by examining the environment fakeroot creates
+	cmd := osExec.Command(fakerootPath, "env")
+	env := os.Environ()
+	for idx := range env {
+		if strings.HasPrefix(env[idx], "LD_LIBRARY_PATH=") {
+			// Remove any incoming LD_LIBRARY_PATH
+			env[idx] = "LD_LIBRARY_PREFIX="
+		}
+	}
+	cmd.Env = env
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return binds, fmt.Errorf("error make fakeroot stdout pipe: %v", err)
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return binds, fmt.Errorf("error starting fakeroot: %v", err)
+	}
+	preload := ""
+	libraryPath := ""
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "LD_PRELOAD=") {
+			preload = line[len("LD_PRELOAD="):]
+		} else if strings.HasPrefix(line, "LD_LIBRARY_PATH=") {
+			libraryPath = line[len("LD_LIBRARY_PATH="):]
+		}
+	}
+	_ = cmd.Wait()
+	if preload == "" {
+		return binds, fmt.Errorf("No LD_PRELOAD in fakeroot environment")
+	}
+	if libraryPath == "" {
+		return binds, fmt.Errorf("No LD_LIBRARY_PATH in fakeroot environment")
+	}
+
+	src := fakerootPath
+	point := binds[0]
+	binds[0] = src + ":" + point
+
+	dir := filepath.Dir(src)
+	src = filepath.Join(dir, "faked")
+	point = binds[1]
+	splits := strings.Split(preload, ".")
+	splits = strings.Split(splits[0], "-")
+	if len(splits) > 1 {
+		// add the faked that corresponds to the preload library
+		src += "-" + splits[1]
+		if _, err = os.Stat(src); err == nil {
+			binds[1] = src + ":" + point
+		}
+	}
+	point = binds[2]
+	splits = strings.Split(libraryPath, ":")
+	for _, dir := range splits {
+		// Find the preload library in libraryPath
+		src = filepath.Join(dir, preload)
+		if _, err = os.Stat(src); err == nil {
+			binds[2] = src + ":" + point
+			break
+		}
+	}
+	return binds, nil
+}

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -87,6 +87,11 @@ func GetFakeBinds(fakerootPath string) ([]string, error) {
 		args[4],
 	}
 
+	if fakerootPath == args[0] {
+		// The binding has already been done, this is for nesting
+		return binds, nil
+	}
+
 	// Start by examining the environment fakeroot creates
 	cmd := osExec.Command(fakerootPath, "env")
 	env := os.Environ()

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -276,7 +276,7 @@ func GetLogFilePaths(name string, subDir string) (string, string, error) {
 
 // SetLogFile replaces stdout/stderr streams and redirect content
 // to log file
-func SetLogFile(name string, uid int, subDir string) (*os.File, *os.File, error) {
+func SetLogFile(name string, userNs bool, uid int, subDir string) (*os.File, *os.File, error) {
 	path, err := getPath("", subDir)
 	if err != nil {
 		return nil, nil, err
@@ -304,7 +304,7 @@ func SetLogFile(name string, uid int, subDir string) (*os.File, *os.File, error)
 		return nil, nil, err
 	}
 
-	if uid != os.Getuid() || uid == 0 {
+	if !userNs && (uid != os.Getuid() || uid == 0) {
 		if err := stderr.Chown(uid, os.Getgid()); err != nil {
 			return nil, nil, err
 		}

--- a/internal/pkg/instance/instance_linux_test.go
+++ b/internal/pkg/instance/instance_linux_test.go
@@ -205,7 +205,7 @@ func TestAdd(t *testing.T) {
 		if err := file.Update(); err != nil {
 			t.Errorf("error while creating instance %s: %s", e.name, err)
 		}
-		stdout, stderr, err := SetLogFile(e.name, 0, testSubDir)
+		stdout, stderr, err := SetLogFile(e.name, false, 0, testSubDir)
 		if err != nil {
 			t.Errorf("error while creating instance log file: %s", err)
 		}

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -115,6 +115,16 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 	}
 
 	if engine.EngineConfig.OciConfig.Linux != nil {
+		if os.Getuid() == 0 && namespaces.IsUnprivileged() {
+			// This is any root-mapped unprivileged user namespace,
+			//  the real fakeroot or the "fake" fakeroot with just
+			//  a root-mapped unprivileged user namespace.
+			// This setting is already on the real fakeroot but it is
+			//  needed to be added on the fake fakeroot for starting
+			//  instances.
+			engine.EngineConfig.OciConfig.AddOrReplaceLinuxNamespace(specs.UserNamespace, "")
+		}
+
 		for _, namespace := range engine.EngineConfig.OciConfig.Linux.Namespaces {
 			switch namespace.Type {
 			case specs.UserNamespace:
@@ -1609,11 +1619,18 @@ func (c *container) getHomePaths() (source string, dest string, err error) {
 		pw, err := user.CurrentOriginal()
 		if err == nil {
 			source = pw.Dir
-			if c.engine.EngineConfig.GetFakeroot() {
+			if os.Getuid() == 0 {
+				// Mount user home directory onto /root for
+				//  any root-mapped namespace
 				dest = "/root"
 			} else {
 				dest = pw.Dir
 			}
+		} else if os.Getuid() == 0 {
+			// The user could not be found
+			// This can happen when running under fakeroot
+			source = "/root"
+			dest = source
 		}
 	}
 
@@ -1739,6 +1756,18 @@ func (c *container) addUserbindsMount(system *mount.System) error {
 	defaultFlags := uintptr(syscall.MS_BIND | c.suidFlag | syscall.MS_NODEV | syscall.MS_REC)
 
 	for _, b := range c.engine.EngineConfig.GetBindPath() {
+		if strings.HasPrefix(b.Destination, "/.singularity.d/libs") {
+			// Defer to library bind time because otherwise the
+			//  binds here will get hidden under a new directory
+			libraries := c.engine.EngineConfig.GetLibrariesPath()
+			if b.Source == b.Destination {
+				libraries = append(libraries, b.Source)
+			} else {
+				libraries = append(libraries, b.Source+":"+b.Destination)
+			}
+			c.engine.EngineConfig.SetLibrariesPath(libraries)
+			continue
+		}
 		// data image bind
 		if b.ID() != "" || b.ImageSrc() != "" {
 			source, ok := c.imageBind[b.Destination]
@@ -2063,9 +2092,18 @@ func (c *container) addLibsMount(system *mount.System) error {
 	}
 
 	for _, lib := range libraries {
+		splits := strings.Split(lib, ":")
+		var file string
+		if len(splits) > 1 {
+			// this can happen with a user bind (including for
+			//   the fakeroot command) to the libs directory
+			//   where the base name is desired to be changed
+			lib = splits[0]
+			file = filepath.Base(splits[1])
+		} else {
+			file = filepath.Base(lib)
+		}
 		sylog.Debugf("Add library %s to mount list", lib)
-
-		file := filepath.Base(lib)
 		sessionFile := filepath.Join(sessionDir, file)
 
 		if err := c.session.AddFile(sessionFile, []byte{}); err != nil {

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -95,6 +95,18 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		if !fs.IsOwner(buildcfg.ECL_FILE, 0) {
 			return fmt.Errorf("%s must be owned by root", buildcfg.ECL_FILE)
 		}
+		if fakerootPath := e.EngineConfig.GetFakerootPath(); fakerootPath != "" {
+			// look for fakeroot again because the PATH used is
+			//  more restricted at this point than it was earlier
+			newPath, err := fakerootutil.FindFake()
+			if err != nil {
+				return fmt.Errorf("error finding fakeroot in privileged PATH: %v", err)
+			}
+			if newPath != fakerootPath {
+				sylog.Verbosef("path to fakeroot changed from %v to %v", fakerootPath, newPath)
+			}
+			e.EngineConfig.SetFakerootPath(newPath)
+		}
 	}
 
 	// Save the current working directory if not set

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -33,6 +33,7 @@ import (
 	"unsafe"
 
 	"github.com/apptainer/apptainer/internal/pkg/checkpoint/dmtcp"
+	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
 	"github.com/apptainer/apptainer/internal/pkg/instance"
 	"github.com/apptainer/apptainer/internal/pkg/plugin"
 	"github.com/apptainer/apptainer/internal/pkg/security"
@@ -876,6 +877,11 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 				return nil, nil, err
 			}
 		}
+	}
+
+	if fakerootPath := engineConfig.GetFakerootPath(); fakerootPath != "" {
+		sylog.Verbosef("Running command with %v", filepath.Base(fakerootPath))
+		args = append(fakeroot.GetFakeArgs(), args...)
 	}
 
 	return args, env, nil

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -80,6 +80,8 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	if err != nil {
 		return fmt.Errorf("unable to parse apptainer.conf file: %s", err)
 	}
+	apptainerconf.SetCurrentConfig(fileConfig)
+	apptainerconf.SetBinaryPath(!starterConfig.GetIsSUID())
 
 	if starterConfig.GetIsSUID() {
 		if !fileConfig.AllowSetuid {

--- a/internal/pkg/security/seccomp/seccomp_supported.go
+++ b/internal/pkg/security/seccomp/seccomp_supported.go
@@ -45,7 +45,7 @@ var scmpArchMap = map[specs.Arch]lseccomp.ScmpArch{
 }
 
 var scmpActionMap = map[specs.LinuxSeccompAction]lseccomp.ScmpAction{
-	specs.ActKill:  lseccomp.ActKill,
+	specs.ActKill:  lseccomp.ActKillThread,
 	specs.ActTrap:  lseccomp.ActTrap,
 	specs.ActErrno: lseccomp.ActErrno,
 	specs.ActTrace: lseccomp.ActTrace,

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -31,8 +31,8 @@ func FindBin(name string) (path string, err error) {
 	// Bootstrap related executables that we assume are on PATH
 	case "mount", "mknod", "debootstrap", "pacstrap", "dnf", "yum", "rpm", "curl", "uname", "zypper", "SUSEConnect", "rpmkeys", "squashfuse", "fuse-overlayfs", "fakeroot":
 		return findOnPath(name)
-	// Configurable executables that are found at build time, can be overridden
-	// in apptainer.conf. If config value is "" will look on PATH.
+	// Configurable executables that can be overridden in
+	// apptainer.conf. If config value is "" will look on PATH.
 	case "unsquashfs", "mksquashfs", "go", "cryptsetup", "ldconfig", "nvidia-container-cli":
 		return findFromConfigOrPath(name)
 	// distro provided setUID executables that are used in the fakeroot flow to setup subuid/subgid mappings

--- a/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
@@ -216,7 +216,7 @@ func (u *Underlay) duplicateDir(dir string, system *mount.System, existingPath s
 		}
 	}
 	if binds > 50 && existingPath != "" {
-		sylog.Warningf("underlay of %s required more than 50 (%d) bind mounts", existingPath, binds)
+		sylog.Infof("underlay of %s required more than 50 (%d) bind mounts", existingPath, binds)
 	}
 	return nil
 }

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -92,6 +92,7 @@ type JSONConfig struct {
 	HomeDest              string            `json:"homeDest,omitempty"`
 	Command               string            `json:"command,omitempty"`
 	Shell                 string            `json:"shell,omitempty"`
+	FakerootPath          string            `json:"fakerootPath,omitempty"`
 	TmpDir                string            `json:"tmpdir,omitempty"`
 	AddCaps               string            `json:"addCaps,omitempty"`
 	DropCaps              string            `json:"dropCaps,omitempty"`
@@ -318,6 +319,16 @@ func (e *EngineConfig) SetShell(shell string) {
 // GetShell retrieves shell for shell command.
 func (e *EngineConfig) GetShell() string {
 	return e.JSON.Shell
+}
+
+// SetFakerootPath sets the fakeroot path
+func (e *EngineConfig) SetFakerootPath(fakerootPath string) {
+	e.JSON.FakerootPath = fakerootPath
+}
+
+// GetFakerootPath retrieves the fakeroot path
+func (e *EngineConfig) GetFakerootPath() string {
+	return e.JSON.FakerootPath
 }
 
 // SetTmpDir sets temporary directory path.


### PR DESCRIPTION
This PR makes the `--fakeroot` option more general in that if `/etc/subuid` and `/etc/subgid` have not been set up, it will try using a root-mapped unprivileged user namespace and/or the fakeroot command.  This is especially useful with `--overlay` and `--writable-tmpfs` options to action commands and with unprivileged builds.  The PR also then effectively makes `--fakeroot` the default for unprivileged builds, changing the existing functionality so that it will try using `/etc/sub[ug]id` before the other "fake" fake root options.

- Fixes #448

In addition, it fixes nested binds to work even if the source directory was different than the destination (since that was needed for nested fakeroot command) and changes the warning on >50 binds needed for underlay to info level (since there are now a bunch more info level messages and it made me think that that message should be at that level).

e2e tests will be added as part of #412 and #476.