### PR TITLE
Require fuse2fs for el7 and fuse-overlayfs for all RPMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
           go-version: 1.18.4
 
       - name: Fetch deps
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         run: |
@@ -244,7 +244,7 @@ jobs:
 
       - name: Fetch deps
         if: env.run_tests
-        run: sudo apt-get -q update && sudo apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot libseccomp-dev cryptsetup
+        run: sudo apt-get -q update && sudo apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup
 
       - name: Build and install Apptainer
         if: env.run_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Allow the ``newuidmap`` command to be missing if the current user is not
   listed in ``/etc/subuid``.
 - Require the ``uidmap`` package in Debian packaging.
-- Ensure bootstrap_history directory is populated with previous definition files,
-  present in source containers used in a build.
+- Require fuse2fs in RPM packaging.  In EPEL7 the package is called fuse2fs,
+  otherwise it is in e2fsprogs.
+- Require the fuse-overlayfs package for all RPM packages instead of just
+  on el7 because it is sometimes useful even with kernel support for
+  unprivileged overlayfs.
+- Ensure bootstrap_history directory is populated with previous definition
+  files, present in source containers used in a build.
 
 ## v1.1.0-rc.1 - \[2022-08-01\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,6 +44,7 @@ sudo yum install -y \
     squashfuse \
     fuse-overlayfs \
     fakeroot \
+    /usr/*bin/fuse2fs \
     cryptsetup \
     wget git
 ```

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -73,8 +73,11 @@ Requires: squashfs-tools
 BuildRequires: cryptsetup
 Requires: squashfuse
 Requires: fakeroot
-%if 0%{?el7}
 Requires: fuse-overlayfs
+%if 0%{?el7}
+Requires: fuse2fs
+%else
+Requires: e2fsprogs
 %endif
 
 %description

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -10,7 +10,7 @@
 yum install -y rpm-build make yum-utils gcc binutils util-linux-ng which git
 yum install -y libseccomp-devel e2fsprogs cryptsetup
 yum install -y epel-release
-yum install -y golang squashfuse fuse-overlayfs fakeroot
+yum install -y golang squashfuse fuse-overlayfs fakeroot /usr/*bin/fuse2fs
 
 # switch to an unprivileged user with sudo privileges
 yum install -y sudo


### PR DESCRIPTION
Since fuse2fs is now in EPEL7, require it for RPMs.  The package is called fuse2fs on el7, otherwise it is called e2fsprogs.  Also require fuse-overlayfs in all RPMs because it can be invoked if for some reason unprivileged kernel overlayfs doesn't work.  This will especially be true after #602 is merged.

fuse2fs is in /usr/sbin on el7 & el8 and in /usr/bin on el9 and Fedora, so a way to make sure it is installed everywhere in yum install recipes is installing `/usr/*bin/fuse2fs`. 