### PR TITLE
ci: add Rocky 9 package build, from sylabs 920

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,21 @@ jobs:
           GO_ARCH: linux-amd64
         run: ./scripts/ci-docker-run
 
+  rpmbuild-rocky9:
+    runs-on: ubuntu-20.04
+    name: rpmbuild-rocky9
+    steps:
+      - uses: actions/checkout@v2
+      # fetch tags as checkout@v2 doesn't do that by default
+      - run: git fetch --prune --unshallow --tags --force
+
+      - name: Build and test rpm under docker
+        env:
+          OS_TYPE: rockylinux
+          OS_VERSION: 9
+          GO_ARCH: linux-amd64
+        run: ./scripts/ci-docker-run
+
   short_unit_tests:
     name: short_unit_tests
     runs-on: ubuntu-20.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Debug output can now be enabled by setting the `APPTAINER_DEBUG` env var.
 - Debug output is now shown for nested `apptainer` calls, in wrapped
   `unsquashfs` image extraction, and build stages.
+- Added EL9 package builds to CI for GitHub releases.
 
 ### Bug fixes
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#920

The original PR description was:
> ci: add almalinux 9 package build (release-3.10)