### PR TITLE
Ignore new markdown lint error

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -5,3 +5,6 @@ MD010: false
 # Allow mixing of asterisks and underscores for emphasis
 MD049: false
 MD050: false
+# Allow link fragments because they work fine
+#   (seen in dist/debian/DEBIAN_PACKAGE.md)
+MD051: false


### PR DESCRIPTION
This ignores a new markdown lint error seen during a CI test:
```
dist/debian/DEBIAN_PACKAGE.md:91:15 MD051/link-fragments Link fragments should be valid [Context: "[start from scratch](#Preparation)"]
```
The link works fine as far as I can tell and I don't know why it is complaining.