### PR TITLE
Inconsistent key command private / secret flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   overrules both `--insecure` and `APPTAINER_ADD_INSECURE`.
 - Gpu flags `--nv` and `--rocm` can now be used from an apptainer nested
   inside another apptainer container.
-- Added `--public`, `--private`, `--both` flags for `key remove` command to
+- Added `--public`, `--secret`, `--both` flags for `key remove` command to
   support removing private keys from the apptainer keyring.
 - Debug output can now be enabled by setting the `APPTAINER_DEBUG` env var.
 - Debug output is now shown for nested `apptainer` calls, in wrapped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Gpu flags `--nv` and `--rocm` can now be used from an apptainer nested
   inside another apptainer container.
 - Added `--public`, `--secret`, `--both` flags for `key remove` command to
-  support removing private keys from the apptainer keyring.
+  support removing secret keys from the apptainer keyring.
 - Debug output can now be enabled by setting the `APPTAINER_DEBUG` env var.
 - Debug output is now shown for nested `apptainer` calls, in wrapped
   `unsquashfs` image extraction, and build stages.

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -84,13 +84,13 @@ var keyRemovePublicKeyFlag = cmdline.Flag{
 	Usage:        "remove public keys only",
 }
 
-//--private
+//--secret
 var keyRemovePrivateKeyFlag = cmdline.Flag{
 	ID:           "keyRemovePrivateKeyFlag",
 	Value:        &keyRemovePrivate,
 	DefaultValue: false,
-	Name:         "private",
-	ShortHand:    "r",
+	Name:         "secret",
+	ShortHand:    "s",
 	Usage:        "remove private keys only",
 }
 

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -91,7 +91,7 @@ var keyRemovePrivateKeyFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "secret",
 	ShortHand:    "s",
-	Usage:        "remove private keys only",
+	Usage:        "remove secret keys only",
 }
 
 //--both

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -460,7 +460,7 @@ func (c *ctx) apptainerKeyRemoveOpts(t *testing.T) {
 			exit:    0,
 		},
 		{
-			name:    "remove public should succeed",
+			name:    "remove public key should succeed",
 			command: "key remove",
 			profile: e2e.UserProfile,
 			args:    []string{"--public", keyMap["key1"]},
@@ -484,7 +484,7 @@ func (c *ctx) apptainerKeyRemoveOpts(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name:    "remove private should succeed",
+			name:    "remove secret key should succeed",
 			command: "key remove",
 			profile: e2e.UserProfile,
 			args:    []string{"--secret", keyMap["key1"]},
@@ -523,7 +523,7 @@ func (c *ctx) apptainerKeyRemoveOpts(t *testing.T) {
 			exit:          0,
 		},
 		{
-			name:               "remove private should fail because key does not exist in keyring",
+			name:               "remove secret key should fail because key does not exist in keyring",
 			command:            "key remove",
 			profile:            e2e.UserProfile,
 			args:               []string{"--secret", keyMap["key1"]},

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -487,7 +487,7 @@ func (c *ctx) apptainerKeyRemoveOpts(t *testing.T) {
 			name:    "remove private should succeed",
 			command: "key remove",
 			profile: e2e.UserProfile,
-			args:    []string{"--private", keyMap["key1"]},
+			args:    []string{"--secret", keyMap["key1"]},
 			exit:    0,
 		},
 		{
@@ -526,7 +526,7 @@ func (c *ctx) apptainerKeyRemoveOpts(t *testing.T) {
 			name:               "remove private should fail because key does not exist in keyring",
 			command:            "key remove",
 			profile:            e2e.UserProfile,
-			args:               []string{"--private", keyMap["key1"]},
+			args:               []string{"--secret", keyMap["key1"]},
 			expectedErrorRegex: "FATAL:",
 			exit:               255,
 		},
@@ -782,7 +782,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ordered": func(t *testing.T) {
 			t.Run("keyCmd", c.apptainerKeyCmd)                       // Run all the tests in order
 			t.Run("keyNewpairWithLen", c.apptainerKeyNewpairWithLen) // We run a separate test for `key newpair --bit-length` because it requires handling a keyring a specific way
-			t.Run("keyRemoveOpts", c.apptainerKeyRemoveOpts)         // run a separated test for `key remove --public/--private/--both`
+			t.Run("keyRemoveOpts", c.apptainerKeyRemoveOpts)         // run a separated test for `key remove --public/--secret/--both`
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

Change the `--private` flag of `key remove` command to `--secret` to maintain consistency. 


### This fixes or addresses the following GitHub issues:

 - Fixes # https://github.com/apptainer/apptainer/issues/567


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
