### PR TITLE
feat: `bind-paths` options for `--no-mount` flag, from sylabs 885

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes Since Last Release
+
+### New features / functionalities
+
+- The `--no-mount` flag now accepts the value `bind-paths` to disable mounting of
+  all `bind path` entries in `apptainer.conf.
+
 ## v1.1.0-rc.2 - \[2022-08-16\]
 
 ### Changed defaults / behaviours

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -464,7 +464,7 @@ var actionNoMountFlag = cmdline.Flag{
 	Value:        &NoMount,
 	DefaultValue: []string{},
 	Name:         "no-mount",
-	Usage:        "disable one or more 'mount xxx' options set in apptainer.conf and/or specify absolute destination path to disable a 'bind path' entry",
+	Usage:        "disable one or more 'mount xxx' options set in apptainer.conf and/or specify absolute destination path to disable a bind path entry, or 'bind-paths' to disable all bind path entries.",
 	EnvKeys:      []string{"NO_MOUNT"},
 }
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -159,7 +159,11 @@ func setNoMountFlags(c *apptainerConfig.EngineConfig) {
 			c.SetNoHostfs(true)
 		case "cwd":
 			c.SetNoCwd(true)
+		// All bind path apptainer.conf entries
+		case "bind-paths":
+			skipBinds = append(skipBinds, "*")
 		default:
+			// Single bind path apptainer.conf entry by abs path
 			if filepath.IsAbs(v) {
 				skipBinds = append(skipBinds, v)
 				continue

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2327,6 +2327,23 @@ func (c actionTests) actionNoMount(t *testing.T) {
 			testContained: true,
 			exit:          0,
 		},
+		// bind-paths should disable all of the bind path mounts - including both defaults
+		{
+			name:          "binds-paths-hosts",
+			noMount:       "bind-paths",
+			noMatch:       "on /etc/hosts",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
+		{
+			name:          "bind-paths-localtime",
+			noMount:       "bind-paths",
+			noMatch:       "on /etc/localtime",
+			testDefault:   true,
+			testContained: true,
+			exit:          0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -1560,6 +1560,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 	)
 
 	skipBinds := c.engine.EngineConfig.GetSkipBinds()
+	skipAllBinds := slice.ContainsString(skipBinds, "*")
 
 	if c.engine.EngineConfig.GetContain() {
 		hosts := hostsPath
@@ -1580,7 +1581,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 			hosts, _ = c.session.GetPath(hostsPath)
 		}
 
-		if !slice.ContainsString(skipBinds, hostsPath) {
+		if !skipAllBinds && !slice.ContainsString(skipBinds, hostsPath) {
 			// #5465 If hosts/localtime mount fails, it should not be fatal so skip-on-error
 			if err := system.Points.AddBind(mount.BindsTag, hosts, hostsPath, flags, "skip-on-error"); err != nil {
 				return fmt.Errorf("unable to add %s to mount list: %s", hosts, err)
@@ -1589,7 +1590,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 				return fmt.Errorf("unable to add %s for remount: %s", hostsPath, err)
 			}
 		}
-		if !slice.ContainsString(skipBinds, localtimePath) {
+		if !skipAllBinds && !slice.ContainsString(skipBinds, localtimePath) {
 			if err := system.Points.AddBind(mount.BindsTag, localtimePath, localtimePath, flags, "skip-on-error"); err != nil {
 				return fmt.Errorf("unable to add %s to mount list: %s", localtimePath, err)
 			}
@@ -1612,7 +1613,7 @@ func (c *container) addBindsMount(system *mount.System) error {
 
 		sylog.Verbosef("Found 'bind path' = %s, %s", src, dst)
 
-		if slice.ContainsString(skipBinds, dst) {
+		if skipAllBinds || slice.ContainsString(skipBinds, dst) {
 			sylog.Debugf("Skipping bind to %s at user request", dst)
 			continue
 		}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#885
 which fixed
- sylabs/singularity#883

The original PR description was:
> Add `bind-paths` option for the `--no-mount` flag. This will disable mounting all of the `bind path` entries set in `singularity.conf`.
> 
> Previously, `bind path` entries could only be disabled one-by-one by specifying their absolute path.