### PR TITLE
adding support for test to have a custom shell, from sylabs 866

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Add `--sparse` flag to `overlay create` command to allow generation of a
   sparse ext3 overlay image.
+- Support for a custom hashbang in the `%test` section of an Apptainer recipe
+  (akin to the runscript and start sections).
 
 ## v1.1.0-rc.2 - \[2022-08-16\]
 

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -149,7 +149,8 @@ func insertStartScript(b *types.Bundle) error {
 func insertTestScript(b *types.Bundle) error {
 	if b.RunSection("test") && b.Recipe.ImageData.Test.Script != "" {
 		sylog.Infof("Adding testscript")
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Test.Script+"\n"), 0o755)
+		shebang, script := handleShebangScript(b.Recipe.ImageData.Test)
+		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -193,6 +193,7 @@ func TestParseDefinitionFile(t *testing.T) {
 		{"MultipleFiles", "testdata_good/multiplefiles/multiplefiles", "testdata_good/multiplefiles/multiplefiles.json"},
 		{"QuotedFiles", "testdata_good/quotedfiles/quotedfiles", "testdata_good/quotedfiles/quotedfiles.json"},
 		{"Shebang", "testdata_good/shebang/shebang", "testdata_good/shebang/shebang.json"},
+		{"ShebangTest", "testdata_good/shebang_test/shebang_test", "testdata_good/shebang_test/shebang_test.json"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/build/types/parser/testdata_good/shebang_test/shebang_test
+++ b/pkg/build/types/parser/testdata_good/shebang_test/shebang_test
@@ -1,0 +1,6 @@
+Bootstrap: docker
+From: ubuntu
+
+%test
+#!/usr/local/csh
+echo $0

--- a/pkg/build/types/parser/testdata_good/shebang_test/shebang_test.json
+++ b/pkg/build/types/parser/testdata_good/shebang_test/shebang_test.json
@@ -1,0 +1,56 @@
+{
+          "header": {
+            "bootstrap": "docker",
+            "from": "ubuntu"
+          },
+          "imageData": {
+            "metadata": null,
+            "labels": {},
+            "imageScripts": {
+              "help": {
+                "args": "",
+                "script": ""
+              },
+              "environment": {
+                "args": "",
+                "script": ""
+              },
+              "runScript": {
+                "args": "",
+                "script": ""
+              },
+              "test": {
+                "args": "",
+                "script": "#!/usr/local/csh\necho $0\n"
+              },
+              "startScript": {
+                "args": "",
+                "script": ""
+              }
+            }
+          },
+          "buildData": {
+            "files": [],
+            "buildScripts": {
+              "pre": {
+                "args": "",
+                "script": ""
+              },
+              "setup": {
+                "args": "",
+                "script": ""
+              },
+              "post": {
+                "args": "",
+                "script": ""
+              },
+              "test": {
+                "args": "",
+                "script": "#!/usr/local/csh\necho $0\n"
+              }
+            }
+          },
+          "customData": null,
+          "raw": "Qm9vdHN0cmFwOiBkb2NrZXIKRnJvbTogdWJ1bnR1CgoldGVzdAojIS91c3IvbG9jYWwvY3NoCmVjaG8gJDAK",
+          "appOrder": []
+}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#866

The original PR description was:
> Akin to start and run, a user might want a test file to use a custom hashbang. This was basically all ready to go and just needed to be extended to the test script! I was not sure where to write tests so I will wait for guidance on that.
> 
> This request came from Twitter! https://twitter.com/ifndef_define/status/1536689964225908737 As I noted above I still need to add a test, and will do so with further guidance. I indeed have tested manually/locally and it looks good! 🥳
> 
> ![image](https://user-images.githubusercontent.com/814322/173720183-090d2766-e383-40d9-82f7-75d0a5d37c38.png)