### PR TITLE
Error on pass protected PEM file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Allow the ``newuidmap`` command to be missing if the current user is not
   listed in ``/etc/subuid``.
 - Require the ``uidmap`` package in Debian packaging.
-- Improved error handling of unsupported pass protected PEM files with 
+- Improved error handling of unsupported pass protected PEM files with
   encrypted containers.
 - Require fuse2fs in RPM packaging.  In EPEL7 the package is called fuse2fs,
   otherwise it is in e2fsprogs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Allow the ``newuidmap`` command to be missing if the current user is not
   listed in ``/etc/subuid``.
 - Require the ``uidmap`` package in Debian packaging.
+- Improved error handling of unsupported pass protected PEM files with 
+  encrypted containers.
 
 ## v1.1.0-rc.1 - \[2022-08-01\]
 

--- a/pkg/util/cryptkey/key.go
+++ b/pkg/util/cryptkey/key.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/apptainer/sif/v2/pkg/sif"
 )
@@ -153,6 +154,10 @@ func LoadPEMPrivateKey(fn string) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(b)
 	if block == nil {
 		return nil, fmt.Errorf("could not read %s: %v", fn, ErrNoPEMData)
+	}
+
+	if strings.Contains(block.Headers["Proc-Type"], "ENCRYPTED") {
+		return nil, fmt.Errorf("passphrase protected pem files not supported")
 	}
 
 	return x509.ParsePKCS1PrivateKey(block.Bytes)


### PR DESCRIPTION


## Description of the Pull Request (PR):

Password protected PEM files were [deprecated](https://github.com/golang/go/commit/57af9745bfad2c20ed6842878e373d6c5b79285a) in Go in 2020. This PR improves the warning and makes it explicit that password protected PEM files are not supported. 

### This fixes or addresses the following GitHub issues:

 - Fixes #585 