### PR TITLE
Tell squashfuse to show files owned by the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `--fakeroot` that probably requires a sandbox image that was built with
   `--fix-perms`.
 - The `--nvccli` option implies `--nv`.
+- Configure squashfuse to always show files to be owned by the current user.
+  That's especially important for fakeroot to prevent most of the files
+  from looking like they are owned by user 65534.
 - The fakeroot command can now be used even if $PATH is empty in the
   environment of the apptainer command.
 - Allow the ``newuidmap`` command to be missing if the current user is not

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -116,7 +116,10 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 
 	case "squashfs":
 		f = &d.squashFeature
-		optsStr := "offset=" + strconv.FormatUint(params.Offset, 10)
+		optsStr := fmt.Sprintf("uid=%v,gid=%v", os.Getuid(), os.Getgid())
+		if params.Offset > 0 {
+			optsStr += ",offset=" + strconv.FormatUint(params.Offset, 10)
+		}
 		srcPath := params.Source
 		if path.Dir(params.Source) == "/proc/self/fd" {
 			// this will be passed as the first ExtraFile below, always fd 3


### PR DESCRIPTION
This adds passing the current user's uid & gid to squashfuse so it will show files owned by them.

- Fixes #582