### PR TITLE
Add fuse2fs image driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Added a squashfuse image driver that enables mounting SIF files without
   using setuid-root.  Requires the squashfuse command and unprivileged user
   namespaces.
+- Added a fuse2fs image driver that enables mounting EXT3 files and EXT3
+  SIF overlay partitions without using setuid-root.  Requires the fuse2fs
+  command and unprivileged user namespaces.
 - Added the ability to use persistent overlay (`--overlay`) and
   `--writable-tmpfs` without using setuid-root.
   This requires unprivileged user namespaces and either a new enough
@@ -64,6 +67,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
   When unprivileged user namespaces are not available, such that only
   the fakeroot command can be used, the `--fix-perms` option is implied
   to allow writing into directories.
+- Added a `--fakeroot` option to the `apptainer overlay create` command
+  to make an overlay EXT3 image file that works with the fakeroot that
+  comes from unprivileged root-mapped namespaces.
+  This is not needed with the fakeroot that comes with `/etc/sub[ug]id`
+  mappings nor with the fakeroot that comes with only the fakeroot
+  command in suid flow.
 - Added a `binary path` configuration variable as the default path to use
   when searching for helper executables.  May contain `$PATH:` which gets
   substituted with the user's PATH except when running a program that may

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,6 +22,7 @@ sudo apt-get install -y \
     pkg-config \
     squashfs-tools \
     squashfuse \
+    fuse2fs \
     fuse-overlayfs \
     fakeroot \
     cryptsetup \

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -207,7 +207,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 				// All good
 				os.Exit(0)
 			}
-			sylog.Debugf("%v", err)
+			sylog.Debugf("UnshareRootMapped failed: %v", err)
 			fakerootPath, err = fakeroot.FindFake()
 			if err != nil {
 				sylog.Fatalf("--fakeroot requires either being in %v, unprivileged user namespaces, or the fakeroot command", fakeroot.SubUIDFile)

--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -20,6 +20,7 @@ func init() {
 
 		cmdManager.RegisterFlagForCmd(&overlaySizeFlag, OverlayCreateCmd)
 		cmdManager.RegisterFlagForCmd(&overlayCreateDirFlag, OverlayCreateCmd)
+		cmdManager.RegisterFlagForCmd(&overlayFakerootFlag, OverlayCreateCmd)
 	})
 }
 

--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	overlaySize int
-	overlayDirs []string
+	overlaySize       int
+	overlayDirs       []string
+	isOverlayFakeroot bool
 )
 
 // -s|--size
@@ -37,11 +38,22 @@ var overlayCreateDirFlag = cmdline.Flag{
 	Usage:        "directory to create as part of the overlay layout",
 }
 
+// --fakeroot
+var overlayFakerootFlag = cmdline.Flag{
+	ID:           "overlayFakerootFlag",
+	Value:        &isOverlayFakeroot,
+	DefaultValue: false,
+	Name:         "fakeroot",
+	ShortHand:    "f",
+	Usage:        "make overlay layout usable by actions run with --fakeroot",
+	EnvKeys:      []string{"FAKEROOT"},
+}
+
 // OverlayCreateCmd is the 'overlay create' command that allows to create writable overlay.
 var OverlayCreateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := apptainer.OverlayCreate(overlaySize, args[0], overlayDirs...); err != nil {
+		if err := apptainer.OverlayCreate(overlaySize, args[0], isOverlayFakeroot, overlayDirs...); err != nil {
 			sylog.Fatalf(err.Error())
 		}
 		return nil

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -22,7 +22,7 @@ Vcs-Browser: https://github.com/apptainer/apptainer
 
 Package: apptainer
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools, squashfuse, fuse-overlayfs, fakeroot
+Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools, squashfuse, fuse2fs, fuse-overlayfs, fakeroot
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -148,6 +148,7 @@ rmdir %{_sysconfdir}/singularity/* %{_sysconfdir}/singularity 2>/dev/null || tru
 %dir %{_libexecdir}/%{name}/bin
 %{_libexecdir}/%{name}/bin/starter
 %{_libexecdir}/%{name}/cni
+%{_libexecdir}/%{name}/lib
 %dir %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/*
 %{_datadir}/bash-completion/completions/*

--- a/docs/content.go
+++ b/docs/content.go
@@ -1074,14 +1074,17 @@ Enterprise Performance Computing (EPC)`
 	OverlayCreateUse   string = `create <options> image`
 	OverlayCreateShort string = `Create EXT3 writable overlay image`
 	OverlayCreateLong  string = `
-  The overlay create command allows to create EXT3 writable overlay image either
+  The overlay create command allows creating EXT3 writable overlay image either
   as a single EXT3 image or by adding it automatically to an existing SIF image.`
 	OverlayCreateExample string = `
   To create and add a writable overlay to an existing SIF image:
   $ apptainer overlay create --size 1024 /tmp/image.sif
 
   To create a single EXT3 writable overlay image:
-  $ apptainer overlay create --size 1024 /tmp/my_overlay.img`
+  $ apptainer overlay create --size 1024 /tmp/my_overlay.img
+
+  To create an EXT3 writable overlay image for use with --fakeroot actions:
+  $ apptainer overlay create --fakeroot --size 1024 /tmp/my_overlay.img`
 
 	CheckpointUse   string = `checkpoint`
 	CheckpointShort string = `Manage container checkpoint state (experimental)`

--- a/examples/plugins/ubuntu-userns-overlay-plugin/main.go
+++ b/examples/plugins/ubuntu-userns-overlay-plugin/main.go
@@ -66,7 +66,7 @@ func (d *ubuntuOvlDriver) Start(params *image.DriverParams) error {
 	return nil
 }
 
-func (d *ubuntuOvlDriver) Stop() error {
+func (d *ubuntuOvlDriver) Stop(target string) error {
 	return nil
 }
 

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -40,7 +40,7 @@ func UnshareRootMapped(args []string) error {
 	}
 	sylog.Debugf("Re-executing to root-mapped unprivileged user namespace")
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("Error re-executing in root-mapped unprivileged user namespace: %v", err)
+		return fmt.Errorf("error re-executing in root-mapped unprivileged user namespace: %v", err)
 	}
 	if err := cmd.Wait(); err != nil {
 		if exiterr, ok := err.(*osExec.ExitError); ok {

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/pkg/image"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -29,27 +30,32 @@ import (
 
 const driverName = "fuseapps"
 
+type fuseappsInstance struct {
+	cmd    *exec.Cmd
+	params *image.MountParams
+}
+
 type fuseappsFeature struct {
-	binName string
-	cmd     *exec.Cmd
-	cmdPath string
+	binName   string
+	cmdPath   string
+	instances []fuseappsInstance
 }
 
 type fuseappsDriver struct {
 	squashFeature  fuseappsFeature
+	ext3Feature    fuseappsFeature
 	overlayFeature fuseappsFeature
 }
 
 func (f *fuseappsFeature) init(binName string, purpose string, desired image.DriverFeature) {
 	var err error
+	f.binName = binName
 	f.cmdPath, err = bin.FindBin(binName)
 	if err != nil {
 		sylog.Debugf("%v mounting not enabled because: %v", binName, err)
 		if desired != 0 {
 			sylog.Infof("%v not found, will not be able to %v", binName, purpose)
 		}
-	} else {
-		f.binName = binName
 	}
 }
 
@@ -70,15 +76,17 @@ func InitImageDrivers(register bool, unprivileged bool, fileconf *apptainerconf.
 	}
 
 	var squashFeature fuseappsFeature
+	var ext3Feature fuseappsFeature
 	var overlayFeature fuseappsFeature
 	squashFeature.init("squashfuse", "mount SIF", desiredFeatures&image.ImageFeature)
+	ext3Feature.init("fuse2fs", "mount EXT3 filesystems", desiredFeatures&image.ImageFeature)
 	overlayFeature.init("fuse-overlayfs", "use overlay", desiredFeatures&image.OverlayFeature)
 
-	if squashFeature.cmdPath != "" || overlayFeature.cmdPath != "" {
+	if squashFeature.cmdPath != "" || ext3Feature.cmdPath != "" || overlayFeature.cmdPath != "" {
 		sylog.Debugf("Setting ImageDriver to %v", driverName)
 		fileconf.ImageDriver = driverName
 		if register {
-			return image.RegisterDriver(driverName, &fuseappsDriver{squashFeature, overlayFeature})
+			return image.RegisterDriver(driverName, &fuseappsDriver{squashFeature, ext3Feature, overlayFeature})
 		}
 	}
 	return nil
@@ -86,7 +94,7 @@ func InitImageDrivers(register bool, unprivileged bool, fileconf *apptainerconf.
 
 func (d *fuseappsDriver) Features() image.DriverFeature {
 	var features image.DriverFeature
-	if d.squashFeature.cmdPath != "" {
+	if d.squashFeature.cmdPath != "" || d.ext3Feature.cmdPath != "" {
 		features |= image.ImageFeature
 	}
 	if d.overlayFeature.cmdPath != "" {
@@ -97,11 +105,12 @@ func (d *fuseappsDriver) Features() image.DriverFeature {
 
 func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc) error {
 	var f *fuseappsFeature
+	var cmd *exec.Cmd
 	switch params.Filesystem {
 	case "overlay":
 		f = &d.overlayFeature
 		optsStr := strings.Join(params.FSOptions, ",")
-		f.cmd = exec.Command(f.cmdPath, "-f", "-o", optsStr, params.Target)
+		cmd = exec.Command(f.cmdPath, "-f", "-o", optsStr, params.Target)
 
 	case "squashfs":
 		f = &d.squashFeature
@@ -111,10 +120,50 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 			// this will be passed as the first ExtraFile below, always fd 3
 			srcPath = "/proc/self/fd/3"
 		}
-		f.cmd = exec.Command(f.cmdPath, "-f", "-o", optsStr, srcPath, params.Target)
+		cmd = exec.Command(f.cmdPath, "-f", "-o", optsStr, srcPath, params.Target)
 
 	case "ext3":
-		return fmt.Errorf("mounting an EXT3 filesystem requires root or a suid installation")
+		f = &d.ext3Feature
+		srcPath := params.Source
+		if path.Dir(params.Source) == "/proc/self/fd" {
+			// this will be passed as the first ExtraFile below, always fd 3
+			srcPath = "/proc/self/fd/3"
+		}
+		optsStr := ""
+		if os.Getuid() != 0 {
+			// Bypass permission checks so all can be read,
+			//  especially overlay work dir
+			optsStr = "fakeroot"
+		}
+		if (params.Flags & syscall.MS_RDONLY) != 0 {
+			if optsStr != "" {
+				optsStr += ","
+			}
+			optsStr += "ro"
+		}
+
+		var cmdArgs []string
+		stdbuf, err := bin.FindBin("stdbuf")
+		if err == nil {
+			// Run fuse2fs through stdbuf to be able to read the
+			//  warnings sometimes sent through stdout
+			cmdArgs = []string{stdbuf, "-oL"}
+		}
+		cmdArgs = append(cmdArgs, f.cmdPath, "-f", "-o", optsStr, srcPath, params.Target)
+		cmd = exec.Command(cmdArgs[0], cmdArgs[1:]...)
+
+		if params.Offset > 0 {
+			// fuse2fs cannot natively offset into a file,
+			//  so load a preload wrapper
+			cmd.Env = []string{
+				"LD_PRELOAD=" + buildcfg.LIBEXECDIR + "/apptainer/lib/offsetpreload.so",
+				"OFFSETPRELOAD_FILE=" + srcPath,
+				"OFFSETPRELOAD_OFFSET=" + strconv.FormatUint(params.Offset, 10),
+			}
+			for _, e := range cmd.Env {
+				sylog.Debugf("Setting env %s", e)
+			}
+		}
 
 	case "encryptfs":
 		return fmt.Errorf("mounting an encrypted filesystem requires root or a suid installation")
@@ -123,70 +172,157 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 		return fmt.Errorf("filesystem type %v not recognized by image driver", params.Filesystem)
 	}
 
-	sylog.Debugf("Executing %v", f.cmd.String())
-	var stderr bytes.Buffer
-	f.cmd.Stderr = &stderr
-	if path.Dir(params.Source) == "/proc/self/fd" {
-		f.cmd.ExtraFiles = make([]*os.File, 1)
-		targetFd, _ := strconv.Atoi(path.Base(params.Source))
-		f.cmd.ExtraFiles[0] = os.NewFile(uintptr(targetFd), params.Source)
+	if f.cmdPath == "" {
+		return fmt.Errorf("%v not found", f.binName)
 	}
-	f.cmd.SysProcAttr = &syscall.SysProcAttr{
+
+	sylog.Debugf("Executing %v", cmd.String())
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if path.Dir(params.Source) == "/proc/self/fd" {
+		cmd.ExtraFiles = make([]*os.File, 1)
+		targetFd, _ := strconv.Atoi(path.Base(params.Source))
+		cmd.ExtraFiles[0] = os.NewFile(uintptr(targetFd), params.Source)
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
 		AmbientCaps: []uintptr{
 			uintptr(capabilities.Map["CAP_SYS_ADMIN"].Value),
 		},
 	}
 	var err error
-	if err = f.cmd.Start(); err != nil {
+	if err = cmd.Start(); err != nil {
 		return fmt.Errorf("%v Start failed: %v: %v", f.binName, err, stderr.String())
 	}
-	process := f.cmd.Process
+	process := cmd.Process
 	if process == nil {
 		return fmt.Errorf("no %v process started", f.binName)
 	}
+
+	filterMsg := func() string {
+		stdoutstr := stdout.String()
+		if len(stdoutstr) > 0 {
+			for _, line := range strings.Split(stdoutstr, "\n") {
+				if len(line) == 0 {
+					continue
+				}
+				if strings.Contains(line, "journal is not supported.") ||
+					line == "Mounting read-only." {
+					// skip these unhelpful messages from fuse2fs
+					sylog.Debugf("%v", stdoutstr)
+					continue
+				}
+				sylog.Infof("%v\n", line)
+			}
+		}
+		return stderr.String()
+	}
+
+	f.instances = append(f.instances, fuseappsInstance{cmd, params})
 	maxTime := 2 * time.Second
 	totTime := 0 * time.Second
 	for totTime < maxTime {
 		sleepTime := 25 * time.Millisecond
 		time.Sleep(sleepTime)
 		totTime += sleepTime
-		err = process.Signal(os.Signal(syscall.Signal(0)))
+		var ws syscall.WaitStatus
+		wpid, err := syscall.Wait4(process.Pid, &ws, syscall.WNOHANG, nil)
 		if err != nil {
-			err := f.cmd.Wait()
-			return fmt.Errorf("%v failed: %v: %v", f.binName, err, stderr.String())
+			return fmt.Errorf("unable to get wait status on %v: %v: %v", f.binName, err, filterMsg())
 		}
+		if wpid != 0 {
+			return fmt.Errorf("%v exited with status %v: %v", f.binName, ws.ExitStatus(), filterMsg())
+		}
+		// See if mount has succeeded
 		entries, err := proc.GetMountInfoEntry("/proc/self/mountinfo")
 		if err != nil {
-			f.stop()
+			f.stop(params.Target, true)
 			return fmt.Errorf("%v failure to get mount info: %v", f.binName, err)
 		}
 		for _, entry := range entries {
-			if entry.Point == params.Target {
-				sylog.Debugf("%v mounted in %v", params.Target, totTime)
-				return nil
+			if entry.Point != params.Target {
+				continue
 			}
+			msg := filterMsg()
+			if len(msg) > 0 {
+				// Haven't seen this happen, but just in case
+				sylog.Infof("%v", msg)
+			}
+			sylog.Debugf("%v mounted in %v", params.Target, totTime)
+			return nil
 		}
 	}
-	f.stop()
-	return fmt.Errorf("%v failed to mount %v in %v", f.binName, params.Target, maxTime)
+	f.stop(params.Target, true)
+	return fmt.Errorf("%v failed to mount %v in %v: %v", f.binName, params.Target, maxTime, stderr.String())
 }
 
 func (d *fuseappsDriver) Start(params *image.DriverParams) error {
 	return nil
 }
 
-func (f *fuseappsFeature) stop() {
-	if f.cmd != nil {
-		process := f.cmd.Process
-		if process != nil {
-			sylog.Debugf("Killing %v", f.binName)
-			process.Kill()
+// Stop the process associated with the mount target, if there is one.
+// If kill is not true, an unmount should already have happened so at
+//   first just wait for the process to exit.
+func (f *fuseappsFeature) stop(target string, kill bool) error {
+	for _, instance := range f.instances {
+		if instance.params.Target != target {
+			continue
 		}
+		process := instance.cmd.Process
+		var ws syscall.WaitStatus
+		sylog.Debugf("Waiting for %v pid %v to exit", f.binName, process.Pid)
+		// maxTime is total time to wait including after kill signal,
+		//   and kill signal is sent at half the time
+		maxTime := 1 * time.Second
+		totTime := 0 * time.Second
+		killed := false
+		for totTime < maxTime {
+			wpid, err := syscall.Wait4(process.Pid, &ws, syscall.WNOHANG, nil)
+			if err != nil {
+				sylog.Debugf("Waiting for %v pid %v failed: %v", f.binName, process.Pid, err)
+				if err == syscall.ECHILD {
+					// not a terrible problem when stopping
+					return nil
+				}
+				return err
+			} else if wpid != 0 {
+				sylog.Debugf("%v pid %v exited with status %v within %v", f.binName, wpid, ws.ExitStatus(), totTime)
+				return nil
+			}
+			if kill {
+				sylog.Debugf("Killing pid %v", process.Pid)
+			} else if !killed && totTime >= maxTime/2 {
+				sylog.Debugf("Took more than %v, killing", maxTime/2)
+				kill = true
+			}
+			if kill {
+				kill = false
+				killed = true
+				process.Kill()
+				continue
+			}
+			sleepTime := 10 * time.Millisecond
+			time.Sleep(sleepTime)
+			totTime += sleepTime
+		}
+		// This is unexpected, because the kill signal at half
+		//  of maxTime should kill quickly
+		return fmt.Errorf("took more than %v to stop %v pid %v", maxTime, f.binName, process.Pid)
 	}
+	return nil
 }
 
-func (d *fuseappsDriver) Stop() error {
-	d.squashFeature.stop()
-	d.overlayFeature.stop()
+func (d *fuseappsDriver) Stop(target string) error {
+	var err error
+	if err = d.squashFeature.stop(target, false); err != nil {
+		return err
+	}
+	if err = d.ext3Feature.stop(target, false); err != nil {
+		return err
+	}
+	if err = d.overlayFeature.stop(target, false); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1171,7 +1171,7 @@ func (e *EngineOperations) loadImages(starterConfig *starter.Config) error {
 		starterConfig.SetWorkingDirectoryFd(int(img.Fd))
 
 		if e.EngineConfig.GetSessionLayer() == apptainerConfig.OverlayLayer {
-			if err := overlay.CheckLower(img.Path); overlay.IsIncompatible(err) {
+			if err := overlay.CheckLower(img.Path, 0); overlay.IsIncompatible(err) {
 				layer := apptainerConfig.UnderlayLayer
 				if !e.EngineConfig.File.EnableUnderlay {
 					sylog.Warningf("Could not fallback to underlay, disabled by configuration ('enable underlay = no')")

--- a/internal/pkg/runtime/engine/apptainer/rpc/args.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/args.go
@@ -77,6 +77,17 @@ type StatArgs struct {
 	Path string
 }
 
+// AccessReply defines the reply for access.
+type AccessReply struct {
+	Err error
+}
+
+// AccessArgs defines the arguments to access.
+type AccessArgs struct {
+	Path string
+	Mode uint32
+}
+
 // SendFuseFdArgs defines the arguments to send fuse file descriptor.
 type SendFuseFdArgs struct {
 	Socket int

--- a/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
@@ -139,6 +139,20 @@ func (t *RPC) Lstat(path string) (os.FileInfo, error) {
 	return reply.Fi, reply.Err
 }
 
+// Access calls the access RPC using the supplied arguments.
+func (t *RPC) Access(path string, mode uint32) error {
+	arguments := &args.AccessArgs{
+		Path: path,
+		Mode: mode,
+	}
+	var reply args.AccessReply
+	err := t.Client.Call(t.Name+".Access", arguments, &reply)
+	if err != nil {
+		return err
+	}
+	return reply.Err
+}
+
 // SendFuseFd calls the SendFuseFd RPC using the supplied arguments.
 func (t *RPC) SendFuseFd(socket int, fds []int) error {
 	arguments := &args.SendFuseFdArgs{

--- a/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
@@ -334,6 +334,12 @@ func (t *Methods) Lstat(arguments *args.StatArgs, reply *args.StatReply) error {
 	return nil
 }
 
+// Access checks file access permissions
+func (t *Methods) Access(arguments *args.AccessArgs, reply *args.AccessReply) error {
+	reply.Err = syscall.Access(arguments.Path, arguments.Mode)
+	return nil
+}
+
 // SendFuseFd send fuse file descriptor over unix socket.
 func (t *Methods) SendFuseFd(arguments *args.SendFuseFdArgs, reply *int) error {
 	usernsFd, err := unix.Open("/proc/self/ns/user", unix.O_RDONLY|unix.O_CLOEXEC, 0)

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -35,6 +35,7 @@ func FindBin(name string) (path string, err error) {
 		"mknod",
 		"mount",
 		"rm",
+		"stdbuf",
 		"true",
 		"uname":
 		return findOnPath(name, true)
@@ -49,6 +50,7 @@ func FindBin(name string) (path string, err error) {
 		"dnf",
 		"fakeroot",
 		"fuse-overlayfs",
+		"fuse2fs",
 		"go",
 		"ldconfig",
 		"mksquashfs",

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -62,7 +62,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "NFS",
 			dir:                   lowerDir,
-			fsType:                nfs,
+			fsType:                Nfs,
 			expectedSuccess:       true,
 			expectIncompatibleErr: false,
 		},
@@ -71,7 +71,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "NFS",
 			dir:                   upperDir,
-			fsType:                nfs,
+			fsType:                Nfs,
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
@@ -80,7 +80,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "FUSE",
 			dir:                   lowerDir,
-			fsType:                fuse,
+			fsType:                Fuse,
 			expectedSuccess:       true,
 			expectIncompatibleErr: false,
 		},
@@ -89,7 +89,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "FUSE",
 			dir:                   upperDir,
-			fsType:                fuse,
+			fsType:                Fuse,
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
@@ -98,7 +98,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "ECRYPT",
 			dir:                   lowerDir,
-			fsType:                ecrypt,
+			fsType:                Ecrypt,
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
@@ -107,7 +107,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "ECRYPT",
 			dir:                   upperDir,
-			fsType:                ecrypt,
+			fsType:                Ecrypt,
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
@@ -117,7 +117,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "LUSTRE",
 			dir:                   lowerDir,
-			fsType:                lustre,
+			fsType:                Lustre,
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
@@ -127,7 +127,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "LUSTRE",
 			dir:                   upperDir,
-			fsType:                lustre,
+			fsType:                Lustre,
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
@@ -136,7 +136,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "GPFS",
 			dir:                   lowerDir,
-			fsType:                gpfs,
+			fsType:                Gpfs,
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
@@ -145,7 +145,7 @@ func TestCheckLowerUpper(t *testing.T) {
 			path:                  "/",
 			fsName:                "GPFS",
 			dir:                   upperDir,
-			fsType:                gpfs,
+			fsType:                Gpfs,
 			expectedSuccess:       false,
 			expectIncompatibleErr: true,
 		},
@@ -170,9 +170,9 @@ func TestCheckLowerUpper(t *testing.T) {
 
 		switch tt.dir {
 		case lowerDir:
-			err = CheckLower(tt.path)
+			err = CheckLower(tt.path, 0)
 		case upperDir:
-			err = CheckUpper(tt.path)
+			err = CheckUpper(tt.path, 0)
 		}
 
 		if err != nil && tt.expectedSuccess {

--- a/mlocal/frags/build_runtime.mk
+++ b/mlocal/frags/build_runtime.mk
@@ -39,6 +39,24 @@ INSTALLFILES += $(starter_INSTALL)
 ALL += $(starter)
 
 
+# preload library for offsetting accesses into a file
+offsetpreload := $(BUILDDIR)/offsetpreload.so
+offsetpreload_SOURCE := $(SOURCEDIR)/tools/offsetpreload.c
+$(offsetpreload): $(offsetpreload_SOURCE)
+	@echo " CC" $@
+	$(V)$(CC) $(CFLAGS) -shared -o $@ $(offsetpreload_SOURCE) -ldl
+
+offsetpreload_INSTALL := $(DESTDIR)$(LIBEXECDIR)/apptainer/lib/offsetpreload.so
+$(offsetpreload_INSTALL): $(offsetpreload)
+	@echo " INSTALL" $@
+	$(V)umask 0022 && mkdir -p $(@D)
+	$(V)install -m 0755 $(offsetpreload) $@
+
+CLEANFILES += $(offsetpreload)
+INSTALLFILES += $(offsetpreload_INSTALL)
+ALL += $(offsetpreload)
+
+
 # sessiondir
 sessiondir_INSTALL := $(DESTDIR)$(LOCALSTATEDIR)/apptainer/mnt/session
 $(sessiondir_INSTALL):

--- a/mlocal/frags/debug_opts.mk
+++ b/mlocal/frags/debug_opts.mk
@@ -1,2 +1,2 @@
-CFLAGS += -O0 -ggdb
+CFLAGS := $(filter-out -D_FORTIFY_SOURCE=2 -O2,$(CFLAGS)) -O0 -ggdb
 CPPFLAGS += -DDBG

--- a/pkg/image/driver.go
+++ b/pkg/image/driver.go
@@ -58,8 +58,8 @@ type Driver interface {
 	Mount(*MountParams, MountFunc) error
 	// Start the driver for initialization.
 	Start(*DriverParams) error
-	// Stop the driver for cleanup.
-	Stop() error
+	// Stop the driver related to given mount target for cleanup.
+	Stop(string) error
 	// Features Feature returns supported features.
 	Features() DriverFeature
 }

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -14,6 +14,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     pkg-config \
     squashfs-tools \
     squashfuse \
+    fuse2fs \
     fuse-overlayfs \
     fakeroot \
     cryptsetup \

--- a/tools/offsetpreload.c
+++ b/tools/offsetpreload.c
@@ -1,0 +1,80 @@
+/*
+  Copyright (c) Contributors to the Apptainer project, established as
+    Apptainer a Series of LF Projects LLC.
+    For website terms of use, trademark policy, privacy policy and other
+    project policies see https://lfprojects.org/policies
+
+  This software is licensed under a 3-clause BSD license.  Please
+  consult LICENSE.md file distributed with the sources of this project
+  regarding your rights to use or distribute this software.
+*/
+
+/*
+   LD_PRELOAD wrapper to add an offset into a file read by fuse2fs.
+   Set OFFSETPRELOAD_FILE to the path of the file and OFFSETPRELOAD_OFFSET
+     to the value of the offset.
+   This is not general purpose, it is specific to fuse2fs.
+*/
+
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+static int offsetfd = -3;
+static int offsetval;
+
+ssize_t pread64(int fd, void *buf, size_t count, off_t offset) {
+	static off_t (*original_pread64)(int, void *, size_t, off_t) = NULL;
+	if (original_pread64 == NULL) {
+		original_pread64 = dlsym(RTLD_NEXT, "pread64");
+	}
+
+	if (offsetfd == fd) {
+		offset += offsetval;
+	}
+
+	return (*original_pread64)(fd, buf, count, offset);
+}
+
+ssize_t pwrite64(int fd, const void *buf, size_t count, off_t offset) {
+	static off_t (*original_pwrite64)(int, const void *, size_t, off_t) = NULL;
+	if (original_pwrite64 == NULL) {
+		original_pwrite64 = dlsym(RTLD_NEXT, "pwrite64");
+	}
+
+	if (offsetfd == fd) {
+		offset += offsetval;
+	}
+
+	return (*original_pwrite64)(fd, buf, count, offset);
+}
+
+int __open64_2(const char *path, int flags1, int flags2, int flags3) {
+	static int (*original_open64_2)(const char*, int, int, int) = NULL;
+	if (original_open64_2 == NULL) {
+		original_open64_2 = dlsym(RTLD_NEXT, "__open64_2");
+	}
+
+	static char *offsetpath = NULL;
+	if (offsetfd == -3) {
+		offsetfd = -2;
+		offsetpath = getenv("OFFSETPRELOAD_FILE");
+		char *valenv = getenv("OFFSETPRELOAD_OFFSET");
+		if (valenv != NULL) {
+			offsetval = atoi(valenv);
+		}
+	}
+
+	int fd = (*original_open64_2)(path, flags1, flags2, flags3);
+
+	if (fd >= 0) {
+		if ((offsetpath != NULL) && (strcmp(offsetpath, path) == 0)) {
+			offsetfd = fd;
+		}
+	}
+
+	return fd;
+}


### PR DESCRIPTION
This adds a fuse2fs image driver for mounting EXT3 images.  It also adds a `--fakeroot` option to the `apptainer overlay create` command because that's needed when the fakeroot comes from only root-mapped user namespaces.  Unlike squashfuse, fuse2fs does not natively support working with offsets into a file, so in order to mount partitions of a SIF file I added a small LD_PRELOAD library that modifies its behavior.

Because a writable EXT3 filesystem needs to be unmounted cleanly to avoid requiring fsck, this includes a more robust umount function that unmounts everything in reverse order and waits for any fuse processes to complete before proceeding.

- Fixes #489

Does not yet require /usr/sbin/fuse2fs for rpm because it is not yet available on EL7.  I am in the final stages of getting a package for that approved for EPEL7.  It is installed by default on EL8 and later as part of the e2fsprogs package.

e2e tests will be added as part of #412.