### PR TITLE
Allow the newuidmap command to be missing when not needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
 
       - name: Fetch deps
         if: env.run_tests
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         if: env.run_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - The `--nvccli` option implies `--nv`.
 - The fakeroot command can now be used even if $PATH is empty in the
   environment of the apptainer command.
+- Allow the ``newuidmap`` command to be missing if the current user is not
+  listed in ``/etc/subuid``.
 
 ## v1.1.0-rc.1 - \[2022-08-01\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   environment of the apptainer command.
 - Allow the ``newuidmap`` command to be missing if the current user is not
   listed in ``/etc/subuid``.
+- Require the ``uidmap`` package in Debian packaging.
 
 ## v1.1.0-rc.1 - \[2022-08-01\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,6 +20,7 @@ sudo apt-get install -y \
     build-essential \
     libseccomp-dev \
     pkg-config \
+    uidmap \
     squashfs-tools \
     squashfuse \
     fuse2fs \

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -22,7 +22,15 @@ Vcs-Browser: https://github.com/apptainer/apptainer
 
 Package: apptainer
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, squashfs-tools, squashfuse, fuse2fs, fuse-overlayfs, fakeroot
+Depends:
+ ${misc:Depends},
+ ${shlibs:Depends},
+ uidmap,
+ squashfs-tools,
+ squashfuse,
+ fuse2fs,
+ fuse-overlayfs,
+ fakeroot
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute"
  Mobility of Compute encapsulates the development to compute model

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -560,7 +560,10 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 	}
 
 	if e.EngineConfig.GetFakeroot() {
-		if !starterConfig.GetIsSUID() {
+		uid := uint32(os.Getuid())
+		gid := uint32(os.Getgid())
+
+		if !starterConfig.GetIsSUID() && fakerootutil.IsUIDMapped(uid) {
 			// no SUID workflow, check if newuidmap/newgidmap are present
 			sylog.Verbosef("Fakeroot requested with unprivileged workflow, fallback to newuidmap/newgidmap")
 			sylog.Debugf("Search for newuidmap binary")
@@ -572,9 +575,6 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 				return err
 			}
 		}
-
-		uid := uint32(os.Getuid())
-		gid := uint32(os.Getgid())
 
 		getIDRange := fakerootutil.GetIDRange
 

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -272,7 +272,7 @@ func setNewIDMapPath(command string, pathPointer unsafe.Pointer) error {
 	path, err := bin.FindBin(command)
 	if err != nil {
 		return fmt.Errorf(
-			"%s was not found in PATH (%s), required with fakeroot and unprivileged installation",
+			"%s was not found in PATH (%s), required with fakeroot and unprivileged installation when user is in /etc/subuid",
 			command, env.DefaultPath,
 		)
 	}

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -12,6 +12,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     libseccomp-dev \
     pkg-config \
+    uidmap \
     squashfs-tools \
     squashfuse \
     fuse2fs \


### PR DESCRIPTION
This allows the newuidmap command to be missing when the user is not in /etc/subuid in addition to the previous exception of a suid installation.  It also makes sure it gets installed by default on debian in case the user is in /etc/subuid.

- Fixes #601