### PR TITLE
feat: enable cgroups for non-root instances, from sylabs 896

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - The `--no-mount` flag now accepts the value `bind-paths` to disable mounting of
   all `bind path` entries in `apptainer.conf.
+- Instances started by a non-root user can use `--apply-cgroups` to apply
+  resource limits. Requires cgroups v2, and delegation configured via systemd.
 
 ## Changes Since Last Release Candidate
 

--- a/e2e/testdata/cgroups/cpu_success.toml
+++ b/e2e/testdata/cgroups/cpu_success.toml
@@ -1,4 +1,4 @@
 [cpu]
-  cpus = "0"
-  mems = "0"
+  shares = 512
+
 

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -914,6 +914,10 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 		e.EngineConfig.OciConfig.Linux.Seccomp = instanceEngineConfig.OciConfig.Linux.Seccomp
 	}
 
+	// Note - in non-root flow without userns the CLI process joined the cgroup
+	// early in execStarter because we don't have permission to move a parent
+	// process into the cgroup here. In that case, this code is a no-op that
+	// just enforces that actually happened.
 	if file.Cgroup {
 		sylog.Debugf("Adding process to instance cgroup")
 		ppid := os.Getppid()

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -121,23 +121,24 @@ func New(r io.Reader, name string, args []string, envs []string, runnerOptions .
 		name:   name,
 	}
 
+	dir, err := os.Getwd()
+	if err != nil {
+		dir = "/"
+	}
+
 	opts := []interp.RunnerOption{
 		interp.StdIO(os.Stdin, os.Stdout, os.Stderr),
 		interp.ExecHandler(s.internalExecHandler()),
 		interp.OpenHandler(s.internalOpenHandler()),
 		interp.Params("--"),
 		interp.Env(expand.ListEnviron(envs...)),
+		interp.Dir(dir),
 	}
 	opts = append(opts, runnerOptions...)
 	s.runner, err = interp.New(opts...)
 
 	if err != nil {
 		return nil, fmt.Errorf("while creating shell interpreter: %s", err)
-	}
-
-	s.runner.Dir, err = os.Getwd()
-	if err != nil {
-		s.runner.Dir = "/"
 	}
 
 	s.runner.Params = append(s.runner.Params, args...)

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs, Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license.  Please
 // consult LICENSE.md file distributed with the sources of this project regarding
 // your rights to use or distribute this software.


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#896
 which fixed
- sylabs/singularity#816

The original PR description was:
> **feat: enable cgroups for non-root instances**
> 
> Our existing method for joining an instance cgroup with an action on an `instance://` does not work for non-root instances, without a usernamepace - so we blocked non-root instances with cgroups. The existing code attempts to move its parent ID (the starter main process), into the instance cgroup. This will receive an operation not permitted error.
> 
> We can work around by having the CLI process directly join the cgroup, so that everything is spawned within the instance cgroup.
> 
> Also modify e2e cgroups tests to verify this functionality, and correct unintentional test skips in rootless flow.
> 
> **e2e: use cpu controller instead of cpuset for cgroups test**
> 
> The cpuset controller may not be delegated by default on many distributions.
> 
> **fix: handle invalid wd before shell interp.New**