### PR TITLE
Use better messages for overlays when not root or in the suid flow

### DIFF
--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -973,6 +973,15 @@ func (c *container) addOverlayMount(system *mount.System) error {
 			return fmt.Errorf("while opening overlay image %s: %s", img.Path, err)
 		}
 		for _, overlay := range overlays {
+			if overlay.Type == image.EXT3 && c.userNS {
+				// This can be removed when fuse2fs is supported
+				if overlay.Offset > 0 {
+					sylog.Infof("Ignoring EXT3 overlay partition in %s because not root or suid", img.Path)
+					continue
+				}
+				return fmt.Errorf("cannot use overlay in %v without root or suid", img.Path)
+			}
+
 			sylog.Debugf("Using overlay partition in image %s", img.Path)
 
 			sessionDest := fmt.Sprintf("/overlay-images/%d", nb)

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1068,9 +1068,18 @@ func (e *EngineOperations) setSessionLayer(img *image.Image) error {
 			return nil
 		}
 		if !writableImage {
+			if hasSIFOverlay {
+				// This can be removed when fuse2fs is supported
+				sylog.Infof("Ignoring EXT3 overlay partition in %s because not root or suid", img.Path)
+			}
 			sylog.Debugf("Using underlay layer: user namespace requested")
 			e.EngineConfig.SetSessionLayer(apptainerConfig.UnderlayLayer)
 			return nil
+		}
+		if hasSIFOverlay {
+			// This can be removed when fuse2fs is supported
+			sylog.Infof("Consider using --overlay or --writable-tmpfs instead of --writable")
+			return fmt.Errorf("cannot use overlay partition in %v for --writable without root or suid", img.Path)
 		}
 		sylog.Debugf("Not attempting to use overlay or underlay: writable flag requested")
 		return nil


### PR DESCRIPTION
This ignores overlay partitions in SIF images when running unprivileged in order to avoid an incomprehensible error noted in #446.  It also gives a better error message when attempting to use --writable to use an overlay partition when unprivileged.   Builds on cases introduced in #411.

- FIxes #446