### PR TITLE
Use user's home directory as /root in fakeroot mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Replaced checks for compatible filesystem types when using fuse-overlayfs
   with an INFO message when an incompatible filesystem type causes it to
   be unwritable by a fakeroot user.
+- Mount the user's home directory at `/root` when using `--fakeroot` in
+  the setuid flow (fixes a regression introduced in 1.1.0-rc.1 which didn't
+  impact non-setuid flow).
 - The `--nvccli` option now works without `--fakeroot`.  In that case the
   option can be used with `--writable-tmpfs` instead of `--writable`,
   and `--writable-tmpfs` is implied if neither option is given.

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -579,7 +579,7 @@ var actionUserNamespaceFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "userns",
 	ShortHand:    "u",
-	Usage:        "run container in a new user namespace, allowing Apptainer to run completely unprivileged on recent kernels. This disables some features of Apptainer, for example it only works with sandbox images.",
+	Usage:        "run container in a new user namespace",
 	EnvKeys:      []string{"USERNS", "UNSHARE_USERNS"},
 }
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -1644,12 +1644,12 @@ func (c *container) getHomePaths() (source string, dest string, err error) {
 		pw, err := user.CurrentOriginal()
 		if err == nil {
 			source = pw.Dir
-			if os.Getuid() == 0 {
+			if c.engine.EngineConfig.GetFakeroot() || os.Getuid() == 0 {
 				// Mount user home directory onto /root for
 				//  any root-mapped namespace
 				dest = "/root"
 			} else {
-				dest = pw.Dir
+				dest = source
 			}
 		} else if os.Getuid() == 0 {
 			// The user could not be found


### PR DESCRIPTION
This makes the user's home directory be mounted as /root with `--fakeroot` even in the setuid flow.  With `--writable-tmpfs` it was especially noticeable because it showed Permission denied on `/root`, but even without that it was using the original user's home directory path which didn't make a lot of sense.

- Fixes #583

This also patches up the Usage for the `--userns` action option because I happened to notice that as I was testing this.