### PR TITLE
Print key server response if included by server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
     to check version that container was built with*.
 - Added `--no-eval` to the list of flags set by the OCI/Docker `--compat` mode.
 - `sinit` process has been renamed to `appinit`.
+- `apptainer key push` will output the key server's response if included in
+  order to help guide users through any identity verification the server may
+  require.
 
 ### New features / functionalities
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20220517143526-88bb52951d5b
 	github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60
 	github.com/apex/log v1.9.0
-	github.com/apptainer/container-key-client v0.7.3
+	github.com/apptainer/container-key-client v0.8.0
 	github.com/apptainer/container-library-client v1.3.3
 	github.com/apptainer/sif/v2 v2.7.1
 	github.com/blang/semver/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/apex/logs v0.0.7/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDw
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
-github.com/apptainer/container-key-client v0.7.3 h1:7M4CQOnN5ss1NReIe4v3C+noQvOP5ULATuh8rxooq3Q=
-github.com/apptainer/container-key-client v0.7.3/go.mod h1:wMeJdiMXlPRiwJfUyae2WRHsZlHG9Af6iPQ9TZcBnS8=
+github.com/apptainer/container-key-client v0.8.0 h1:K181Zrejb53mR2YQZwCathSj8YReCen+Wi2YuBxGH60=
+github.com/apptainer/container-key-client v0.8.0/go.mod h1:wMeJdiMXlPRiwJfUyae2WRHsZlHG9Af6iPQ9TZcBnS8=
 github.com/apptainer/container-library-client v1.3.3 h1:xd0/27nB8mAtyJAwG/7tTOoWAhjMiZPyZy4fzzQHMak=
 github.com/apptainer/container-library-client v1.3.3/go.mod h1:B+ARx/+WaE/E2pkv2qZUQeoEBO89PUpmLKsTJmbM5eQ=
 github.com/apptainer/sif/v2 v2.7.1 h1:SOKVYyAzkZoixFWUNs2I/p6fc1ZRwYbes/6guN/jAt8=


### PR DESCRIPTION
## Description of the Pull Request (PR):

This will help guide users through the process of verifying their identity
for key servers that require it.

Updates github.com/apptainer/container-key-client to v0.8.0

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>


Example output:
```
$ apptainer key  push --url http://127.0.0.1:8080 8232570480B868E1473AEEB03DBCBA1EE9D661E5
INFO:    Key server response: Upload successful. Please note that identity information will only be published after verification. See http://localhost:8080/about/usage#gnupg-upload
public key `8232570480B868E1473AEEB03DBCBA1EE9D661E5' pushed to server successfully
```


### This fixes or addresses the following GitHub issues:

 - Fixes #20


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
