### PR TITLE
Patch GetenvLegacy in env.go to suppress frequent warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Bug fixes
 
+- Remove warning message about SINGULARITY and APPTAINER variables having
+  different values when the SINGULARITY variable is not set.
 - Add specific error for unreadable image / overlay file.
 - Pass through a literal `\n` in host environment variables to container.
 - Allow `newgidmap / newuidmap` that use capabilities instead of setuid root.

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -63,7 +63,7 @@ func GetenvLegacy(key, legacyKey string) string {
 		if val != "" {
 			sylog.Warningf("DEPRECATED USAGE: Environment variable %s will not be supported in the future, use %s instead", legacyKeyEnv, keyEnv)
 		}
-	} else if os.Getenv(legacyKeyEnv) != val {
+	} else if os.Getenv(legacyKeyEnv) != "" && os.Getenv(legacyKeyEnv) != val {
 		sylog.Warningf("%s and %s have different values, using the latter", legacyKeyEnv, keyEnv)
 	}
 


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

```
WARNING: SINGULARITY_CACHEDIR and APPTAINER_CACHEDIR have different values, using the latter
```

Patch GetenvLegacy in env.go to suppress frequent warning message


### This fixes or addresses the following GitHub issues:

 - Fixes # https://github.com/apptainer/apptainer/issues/474


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
