### PR TITLE
Make e2e tests for adding on packages with --fakeroot --writable-tmpfs

### DIFF
--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -205,13 +205,13 @@ func (c ctx) testAddPackageWithFakerootAndTmpfs(t *testing.T) {
 		t.Fatalf("could not create sandbox folder inside tempdir: %s", tempDir)
 	}
 
-	sif := fmt.Sprintf("%s/centos7.sif", tempDir)
+	sif := fmt.Sprintf("%s/alpine.sif", tempDir)
 
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs(sif, "docker://centos:7"),
+		e2e.WithArgs(sif, "docker://alpine"),
 		e2e.ExpectExit(0),
 	)
 
@@ -227,15 +227,15 @@ func (c ctx) testAddPackageWithFakerootAndTmpfs(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.FakerootProfile),
 		e2e.WithCommand("exec"),
-		e2e.WithArgs("--writable-tmpfs", sif, "yum", "install", "-y", "openssh"),
-		e2e.ExpectExit(1), // because of no enough permission
+		e2e.WithArgs("--writable-tmpfs", sif, "apk", "add", "openssh"),
+		e2e.ExpectExit(99), // because of no enough permission
 	)
 
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("exec"),
-		e2e.WithArgs("--writable-tmpfs", sif, "yum", "install", "-y", "openssh"),
+		e2e.WithArgs("--writable-tmpfs", sif, "apk", "add", "openssh"),
 		e2e.ExpectExit(0), // works fine with root permission
 	)
 
@@ -243,7 +243,7 @@ func (c ctx) testAddPackageWithFakerootAndTmpfs(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.FakerootProfile),
 		e2e.WithCommand("exec"),
-		e2e.WithArgs("--writable-tmpfs", sandbox, "yum", "install", "-y", "openssh"),
+		e2e.WithArgs("--writable-tmpfs", sandbox, "apk", "add", "openssh"),
 		e2e.ExpectExit(0), // works fine in sandbox
 	)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Make e2e tests for adding on packages with --fakeroot --writable-tmpfs

### This fixes or addresses the following GitHub issues:

 - Fixes #617 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
