### PR TITLE
Add confURL & include to Arch packer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Debug output is now shown for nested `apptainer` calls, in wrapped
   `unsquashfs` image extraction, and build stages.
 - Added EL9 package builds to CI for GitHub releases.
+- Add confURL & Include parameters to Arch packer for alternate `pacman.conf`
+  URL and alternate installed (meta)package.
 
 ### Bug fixes
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -92,4 +92,5 @@
 - Chen Yiyang <cyyzero@qq.com>
 - Pablo Caderno <kaderno@gmail.com>
 - Xu Yang <jasonyangshadow@gmail.com>
+- Charles Vejnar <charles.vejnar@gmail.com>
 ```

--- a/examples/arch/README.md
+++ b/examples/arch/README.md
@@ -1,16 +1,18 @@
 # Arch for Apptainer
 
-This bootstrap spec will generate an arch linux distribution using Apptainer
-2.3 (current development branch). Note that you can also just bootstrap a Docker
-image:
+This bootstrap spec will generate an Archlinux distribution using Apptainer.
+Note that you can also just bootstrap a Docker image. By default, the metapackage
+`base` gets installed. It can be changed using the `Include` parameter (add it
+below `Bootstrap`). Similarly, `pacman` configuration can be changed by
+specifying a URL to get `pacman.conf` in the `confURL` parameter.
 
 If you want to move forward with the raw, old school, jeans and hard toes
 bootstrap, here is what to do. I work on an Ubuntu machine, so I had to use a
-Docker Arch Linux image to do this. This first part you should do on your local
-machine (if not arch linux) is to use Docker to interactively work in an Arch
-Linux image. If you don't want to copy paste the build spec file, you can use
-`--volume` to mount a directory from your host to a folder in the image (I would
-recommend `/tmp` or similar). Here we run the docker image:
+Docker Archlinux image to do this. This first part you should do on your local
+machine (if not Archlinux) is to use Docker to interactively work in an Archlinux
+image. If you don't want to copy paste the build spec file, you can use `--volume`
+to mount a directory from your host to a folder in the image (I would recommend
+`/tmp` or similar). Here we run the docker image:
 
 ```bash
 docker run -it  --privileged pritunl/archlinux bash
@@ -18,13 +20,7 @@ docker run -it  --privileged pritunl/archlinux bash
 
 ```bash
 pacman -S -y git autoconf libtool automake gcc python make sudo vim \
- arch-install-scripts wget
-git clone https://github.com/apptainer/apptainer
-cd apptainer
-git checkout -b development
-git pull origin development
-./autogen.sh
-./configure --prefix=/usr/local
+ arch-install-scripts wget apptainer
 ```
 
 You can add the [Apptainer](Apptainer) build spec here, or cd to where it is

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -593,4 +593,5 @@ var validHeaders = map[string]bool{
 	"modules":      true,
 	"otherurl&n":   true,
 	"fingerprints": true,
+	"confurl":      true,
 }


### PR DESCRIPTION
Signed-off-by: vejnar <charles.vejnar@gmail.com>

## Description of the Pull Request (PR):

Building an Arch-based container uses (i) the default Pacman configuration provided by Archlinux and (ii) install the `base` metapackage. This PR allows both of these options to be configured by user by adding the following parameters: 
* `confurl`. I added this new parameter name as none of the existing ones seemed to be appropriate.
* `include`. For building package for Archlinux, only `base-devel` (not `base`) is required. With this option, Apptainer will be usable to build proper package for Arch. I reused this parameter name as it was used in the same context of package installation.

Both parameters aren't mandatory and defaults are kept unchanged.
