### PR TITLE
Refactor pkg/sypgp to remove environment variable parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
     to check version that container was built with*.
 - Added `--no-eval` to the list of flags set by the OCI/Docker `--compat` mode.
 - `sinit` process has been renamed to `appinit`.
+- Added `--keysdir` to `key` command to provide an alternative way of setting
+  local keyring path, existing reading keyring path from environment variable
+  'APPTAINER_KEYSDIR' is untouched.
 
 ### New features / functionalities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Added `--no-eval` to the list of flags set by the OCI/Docker `--compat` mode.
 - `sinit` process has been renamed to `appinit`.
 - Added `--keysdir` to `key` command to provide an alternative way of setting
-  local keyring path, existing reading keyring path from environment variable
+  local keyring path. The existing reading keyring path from environment variable
   'APPTAINER_KEYSDIR' is untouched.
 
 ### New features / functionalities

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -114,7 +114,6 @@ var keyLocalDirKeyFlag = cmdline.Flag{
 	Name:         "keysdir",
 	ShortHand:    "d",
 	Usage:        "set local keyring dir path, an alternative way is to set environment variable 'APPTAINER_KEYSDIR'",
-	Hidden:       true,
 }
 
 func init() {

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/apptainer/apptainer/docs"
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
+	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/starter"
 	"github.com/apptainer/apptainer/pkg/cmdline"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -31,6 +32,7 @@ var (
 	keyRemovePublic     bool   //--public option to remove only public keys
 	keyRemovePrivate    bool   //--private option to remove only private keys
 	keyRemoveBoth       bool   //--both option to remove both public and private keys
+	keyLocalDir         string //--keysdir option for local key dir path
 )
 
 // -u|--url
@@ -104,6 +106,17 @@ var keyRemoveBothKeyFlag = cmdline.Flag{
 	Usage:        "remove both public and private keys",
 }
 
+//--keysdir
+var keyLocalDirKeyFlag = cmdline.Flag{
+	ID:           "keyLocalDirKeyFlag",
+	Value:        &keyLocalDir,
+	DefaultValue: env.DefaultLocalKeyDirPath(),
+	Name:         "keysdir",
+	ShortHand:    "d",
+	Usage:        "set local keyring dir path, an alternative way is to set environment variable 'APPTAINER_KEYSDIR'",
+	Hidden:       true,
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(KeyCmd)
@@ -128,9 +141,16 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&keyNewpairBitLengthFlag, KeyNewPairCmd)
 		cmdManager.RegisterFlagForCmd(&keyImportWithNewPasswordFlag, KeyImportCmd)
 
+		cmdManager.SetCmdGroup("key_group_cmd", KeyImportCmd, KeyExportCmd, KeyListCmd, KeyPullCmd, KeyPushCmd, KeyRemoveCmd)
+
 		cmdManager.RegisterFlagForCmd(
 			&keyGlobalPubKeyFlag,
-			KeyImportCmd, KeyExportCmd, KeyListCmd, KeyPullCmd, KeyPushCmd, KeyRemoveCmd,
+			cmdManager.GetCmdGroup("key_group_cmd")...,
+		)
+
+		cmdManager.RegisterFlagForCmd(
+			&keyLocalDirKeyFlag,
+			append(cmdManager.GetCmdGroup("key_group_cmd"), KeyNewPairCmd)...,
 		)
 
 		// register public/private/both flags for KeyRemoveCmd only

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -68,7 +68,7 @@ var KeyExportCmd = &cobra.Command{
 
 func exportRun(cmd *cobra.Command, args []string) {
 	var opts []sypgp.HandleOpt
-	path := ""
+	path := keyLocalDir
 
 	if keyGlobalPubKey {
 		path = buildcfg.APPTAINER_CONFDIR

--- a/cmd/internal/cli/key_import.go
+++ b/cmd/internal/cli/key_import.go
@@ -47,7 +47,7 @@ var (
 
 func importRun(cmd *cobra.Command, args []string) {
 	var opts []sypgp.HandleOpt
-	path := ""
+	path := keyLocalDir
 
 	if keyGlobalPubKey {
 		path = buildcfg.APPTAINER_CONFDIR

--- a/cmd/internal/cli/key_list.go
+++ b/cmd/internal/cli/key_list.go
@@ -58,7 +58,7 @@ var KeyListCmd = &cobra.Command{
 
 func doKeyListCmd(secret bool) error {
 	var opts []sypgp.HandleOpt
-	path := ""
+	path := keyLocalDir
 
 	if keyGlobalPubKey {
 		path = buildcfg.APPTAINER_CONFDIR

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -93,7 +93,8 @@ type keyNewPairOptions struct {
 }
 
 func runNewPairCmd(cmd *cobra.Command, args []string) {
-	keyring := sypgp.NewHandle("")
+	path := keyLocalDir
+	keyring := sypgp.NewHandle(path)
 
 	opts, err := collectInput(cmd)
 	if err != nil {

--- a/cmd/internal/cli/key_pull.go
+++ b/cmd/internal/cli/key_pull.go
@@ -50,7 +50,7 @@ var KeyPullCmd = &cobra.Command{
 func doKeyPullCmd(ctx context.Context, fingerprint string, co ...client.Option) error {
 	var count int
 	var opts []sypgp.HandleOpt
-	path := ""
+	path := keyLocalDir
 	mode := os.FileMode(0o600)
 
 	if keyGlobalPubKey {

--- a/cmd/internal/cli/key_push.go
+++ b/cmd/internal/cli/key_push.go
@@ -49,7 +49,7 @@ var KeyPushCmd = &cobra.Command{
 
 func doKeyPushCmd(ctx context.Context, fingerprint string, co ...client.Option) error {
 	var opts []sypgp.HandleOpt
-	path := ""
+	path := keyLocalDir
 
 	if keyGlobalPubKey {
 		path = buildcfg.APPTAINER_CONFDIR

--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -25,7 +25,7 @@ var KeyRemoveCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		var opts []sypgp.HandleOpt
-		path := ""
+		path := keyLocalDir
 
 		if keyGlobalPubKey {
 			path = buildcfg.APPTAINER_CONFDIR

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -164,7 +164,7 @@ func (c *ctx) apptainerKeyNewpair(t *testing.T) {
 		{
 			name:   "newpair help",
 			args:   []string{"newpair", "--help"},
-			stdout: "^Create a new key pair",
+			stdout: "Create a new key pair",
 		},
 		{
 			name: "newpair",
@@ -187,7 +187,7 @@ func (c *ctx) apptainerKeyNewpair(t *testing.T) {
 			e2e.ConsoleRun(buildConsoleLines(tt.consoleOps...)...),
 			e2e.WithCommand("key"),
 			e2e.WithArgs(tt.args...),
-			e2e.ExpectExit(0, e2e.ExpectOutput(e2e.RegexMatch, tt.stdout)),
+			e2e.ExpectExit(0, e2e.ExpectOutput(e2e.ContainMatch, tt.stdout)),
 		)
 	}
 }
@@ -764,7 +764,6 @@ func (c *ctx) apptainerLocalKeyDirFlagRegression(t *testing.T) {
 		consoleOps []string
 		resultOp   []e2e.ApptainerCmdResultOp
 		exit       int
-		stdout     string
 	}{
 		{
 			name:    "newpair regression with customized keydirs",
@@ -783,8 +782,10 @@ func (c *ctx) apptainerLocalKeyDirFlagRegression(t *testing.T) {
 			name:    "key list regression test should succeed and return value",
 			command: "key list",
 			args:    []string{"--secret", "--keysdir", keysdir},
-			stdout:  "e2e test key",
-			exit:    0,
+			resultOp: []e2e.ApptainerCmdResultOp{
+				e2e.ExpectOutput(e2e.ContainMatch, "e2e test key"),
+			},
+			exit: 0,
 		},
 		{
 			name:    "key list regression test should succeed but shoud return nothing because keysdir value is invalid",

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -68,6 +68,8 @@ func GetenvLegacy(key, legacyKey string) string {
 		if val != "" {
 			sylog.Warningf("DEPRECATED USAGE: Environment variable %s will not be supported in the future, use %s instead", legacyKeyEnv, keyEnv)
 		}
+	} else if os.Getenv(legacyKeyEnv) != "" && os.Getenv(legacyKeyEnv) != val {
+		sylog.Warningf("%s and %s have different values, using the latter", legacyKeyEnv, keyEnv)
 	}
 
 	return val

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -12,8 +12,10 @@ package env
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
@@ -26,6 +28,9 @@ const (
 
 	// ApptainerEnvPrefix Apptainer environment variables recognized prefixes for passthru to container
 	ApptainerEnvPrefix = "APPTAINERENV_"
+
+	// DefaultLocalKeyDirName represents the default local key storage folder name
+	DefaultLocalKeyDirName = "keys"
 )
 
 // ApptainerPrefixes the following prefixes are for settings looked at by Apptainer command
@@ -73,4 +78,12 @@ func GetenvLegacy(key, legacyKey string) string {
 // TrimApptainerKey returns the key without APPTAINER_ prefix.
 func TrimApptainerKey(key string) string {
 	return strings.TrimPrefix(key, ApptainerPrefixes[0])
+}
+
+func DefaultLocalKeyDirPath() string {
+	// read this as: look for APPTAINER_KEYSDIR and/or SINGULARITY_SYPGPDIR
+	if dir := GetenvLegacy("KEYSDIR", "SYPGPDIR"); dir != "" {
+		return dir
+	}
+	return filepath.Join(syfs.ConfigDir(), DefaultLocalKeyDirName)
 }

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -68,8 +68,6 @@ func GetenvLegacy(key, legacyKey string) string {
 		if val != "" {
 			sylog.Warningf("DEPRECATED USAGE: Environment variable %s will not be supported in the future, use %s instead", legacyKeyEnv, keyEnv)
 		}
-	} else if os.Getenv(legacyKeyEnv) != val {
-		sylog.Warningf("%s and %s have different values, using the latter", legacyKeyEnv, keyEnv)
 	}
 
 	return val

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -29,8 +29,8 @@ const (
 	// ApptainerEnvPrefix Apptainer environment variables recognized prefixes for passthru to container
 	ApptainerEnvPrefix = "APPTAINERENV_"
 
-	// DefaultLocalKeyDirName represents the default local key storage folder name
-	DefaultLocalKeyDirName = "keys"
+	// defaultLocalKeyDirName represents the default local key storage folder name
+	defaultLocalKeyDirName = "keys"
 )
 
 // ApptainerPrefixes the following prefixes are for settings looked at by Apptainer command
@@ -85,5 +85,5 @@ func DefaultLocalKeyDirPath() string {
 	if dir := GetenvLegacy("KEYSDIR", "SYPGPDIR"); dir != "" {
 		return dir
 	}
-	return filepath.Join(syfs.ConfigDir(), DefaultLocalKeyDirName)
+	return filepath.Join(syfs.ConfigDir(), defaultLocalKeyDirName)
 }

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -106,15 +106,6 @@ func GetTokenFile() string {
 	return filepath.Join(syfs.ConfigDir(), "sylabs-token")
 }
 
-// dirPath returns a string describing the path to the sypgp home folder
-func dirPath() string {
-	// read this as: look for APPTAINER_KEYSDIR and/or SINGULARITY_SYPGPDIR
-	if dir := env.GetenvLegacy("KEYSDIR", "SYPGPDIR"); dir != "" {
-		return dir
-	}
-	return filepath.Join(syfs.ConfigDir(), Directory)
-}
-
 // NewHandle initializes a new keyring in path.
 func NewHandle(path string, opts ...HandleOpt) *Handle {
 	newHandle := new(Handle)
@@ -128,7 +119,7 @@ func NewHandle(path string, opts ...HandleOpt) *Handle {
 		if newHandle.global {
 			panic("global public keyring requires a path")
 		}
-		newHandle.path = dirPath()
+		newHandle.path = env.DefaultLocalKeyDirPath()
 	}
 
 	return newHandle


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

Add hidden flag `--keysdir` to `apptainer key` command to provide an alternative way of setting local keyring path.


### This fixes or addresses the following GitHub issues:

 - Fixes # https://github.com/apptainer/apptainer/issues/207


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
