### PR TITLE
Add "--no-imgdrv" option

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -92,6 +92,8 @@ var (
 	IgnoreSubuid      bool
 	IgnoreFakerootCmd bool
 	IgnoreUserns      bool
+
+	NoImgDrv bool
 )
 
 // --app
@@ -839,6 +841,16 @@ var actionIgnoreUsernsFlag = cmdline.Flag{
 	Hidden:       true,
 }
 
+// --no-imgdrv
+var actionNoImgDrv = cmdline.Flag{
+	ID:           "actionNoImgDrv",
+	Value:        &NoImgDrv,
+	DefaultValue: false,
+	Name:         "no-imgdrv",
+	Usage:        "Disable image drivers",
+	EnvKeys:      []string{"NOIMGDRV"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -932,5 +944,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionIgnoreSubuidFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreFakerootCommand, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreUsernsFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoImgDrv, actionsInstanceCmd...)
 	})
 }

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -786,7 +786,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	if (UserNamespace || insideUserNs) && fs.IsFile(image) {
 		convert := true
 
-		if engineConfig.File.ImageDriver != "" {
+		if !NoImgDrv && engineConfig.File.ImageDriver != "" {
 			// load image driver plugins
 			callbackType := (apptainercallback.RegisterImageDriver)(nil)
 			callbacks, err := plugin.LoadCallbacks(callbackType)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add the ability to disable the use of image drivers on the commandline.  This will allow users to disable the use of the builtin "fuesapps" driver, which may create performance issues related to squashfuse for some SIF images when Apptainer is unprivileged.  This PR provides a quick/short fix for #665, and I've tested that it is functional.  Ideally it would be possible to disable the use of squashfuse specifically instead of all drivers, but that would likely entail significantly more changes.

### This fixes or addresses the following GitHub issues:

 - Fixes #665


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
