### PR TITLE
Fix inspection of definition files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Add specific error for unreadable image / overlay file.
 - Pass through a literal `\n` in host environment variables to container.
 - Allow `newgidmap / newuidmap` that use capabilities instead of setuid root.
+- Fix `inspect --deffile` and `inspect --all` to correctly show definition
+  files in sandbox container images instead of empty output.
+  This has a side effect of also fixing the storing of definition files in
+  the metadata of sif files built by Apptainer, because that metadata is
+  constructed by doing `inspect --all`.
 
 ## v1.0.2 - \[2022-05-09\]
 

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -534,7 +534,7 @@ func (c *command) addEnvironmentCommand() {
 func (c *command) addDefinitionCommand() {
 	deffile, err := inspectDeffilePartition(c.img)
 	if err == errNoSIFMetadata || err == errNoSIF {
-		c.addSingleFileCommand("Apptainer", "deffile")
+		c.addSingleFileCommand("Singularity", "deffile")
 	} else if err != nil {
 		sylog.Warningf("Unable to inspect deffile: %s", err)
 	} else {

--- a/e2e/inspect/inspect.go
+++ b/e2e/inspect/inspect.go
@@ -156,6 +156,17 @@ func (c ctx) apptainerInspect(t *testing.T) {
 			compareFn: compareLabel("org.label-schema.usage.apptainer.runscript.help", "/.singularity.d/runscript.help", ""),
 		},
 		{
+			name:    "deffile",
+			insType: "--deffile",
+			compareFn: func(t *testing.T, meta *inspect.Metadata) {
+				out := "bootstrap:"
+				v := meta.Attributes.Deffile[0:len(out)]
+				if v != out {
+					t.Errorf("unexpected deffile output, got '%s' instead of '%s'", v, out)
+				}
+			},
+		},
+		{
 			name:    "runscript",
 			insType: "--runscript",
 			compareFn: func(t *testing.T, meta *inspect.Metadata) {


### PR DESCRIPTION
This fixes `inspect -d` and `inspect --all` to work for sandbox container images and as a side effect fixes storing those definition files in the metadata section of sif files.

- Fixes #521 