### PR TITLE
Fix `--nvccli` for unprivileged use without `--fakeroot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Improved wildcard matching in the %files directive of build definition
   files by replacing usage of sh with the mvdan.cc library.
+- The `--nvccli` option now works without `--fakeroot`.  In that case the
+  option can be used with `--writable-tmpfs` instead of `--writable`,
+  and `--writable-tmpfs` is implied if neither option is given.
+  Note that also `/usr/bin` has to be writable by the user, so without
+  `--fakeroot` that probably requires a sandbox image that was built with
+  `--fix-perms`.
+- The `--nvccli` option implies `--nv`.
 
 ## v1.1.0-rc.1 - \[2022-08-01\]
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -906,6 +906,11 @@ func SetGPUConfig(engineConfig *apptainerConfig.EngineConfig) error {
 		sylog.Verbosef("'always use rocm = yes' found in apptainer.conf")
 	}
 
+	if NvCCLI && !Nvidia {
+		sylog.Debugf("implying --nv from --nvccli")
+		Nvidia = true
+	}
+
 	if Nvidia && Rocm {
 		sylog.Warningf("--nv and --rocm cannot be used together. Only --nv will be applied.")
 	}
@@ -959,9 +964,6 @@ func setNvCCLIConfig(engineConfig *apptainerConfig.EngineConfig) (err error) {
 	}
 	engineConfig.SetNvCCLIEnv(nvCCLIEnv)
 
-	if UserNamespace && !IsWritable {
-		return fmt.Errorf("nvidia-container-cli requires --writable with user namespace/fakeroot")
-	}
 	if !IsWritable && !IsWritableTmpfs {
 		sylog.Infof("Setting --writable-tmpfs (required by nvidia-container-cli)")
 		IsWritableTmpfs = true

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -140,21 +140,21 @@ func (c ctx) testNvCCLI(t *testing.T) {
 		{
 			name:       "User",
 			profile:    e2e.RootProfile,
-			args:       []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
+			args:       []string{"--nvccli", imagePath, "nvidia-smi"},
 			expectExit: 0,
 		},
 		{
 			// With --contain, we should only see NVIDIA_VISIBLE_DEVICES configured GPUs
 			name:        "UserContainNoDevices",
 			profile:     e2e.RootProfile,
-			args:        []string{"--contain", "--nv", "--nvccli", imagePath, "nvidia-smi"},
+			args:        []string{"--contain", "--nvccli", imagePath, "nvidia-smi"},
 			expectMatch: e2e.ExpectOutput(e2e.ContainMatch, "No devices were found"),
 			expectExit:  6,
 		},
 		{
 			name:       "UserContainAllDevices",
 			profile:    e2e.RootProfile,
-			args:       []string{"--contain", "--nv", "--nvccli", imagePath, "nvidia-smi"},
+			args:       []string{"--contain", "--nvccli", imagePath, "nvidia-smi"},
 			env:        []string{"NVIDIA_VISIBLE_DEVICES=all"},
 			expectExit: 0,
 		},
@@ -162,7 +162,7 @@ func (c ctx) testNvCCLI(t *testing.T) {
 			// If we only request compute, not utility, then nvidia-smi should not be present
 			name:        "UserNoUtility",
 			profile:     e2e.RootProfile,
-			args:        []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
+			args:        []string{"--nvccli", imagePath, "nvidia-smi"},
 			env:         []string{"NVIDIA_DRIVER_CAPABILITIES=compute"},
 			expectMatch: e2e.ExpectError(e2e.ContainMatch, "\"nvidia-smi\": executable file not found in $PATH"),
 			expectExit:  255,
@@ -171,7 +171,7 @@ func (c ctx) testNvCCLI(t *testing.T) {
 			// Require CUDA version >8 should be fine!
 			name:       "UserValidRequire",
 			profile:    e2e.RootProfile,
-			args:       []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
+			args:       []string{"--nvccli", imagePath, "nvidia-smi"},
 			env:        []string{"NVIDIA_REQUIRE_CUDA=cuda>8"},
 			expectExit: 0,
 		},
@@ -179,7 +179,7 @@ func (c ctx) testNvCCLI(t *testing.T) {
 			// Require CUDA version >999 should not be satisfied
 			name:        "UserInvalidRequire",
 			profile:     e2e.RootProfile,
-			args:        []string{"--nv", "--nvccli", imagePath, "nvidia-smi"},
+			args:        []string{"--nvccli", imagePath, "nvidia-smi"},
 			env:         []string{"NVIDIA_REQUIRE_CUDA=cuda>999"},
 			expectMatch: e2e.ExpectError(e2e.ContainMatch, "requirement error: unsatisfied condition: cuda>99"),
 			expectExit:  255,
@@ -187,7 +187,17 @@ func (c ctx) testNvCCLI(t *testing.T) {
 		{
 			name:    "UserNamespace",
 			profile: e2e.UserNamespaceProfile,
-			args:    []string{"--nv", "--nvccli", "--writable", imagePath, "nvidia-smi"},
+			args:    []string{"--nvccli", imagePath, "nvidia-smi"},
+		},
+		{
+			name:    "UserNamespaceWritable",
+			profile: e2e.UserNamespaceProfile,
+			args:    []string{"--nvccli", "--writable", imagePath, "nvidia-smi"},
+		},
+		{
+			name:    "Fakeroot",
+			profile: e2e.FakerootProfile,
+			args:    []string{"--nvccli", imagePath, "nvidia-smi"},
 		},
 	}
 
@@ -409,7 +419,7 @@ func (c ctx) testBuildNvCCLI(t *testing.T) {
 
 		args := []string{}
 		if tt.setNvFlag {
-			args = append(args, "--nv", "--nvccli")
+			args = append(args, "--nvccli")
 		}
 		args = append(args, "-F", "--sandbox", sandboxImage, defFile)
 


### PR DESCRIPTION
This enables using `--nvccli` without `--fakeroot`.

It also makes the `--nvccli` option imply `--nv`.

- Fixes #593