### PR TITLE
Require root user to build encrypted container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Add additional options to the build command for testing different fakeroot
   modes: `--userns` like the action flag and hidden options `--ignore-subuid`,
   `--ignore-fakeroot-command`, and `--ignore-userns`.
+- Require root user early when building an encrypted container.
 
 ## v1.1.0-rc.1 - \[2022-08-01\]
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/cryptkey"
+	"github.com/apptainer/apptainer/pkg/util/namespaces"
 	keyClient "github.com/apptainer/container-key-client/client"
 	"github.com/spf13/cobra"
 )
@@ -202,7 +203,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fakerootPath string) {
 	var keyInfo *cryptkey.KeyInfo
 	if buildArgs.encrypt || promptForPassphrase || cmd.Flags().Lookup("pem-path").Changed {
-		if os.Getuid() != 0 {
+		if namespaces.IsUnprivileged() {
 			sylog.Fatalf("You must be root to build an encrypted container")
 		}
 


### PR DESCRIPTION
Version 1.1.0-rc.1 attempts to build an encrypted container with fakeroot but fails at the end with
```
failed to attach loop device: while acquiring exclusive lock on /dev/loop0: permission denied
```
This PR makes it die much sooner if it is not attempted as the real root user.