### PR TITLE
Add --public/--private/--both flags when removing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   overrules both `--insecure` and `APPTAINER_ADD_INSECURE`.
 - Gpu flags `--nv` and `--rocm` can now be used from an apptainer nested
   inside another apptainer container.
+- Added `--public`, `--private`, `--both` flags for `key remove` command to 
+  support removing private keys from the apptainer keyring
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,8 +129,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   overrules both `--insecure` and `APPTAINER_ADD_INSECURE`.
 - Gpu flags `--nv` and `--rocm` can now be used from an apptainer nested
   inside another apptainer container.
-- Added `--public`, `--private`, `--both` flags for `key remove` command to 
-  support removing private keys from the apptainer keyring
+- Added `--public`, `--private`, `--both` flags for `key remove` command to
+  support removing private keys from the apptainer keyring.
 
 ### Bug fixes
 

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -28,6 +28,9 @@ var (
 	keySearchLongList   bool   // -l option for long-list
 	keyNewpairBitLength int    // -b option for bit length
 	keyGlobalPubKey     bool   // -g option to manage global public keys
+	keyRemovePublic     bool   //--public option to remove only public keys
+	keyRemovePrivate    bool   //--private option to remove only private keys
+	keyRemoveBoth       bool   //--both option to remove both public and private keys
 )
 
 // -u|--url
@@ -71,6 +74,36 @@ var keyGlobalPubKeyFlag = cmdline.Flag{
 	Usage:        "manage global public keys (import/pull/remove are restricted to root user or unprivileged installation only)",
 }
 
+//--public
+var keyRemovePublicKeyFlag = cmdline.Flag{
+	ID:           "keyRemovePublicKeyFlag",
+	Value:        &keyRemovePublic,
+	DefaultValue: false,
+	Name:         "public",
+	ShortHand:    "p",
+	Usage:        "remove public keys only",
+}
+
+//--private
+var keyRemovePrivateKeyFlag = cmdline.Flag{
+	ID:           "keyRemovePrivateKeyFlag",
+	Value:        &keyRemovePrivate,
+	DefaultValue: false,
+	Name:         "private",
+	ShortHand:    "r",
+	Usage:        "remove private keys only",
+}
+
+//--both
+var keyRemoveBothKeyFlag = cmdline.Flag{
+	ID:           "keyRemoveBothKeyFlag",
+	Value:        &keyRemoveBoth,
+	DefaultValue: false,
+	Name:         "both",
+	ShortHand:    "b",
+	Usage:        "remove both public and private keys",
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(KeyCmd)
@@ -99,6 +132,11 @@ func init() {
 			&keyGlobalPubKeyFlag,
 			KeyImportCmd, KeyExportCmd, KeyListCmd, KeyPullCmd, KeyPushCmd, KeyRemoveCmd,
 		)
+
+		// register public/private/both flags for KeyRemoveCmd only
+		cmdManager.RegisterFlagForCmd(&keyRemovePublicKeyFlag, KeyRemoveCmd)
+		cmdManager.RegisterFlagForCmd(&keyRemovePrivateKeyFlag, KeyRemoveCmd)
+		cmdManager.RegisterFlagForCmd(&keyRemoveBothKeyFlag, KeyRemoveCmd)
 	})
 }
 

--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -33,9 +33,23 @@ var KeyRemoveCmd = &cobra.Command{
 		}
 
 		keyring := sypgp.NewHandle(path, opts...)
-		err := keyring.RemovePubKey(args[0])
-		if err != nil {
-			sylog.Fatalf("Unable to remove public key: %s", err)
+
+		if (keyRemovePrivate && keyRemovePublic) || keyRemoveBoth {
+			pubErr := keyring.RemovePubKey(args[0])
+			priErr := keyring.RemovePrivKey(args[0])
+			if pubErr != nil && priErr != nil {
+				sylog.Fatalf("Unable to remove neither public key: %s, nor private key: %s", pubErr, priErr)
+			}
+		} else if keyRemovePrivate {
+			err := keyring.RemovePrivKey(args[0])
+			if err != nil {
+				sylog.Fatalf("Unable to remove private key: %s", err)
+			}
+		} else {
+			err := keyring.RemovePubKey(args[0])
+			if err != nil {
+				sylog.Fatalf("Unable to remove public key: %s", err)
+			}
 		}
 	},
 

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -508,14 +508,14 @@ func (c *ctx) apptainerKeyRemoveOpts(t *testing.T) {
 			exit:    0,
 		},
 		{
-			name:          "key list should return empty",
+			name:          "key list should return empty because all keys have been removed",
 			command:       "key list",
 			profile:       e2e.UserProfile,
 			expectedRegex: "^Public key listing.*\n",
 			exit:          0,
 		},
 		{
-			name:          "key list --secret should return empty",
+			name:          "key list --secret should return empty because all keys have been removed",
 			command:       "key list",
 			profile:       e2e.UserProfile,
 			args:          []string{"--secret"},
@@ -523,12 +523,26 @@ func (c *ctx) apptainerKeyRemoveOpts(t *testing.T) {
 			exit:          0,
 		},
 		{
-			name:               "remove private should fail",
+			name:               "remove private should fail because key does not exist in keyring",
 			command:            "key remove",
 			profile:            e2e.UserProfile,
 			args:               []string{"--private", keyMap["key1"]},
 			expectedErrorRegex: "FATAL:",
 			exit:               255,
+		},
+		{
+			name:    "import pubkey1 as global user (regression test)",
+			command: "key import",
+			profile: e2e.RootProfile,
+			args:    []string{"--global", "testdata/ecl-pgpkeys/pubkey1.asc"},
+			exit:    0,
+		},
+		{
+			name:    "remove pubkey1 from global (regression test)",
+			command: "key remove",
+			profile: e2e.RootProfile,
+			args:    []string{"--global", "--public", keyMap["key1"]},
+			exit:    0,
 		},
 	}
 

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -532,7 +532,7 @@ func (keyring *Handle) RemovePrivKey(toDelete string) error {
 		return fmt.Errorf("no key matching given fingerprint found")
 	}
 
-	sylog.Verbosef("updating local secret keyring: %v", keyring.SecretPath())
+	sylog.Verbosef("Updating local secret keyring: %v", keyring.SecretPath())
 
 	return keyring.storePrivKeyring(newKeyList)
 }

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -366,6 +366,28 @@ func (keyring *Handle) appendPrivateKey(e *openpgp.Entity) error {
 	return storePrivKeys(f, openpgp.EntityList{e})
 }
 
+// storePivKeyring overwrites the private keyring with the listed keys
+func (keyring *Handle) storePrivKeyring(keys openpgp.EntityList) error {
+	mode := os.FileMode(0o600)
+	if keyring.global {
+		return fmt.Errorf("global keyring can't container private keys")
+	}
+
+	f, err := createOrTruncateFile(keyring.SecretPath(), mode)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	for _, k := range keys {
+		if err := k.Serialize(f); err != nil {
+			return fmt.Errorf("could not store private key: %s", err)
+		}
+	}
+
+	return nil
+}
+
 // storePubKeys writes all the public keys in list to the writer w.
 func storePubKeys(w io.Writer, list openpgp.EntityList) error {
 	for _, e := range list {
@@ -492,6 +514,27 @@ func (keyring *Handle) RemovePubKey(toDelete string) error {
 	sylog.Verbosef("Updating local keyring: %v", keyring.PublicPath())
 
 	return keyring.storePubKeyring(newKeyList)
+}
+
+// RemovePrivKey will delete a private key matching toDelete
+func (keyring *Handle) RemovePrivKey(toDelete string) error {
+	elist, err := loadKeyring(keyring.SecretPath())
+	switch {
+	case os.IsNotExist(err):
+		return nil
+
+	case err != nil:
+		return fmt.Errorf("unable to list local secret keyring: %v", err)
+	}
+
+	newKeyList := removeKey(elist, toDelete)
+	if newKeyList == nil {
+		return fmt.Errorf("no key matching given fingerprint found")
+	}
+
+	sylog.Verbosef("updating local secret keyring: %v", keyring.SecretPath())
+
+	return keyring.storePrivKeyring(newKeyList)
 }
 
 func (keyring *Handle) genKeyPair(opts GenKeyPairOptions) (*openpgp.Entity, error) {


### PR DESCRIPTION
## Description of the Pull Request (PR):
As requested in this issue
https://github.com/apptainer/apptainer/issues/465
to support removing private keys from apptainer keyring.

### This fixes or addresses the following GitHub issues:

 - Fixes https://github.com/apptainer/apptainer/issues/465


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
