### PR TITLE
Make e2e test for exec command with fakeroot and writable-tmpfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   (akin to the runscript and start sections).
 - Skip trying to user kernel overlayfs when using writable overlay and the
   lower layer is FUSE, because of a kernel bug introduced in kernel 5.15.
+- Add additional hidden options to the action command for testing different fakeroot
+  modes with `--fakeroot`: `--ignore-subuid`, `--ignore-fakeroot-command`,
+  and `--ignore-userns`.
 
 ## v1.1.0-rc.2 - \[2022-08-16\]
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -88,6 +88,10 @@ var (
 	MemorySwap        string // bytes
 	OomKillDisable    bool
 	PidsLimit         int
+
+	IgnoreSubuid      bool
+	IgnoreFakerootCmd bool
+	IgnoreUserns      bool
 )
 
 // --app
@@ -802,6 +806,39 @@ var actionPidsLimitFlag = cmdline.Flag{
 	EnvKeys:      []string{"PIDS_LIMIT"},
 }
 
+// --ignore-subuid
+var actionIgnoreSubuidFlag = cmdline.Flag{
+	ID:           "actionIgnoreSubuidFlag",
+	Value:        &IgnoreSubuid,
+	DefaultValue: false,
+	Name:         "ignore-subuid",
+	Usage:        "ignore entries inside /etc/subuid",
+	EnvKeys:      []string{"IGNORE_SUBUID"},
+	Hidden:       true,
+}
+
+// --ignore-fakeroot-command
+var actionIgnoreFakerootCommand = cmdline.Flag{
+	ID:           "actionIgnoreFakerootCommandFlag",
+	Value:        &IgnoreFakerootCmd,
+	DefaultValue: false,
+	Name:         "ignore-fakeroot-command",
+	Usage:        "ignore fakeroot command",
+	EnvKeys:      []string{"IGNORE_FAKEROOT_COMMAND"},
+	Hidden:       true,
+}
+
+// --ignore-userns
+var actionIgnoreUsernsFlag = cmdline.Flag{
+	ID:           "actionIgnoreUsernsFlag",
+	Value:        &IgnoreUserns,
+	DefaultValue: false,
+	Name:         "ignore-userns",
+	Usage:        "ignore user namespaces",
+	EnvKeys:      []string{"IGNORE_USERNS"},
+	Hidden:       true,
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -892,5 +929,8 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionMemorySwapFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionOomKillDisableFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPidsLimitFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionIgnoreSubuidFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionIgnoreFakerootCommand, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionIgnoreUsernsFlag, actionsInstanceCmd...)
 	})
 }


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

Make e2e test for exec command with fakeroot and writable-tmpfs

### This fixes or addresses the following GitHub issues:

 - Fixes #617 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
