### PR TITLE
Replacing usage of '/bin/bash' inside exec.command with mvdan.cc library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes since last release
+
+- Improved wildcard matching in the %files directive of build definition
+  files by replacing usage of sh with the mvdan.cc library.
+
 ## v1.1.0-rc.1 - \[2022-08-01\]
 
 ### Changed defaults / behaviours

--- a/internal/pkg/build/files/files_test.go
+++ b/internal/pkg/build/files/files_test.go
@@ -185,7 +185,7 @@ func TestExpandPath(t *testing.T) {
 		{
 			name:    "hiddenFileWildcards",
 			path:    "dirL1/.*",
-			correct: []string{"dirL1/.", "dirL1/..", "dirL1/.dirL2", "dirL1/.file"},
+			correct: []string{"dirL1/.dirL2", "dirL1/.file"},
 		},
 		{
 			name:    "hiddenDirWildcards",


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

Replacing the exec.command with mvdan.cc code.


### This fixes or addresses the following GitHub issues:

 - Fixes #19 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
