### PR TITLE
e2e: correct docker --no-eval no args test cases, from sylabs 924

### DIFF
--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -508,7 +508,7 @@ func (c ctx) testDockerCMD(t *testing.T) {
 		{
 			name:         "no-eval/default",
 			args:         []string{},
-			noeval:       false,
+			noeval:       true,
 			expectOutput: `CMD 'quotes' "quotes" $DOLLAR s p a c e s`,
 		},
 		{
@@ -600,7 +600,7 @@ func (c ctx) testDockerENTRYPOINT(t *testing.T) {
 		{
 			name:         "no-eval/default",
 			args:         []string{},
-			noeval:       false,
+			noeval:       true,
 			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s`,
 		},
 		{
@@ -686,7 +686,7 @@ func (c ctx) testDockerCMDENTRYPOINT(t *testing.T) {
 		{
 			name:         "no-eval/default",
 			args:         []string{},
-			noeval:       false,
+			noeval:       true,
 			expectOutput: `ENTRYPOINT 'quotes' "quotes" $DOLLAR s p a c e s CMD 'quotes' "quotes" $DOLLAR s p a c e s`,
 		},
 		{


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#924
 which fixed
- sylabs/singularity#922

The original PR description was:
> e2e: correct docker --no-eval no args test cases