### PR TITLE
Allow fuse-overlayfs with all file types, only warn when unexpectedly readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Improved wildcard matching in the %files directive of build definition
   files by replacing usage of sh with the mvdan.cc library.
+- Replaced checks for compatible filesystem types when using fuse-overlayfs
+  with an INFO message when an incompatible filesystem type causes it to
+  be unwritable by a fakeroot user.
 - The `--nvccli` option now works without `--fakeroot`.  In that case the
   option can be used with `--writable-tmpfs` instead of `--writable`,
   and `--writable-tmpfs` is implied if neither option is given.

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -76,6 +76,8 @@ covered by tests.
       - `git add apptainer_source`
    - [Admin Docs](https://apptainer.org/docs/admin/main/) can be
      edited [here](https://github.com/apptainer/apptainer-admindocs)
+   - Look in replacements.py in both the User Docs and Admin Docs for
+     any needed updates to the variable_replacements
    - If a new branch was created, add it to the docsVersion list in the
      [web page](https://github.com/apptainer/apptainer.org/blob/master/src/pages/docs.js)
 1. Ensure the user and admin documentation has been deployed to the

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -69,7 +69,7 @@ var incompatibleFs = map[int64]fs{
 	},
 }
 
-func check(path string, d dir, allowType int64) error {
+func check(path string, d dir) error {
 	stfs := &unix.Statfs_t{}
 
 	if err := statfs(path, stfs); err != nil {
@@ -78,10 +78,6 @@ func check(path string, d dir, allowType int64) error {
 
 	fs, ok := incompatibleFs[int64(stfs.Type)]
 	if !ok || (ok && fs.overlayDir&d == 0) {
-		return nil
-	}
-
-	if int64(stfs.Type) == allowType {
 		return nil
 	}
 
@@ -94,16 +90,14 @@ func check(path string, d dir, allowType int64) error {
 
 // CheckUpper checks if the underlying filesystem of the
 // provided path can be used as an upper overlay directory.
-// allowType is an optional filesystem type to always allow.
-func CheckUpper(path string, allowType int64) error {
-	return check(path, upperDir, allowType)
+func CheckUpper(path string) error {
+	return check(path, upperDir)
 }
 
 // CheckLower checks if the underlying filesystem of the
 // provided path can be used as lower overlay directory.
-// allowType is an optional filesystem type to always allow.
-func CheckLower(path string, allowType int64) error {
-	return check(path, lowerDir, allowType)
+func CheckLower(path string) error {
+	return check(path, lowerDir)
 }
 
 type errIncompatibleFs struct {

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -170,9 +170,9 @@ func TestCheckLowerUpper(t *testing.T) {
 
 		switch tt.dir {
 		case lowerDir:
-			err = CheckLower(tt.path, 0)
+			err = CheckLower(tt.path)
 		case upperDir:
-			err = CheckUpper(tt.path, 0)
+			err = CheckUpper(tt.path)
 		}
 
 		if err != nil && tt.expectedSuccess {


### PR DESCRIPTION
Apptainer 1.1.0 release candidate 1 checks for compatible filesystem types with the --overlay option.  That's because overlayfs is very restrictive and sends obscure messages to /var/log/messages instead of to users.  fuse-overlayfs, however, is less restrictive and in some cases it only turns the mount into readonly instead of dying.  This PR removes those checks when running in non-setuid mode and instead checks for when the mount is unexpectedly readonly by making sure /usr/bin is writable when run with fakeroot and just prints an INFO message when it is not writable.

I have tested this in a lot of combinations, and the cases where fuse-overlayfs goes readonly are when NFS and Lustre are the upper layer.  It works fine with either of them as the lower layer.  I don't have access to GPFS so I didn't try it, but I expect it is similar.  