### PR TITLE
Fix fake fakeroot building after recent redo of --fakeroot option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `--writable-tmpfs` options and for building containers unprivileged,
   because they allow installing packages that assume they're running
   as root.
-  The feature works nested inside of an apptainer container, where
+  A limitation on using it with `--overlay` and `--writable-tmpfs`
+  however is that when only the fakeroot command can be used (because
+  there are no user namespaces available, in suid mode) then the base
+  image has to be a sandbox.
+  This feature works nested inside of an apptainer container, where
   another apptainer command will also be in the fakeroot environment
   without requesting the `--fakeroot` option again, or it can be used
   inside an apptainer container that was not started with `--fakeroot`.

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -212,6 +212,21 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			if err != nil {
 				sylog.Fatalf("--fakeroot requires either being in %v, unprivileged user namespaces, or the fakeroot command", fakeroot.SubUIDFile)
 			}
+			notSandbox := false
+			if strings.Contains(image, "://") {
+				notSandbox = true
+			} else {
+				info, err := os.Stat(image)
+				if err == nil && !info.Mode().IsDir() {
+					notSandbox = true
+				}
+			}
+			if notSandbox {
+				sylog.Infof("No user namespaces available")
+				sylog.Infof("The fakeroot command by itself is only useful with sandbox images")
+				sylog.Infof(" which can be built with 'apptainer build --sandbox'")
+				sylog.Fatalf("--fakeroot used without sandbox image or user namespaces")
+			}
 			sylog.Infof("No user namespaces available, using only the fakeroot command")
 		}
 	}

--- a/docs/content.go
+++ b/docs/content.go
@@ -456,7 +456,8 @@ Enterprise Performance Computing (EPC)`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	formats string = `
 
-  *.sif               Singularity Image Format (SIF). Native to Singularity (3.0+) and Apptainer (v1.0.0+)
+  *.sif               Singularity Image Format (SIF). Native to Singularity
+                      (3.0+) and Apptainer (v1.0.0+)
   
   *.sqsh              SquashFS format.  Native to Singularity 2.4+
 

--- a/internal/pkg/build/sources/packer_sif.go
+++ b/internal/pkg/build/sources/packer_sif.go
@@ -72,6 +72,14 @@ func unpackSIF(b *types.Bundle, img *image.Image) (err error) {
 		return fmt.Errorf("unrecognized partition format")
 	}
 
+	if b.Opts.FixPerms {
+		sylog.Debugf("Modifying permissions for file/directory owners")
+		err = fixPerms(b.RootfsPath)
+		if err != nil {
+			return err
+		}
+	}
+
 	ociReader, err := image.NewSectionReader(img, image.SIFDescOCIConfigJSON, -1)
 	if err == image.ErrNoSection {
 		sylog.Debugf("No %s section found", image.SIFDescOCIConfigJSON)

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -897,6 +897,12 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 		sylog.Verbosef("Running command with %v", filepath.Base(fakerootPath))
 		args = append(fakeargs, args...)
 
+		// Without this workaround fakeroot does not work
+		//  properly in a user namespace. It is especially
+		//  noticeable with debian containers.  Learned from
+		//  https://salsa.debian.org/clint/fakeroot/-/merge_requests/4
+		penv = append(penv, "FAKEROOTDONTTRYCHOWN=1")
+
 		if engineConfig.GetFakerootPath() == "" {
 			// Must be joining an instance, so also set BIND
 			//  variables for nesting


### PR DESCRIPTION
This fixes the use of the fakeroot command for building after the generalizing of the --fakeroot option in #526.  I believe some of the last changes I made there broke that part and I didn't retest it. 

Also enable fix-perms when building based on a SIF image and exit early when the fakeroot command is used by itself without a sandbox as an image source for an action command.