### PR TITLE
feat: Targeted ECL signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,18 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - `apptainer key push` will output the key server's response if included in
   order to help guide users through any identity verification the server may
   require.
+- ECL no longer requires verification for all signatures, but only
+  when signature verification would alter the expected behavior of the
+  list:
+  - At least one matching signature included in a whitelist must be
+    validated, but other unvalidated signatures do not cause ECL to
+    fail.
+  - All matching signatures included in a whitestrict must be
+    validated, but unvalidated signatures not in the whitestrict do
+    not cause ECL to fail.
+  - Signature verification is not checked for a blacklist; unvalidated
+    signatures can still block execution via ECL, and unvalidated
+    signatures not in the blacklist do not cause ECL to fail.
 
 ### New features / functionalities
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@
 - Jeff Kriske <jekriske@gmail.com>
 - Jia Li <jiali@sylabs.io>
 - Joana Chavez <joana@sylabs.io>, <j.chavezlavalle@gmail.com>
+- Jonathon Anderson <janderson@ciq.co>
 - Josef Hrabal <josef.hrabal@vsb.cz>
 - Justin Cook <justin@sylabs.io>
 - Justin Riley <justin_riley@harvard.edu>

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/apex/log v1.9.0
 	github.com/apptainer/container-key-client v0.8.0
 	github.com/apptainer/container-library-client v1.3.3
-	github.com/apptainer/sif/v2 v2.7.1
+	github.com/apptainer/sif/v2 v2.7.2
 	github.com/blang/semver/v4 v4.0.0
 	github.com/buger/jsonparser v1.1.1
 	github.com/cenkalti/backoff/v4 v4.1.3
@@ -57,6 +57,7 @@ require (
 
 require (
 	github.com/docker/distribution v2.8.1+incompatible
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/sirupsen/logrus v1.9.0
 )
 
@@ -103,7 +104,6 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/apptainer/container-key-client v0.8.0 h1:K181Zrejb53mR2YQZwCathSj8YRe
 github.com/apptainer/container-key-client v0.8.0/go.mod h1:wMeJdiMXlPRiwJfUyae2WRHsZlHG9Af6iPQ9TZcBnS8=
 github.com/apptainer/container-library-client v1.3.3 h1:xd0/27nB8mAtyJAwG/7tTOoWAhjMiZPyZy4fzzQHMak=
 github.com/apptainer/container-library-client v1.3.3/go.mod h1:B+ARx/+WaE/E2pkv2qZUQeoEBO89PUpmLKsTJmbM5eQ=
-github.com/apptainer/sif/v2 v2.7.1 h1:SOKVYyAzkZoixFWUNs2I/p6fc1ZRwYbes/6guN/jAt8=
-github.com/apptainer/sif/v2 v2.7.1/go.mod h1:Fv2WlhhLFTHNj3w++tpoUREQ4tngMCQxdqFwFZMOEtw=
+github.com/apptainer/sif/v2 v2.7.2 h1:gVzaGxLDadwi/RtevtzdS/jTTzHoUljYWGYz/TQdl9Y=
+github.com/apptainer/sif/v2 v2.7.2/go.mod h1:cSKZHNNrtVAzpi4INlGlp6mONYLsvV1z/CjlThKRV2c=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
## Description of the Pull Request (PR):

Only fail ECL checks for unvalidated signatures when the signature is required to permit access.

- At least one matching signature included in a whitelist must be validated, but other unvalidated signatures do not cause ECL to fail.

- All matching signatures included in a whitestrict must be validated, but unvalidated signatures not in the whitestrict do not cause ECL to fail.

- Signature verification is not checked for a blacklist; unvalidated signatures can still block execution via ECL, and unvalidated signatures not in the blacklist do not cause ECL to fail.

The implementation makes direct a dependency on https://github.com/hashicorp/go-multierror to unpack the multierror returned by SIF (as added at https://github.com/apptainer/sif/commit/1a43a33dde6a381b69a758482bd8689d50abd9c8).


### This fixes or addresses the following GitHub issues:

 - Fixes #463 


#### Before submitting a PR, make sure you have done the following:

- ~Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.~
- ~Signed-Off~
- ~Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)~
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- ~Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)~
- ~Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)~
