### PR TITLE
Prefer squashfuse_ll over squashfuse and include patched version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### New features / functionalities
 
-- The `--no-mount` flag now accepts the value `bind-paths` to disable mounting of
-  all `bind path` entries in `apptainer.conf.
+- The `--no-mount` flag now accepts the value `bind-paths` to disable mounting
+  of all `bind path` entries in `apptainer.conf`.
 - Instances started by a non-root user can use `--apply-cgroups` to apply
   resource limits. Requires cgroups v2, and delegation configured via systemd.
 - The `instance stats` command displays the resource usage every second. The
@@ -21,6 +21,18 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes Since Last Release Candidate
 
+- Imply adding `${prefix}/libexec/apptainer/bin` to the `binary path` in
+  `apptainer.conf`, which is used for searching for helper executables.
+  It is implied as the first directory of `$PATH` if present (which is at
+  the beginning of `binary path` by default) or just as the first directory
+  if `$PATH` is not included in `binary path`.
+- Change squash mounts to prefer to use `squashfuse_ll` instead of
+  `squashfuse`, if available, for improved performance.
+  `squashfuse_ll` is available on RHEL-based systems but not Debian as
+  part of the `squashfuse` package.
+  Also, for even better parallel performance, include a patched multithreaded
+  version of `squashfuse_ll` in rpm and debian packaging in
+  `${prefix}/libexec/apptainer/bin`.
 - Add `--sparse` flag to `overlay create` command to allow generation of a
   sparse ext3 overlay image.
 - Support for a custom hashbang in the `%test` section of an Apptainer recipe

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -169,6 +169,48 @@ If you want a setuid-installation (formerly the default) use the
 
 See the output of `./mconfig -h` for available options.
 
+## Installing improved performance squashfuse_ll
+
+If you want to have the best performance for unprivileged mounts of SIF
+files for multi-core applications, you can optionally install an improved
+performance version of `squashfuse_ll`.
+
+As of this writing there is a patch pending to the squashfuse project to
+add multithreading support that significantly improves performance for
+applications that access a lot of small files from many cores at once.
+
+First, make sure that additional required packages are installed.  On Debian:
+
+```sh
+apt-get install -y autoconf automake libtool pkg-config libfuse-dev zlib1g-dev
+``
+
+On CentOS/RHEL:
+```sh
+yum install -y autoconf automake libtool pkgconfig fuse3-devel zlib-devel
+```
+
+To download the source code do this:
+
+```sh
+SQUASHFUSEVERSION=0.1.105
+SQUASHFUSEPR=70
+curl -L -O https://github.com/vasi/squashfuse/archive/$SQUASHFUSEVERSION/squashfuse-$SQUASHFUSEVERSION.tar.gz
+curl -L -O https://github.com/vasi/squashfuse/pull/$SQUASHFUSEPR.patch
+```
+
+Then to compile and install do this:
+
+```sh
+tar xzf squashfuse-$SQUASHFUSEVERSION.tar.gz
+cd squashfuse-$SQUASHFUSEVERSION
+patch -p1 <../$SQUASHFUSEPR.patch
+./autogen.sh
+FLAGS=-std=c99 ./configure --enable-multithreading
+make squashfuse_ll
+sudo cp squashfuse_ll /usr/local/libexec/apptainer/bin
+```
+
 ## Building & Installing from RPM
 
 On a RHEL / CentOS / Fedora machine you can build an Apptainer into rpm
@@ -177,17 +219,16 @@ Apptainer across multiple machines, or wish to manage all software via
 `yum/dnf`.
 
 To build the rpms, in addition to the
-[dependencies](#install-system-dependencies),
-install `rpm-build`, `wget`, and `golang`:
+[system dependencies](#install-system-dependencies),
+also install these extra packages:
 
 ```sh
-sudo yum install -y rpm-build wget golang
+sudo yum install -y rpm-build golang
 ```
 
 The rpm build will use the OS distribution or EPEL version of Go,
 or it will use a different installation of Go, whichever is first in $PATH.
-If the first `go` found in $PATH is too old (as it currently is for
-example on RHEL7 / CentOS7),
+If the first `go` found in $PATH is too old,
 then the rpm build uses that older version to compile the newer go
 toolchain from source.
 This mechanism is necessary for rpm build systems that do not allow
@@ -196,15 +237,15 @@ In order to make use of this mechanism, use the `mconfig --only-rpm` option
 to skip the minimum version check.
 `mconfig` will then create a `.spec` file that looks for a go source
 tarball in the rpm build's current directory.
-Download the tarball like this:
+If you need it, download the go tarball like this:
 
 ```sh
 wget https://dl.google.com/go/go$(scripts/get-min-go-version).src.tar.gz
 ```
 
-Download the latest
-[release tarball](https://github.com/apptainer/apptainer/releases)
-and use it to install the RPM like this:
+Then download the latest
+[apptainer release tarball](https://github.com/apptainer/apptainer/releases)
+like this:
 
 <!-- markdownlint-disable MD013 -->
 
@@ -212,7 +253,32 @@ and use it to install the RPM like this:
 VERSION=1.1.0-rc.2  # this is the apptainer version, change as you need
 # Fetch the source
 wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/apptainer-${VERSION}.tar.gz
-# Build rpms from the source tar.gz
+```
+
+At this point if you don't care about improved squashfuse performance
+then skip down to the rpmbuild command below.
+If you do want it then you need to modify the tarball.
+First unpack it and uncomment one line like this:
+
+```sh
+tar xf apptainer-${VERSION}.tar.gz
+cd apptainer-${VERSION}
+sed -i 's/^# %\(%global squashfuse_version\)/\1/' apptainer.spec
+```
+
+Then install the extra packages and download the source code as shown at
+[the above link](#installing-improved-performance-squashfuse_ll)
+and recreate the tarball like this:
+
+```sh
+cd ..
+tar czf apptainer-${VERSION}.tar.gz apptainer-${VERSION}
+rm -rf apptainer-${VERSION}
+```
+
+Then build the rpms from the tarball like this:
+
+```sh
 rpmbuild -tb apptainer-${VERSION}.tar.gz
 # Install Apptainer using the resulting rpm
 sudo rpm -Uvh ~/rpmbuild/RPMS/x86_64/apptainer-$(echo $VERSION|tr - \~)-1.el7.x86_64.rpm
@@ -225,7 +291,7 @@ rm -rf ~/rpmbuild apptainer-${VERSION}*.tar.gz
 <!-- markdownlint-enable MD013 -->
 
 Alternatively, to build RPMs from the latest main you can
-[clone the repo as detailed above](#clone-the-repo).
+[clone the repo as detailed above](#clone-the-repo), and run `./mconfig`.
 Then use the `rpm` make target to build Apptainer as rpm packages,
 for example like this if you already have a new enough golang first
 in your PATH:

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -504,7 +504,7 @@ func persistentPreRun(*cobra.Command, []string) error {
 	apptainerconf.SetCurrentConfig(config)
 	// Include the user's PATH for now.
 	// It will be overridden later if using setuid flow.
-	apptainerconf.SetBinaryPath(true)
+	apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, true)
 
 	// Handle the config dir (~/.apptainer),
 	// then check the remove conf file permission.

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -19,11 +19,13 @@ Also install these additional dependencies for the packaging:
 
 ```sh
 sudo apt-get install \
+    debhelper \
+    dh-autoreconf \
     devscripts \
     help2man \
     libarchive-dev \
     libssl-dev \
-    python \
+    python2 \
     uuid-dev \
     golang-go
 ```
@@ -37,6 +39,10 @@ debian directory like this:
 TARBALL=go$(scripts/get-min-go-version).src.tar.gz
 wget -O debian/$TARBALL https://dl.google.com/go/$TARBALL
 ```
+
+Finally, install the additional dependencies in the section on the
+[improved performance squashfuse](../../INSTALL.md##installing-improved-performance-squashfuse_ll)
+and download the additional files listed there into the debian directory.
 
 ## Configuration
 

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -14,7 +14,13 @@ Build-Depends:
  devscripts,
  libseccomp-dev,
  cryptsetup,
- golang-go (>= 2:1.13~~)
+ golang-go (>= 2:1.13~~),
+ autoconf,
+ automake,
+ libtool,
+ pkg-config,
+ libfuse-dev,
+ zlib1g-dev
 Standards-Version: 3.9.8
 Homepage: http://apptainer.org
 Vcs-Git: https://github.com/apptainer/apptainer.git

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -57,6 +57,18 @@ export APPTAINER_CACHEDIR=$(pkgdir)/var/lib/apptainer/cache
 	dh $@  --with=autoreconf
 
 override_dh_auto_configure:
+	@SQUASHFUSETGZ="`echo debian/squashfuse-*.tar.gz`"; \
+	  if [ -f $$SQUASHFUSETGZ ]; then \
+	    set -x; \
+	    tar -C debian -xf $$SQUASHFUSETGZ; \
+	    cd $${SQUASHFUSETGZ%.tar.gz}; \
+	    for PATCH in ../*.patch; do \
+	      patch -p1 <$$PATCH; \
+	    done; \
+	    ./autogen.sh; \
+	    FLAGS=-std=c99 ./configure --enable-multithreading; \
+	    make squashfuse_ll; \
+	  fi
 	@export PATH=$(GOROOT)/bin:$$PATH; \
 	  if ! ./mlocal/scripts/check-min-go-version go $(MINGO_VERSION); then \
 	    set -e; \
@@ -83,6 +95,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	@dh_auto_install -Smakefile -D$(DEB_SC_BUILDDIR)
+	cp debian/squashfuse-*/squashfuse_ll debian/tmp/usr/libexec/apptainer/bin
 
 override_dh_install:
 	@dh_install -papptainer-suid usr/libexec/apptainer/bin/starter-suid

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -33,6 +33,9 @@
 # For example, it has dash instead of tilde for release candidates.
 %global package_version @PACKAGE_VERSION@
 
+# Uncomment this to include a multithreaded version of squashfuse_ll
+# %%global squashfuse_version 0.1.105
+
 Summary: Application and environment virtualization
 Name: apptainer
 Version: @PACKAGE_RPM_VERSION@
@@ -45,6 +48,10 @@ License: BSD and LBNL BSD and ASL 2.0
 URL: https://apptainer.org
 Source: https://github.com/%{name}/%{name}/releases/download/v%{package_version}/%{name}-%{package_version}.tar.gz
 @PACKAGE_GOLANG_SOURCE@
+%if "%{?squashfuse_version}" != ""
+Source10: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squashfuse-%{squashfuse_version}.tar.gz
+Patch10: https://github.com/vasi/squashfuse/pull/70.patch
+%endif
 # The singularity package was renamed to apptainer after version 3.8.x.
 # The apptainer package reset numbering at 1.0.0, and some singularity
 #  packages are in epoch 1, so Provide corresponding singularity versions
@@ -71,6 +78,14 @@ Requires: squashfs
 Requires: squashfs-tools
 %endif
 BuildRequires: cryptsetup
+%if "%{?squashfuse_version}" != ""
+BuildRequires: autoconf
+BuildRequires: automake
+BuildRequires: libtool
+BuildRequires: pkgconfig
+BuildRequires: fuse3-devel
+BuildRequires: zlib-devel
+%endif
 Requires: squashfuse
 Requires: fakeroot
 Requires: fuse-overlayfs
@@ -93,9 +108,25 @@ Requires: %{name} = %{version}-%{release}
 Provides the optional setuid-root portion of Apptainer.
 
 %prep
+%if "%{?squashfuse_version}" != ""
+# the default directory for other steps is where the %prep section ends
+# so do main package last
+%setup -b 10 -n squashfuse-%{squashfuse_version}
+%patch -P 10 -p1
+%setup -n %{name}-%{package_version}
+%else
 %autosetup -n %{name}-%{package_version}
+%endif
 
 %build
+%if "%{?squashfuse_version}" != ""
+pushd ../squashfuse-%{squashfuse_version}
+./autogen.sh
+FLAGS=-std=c99 ./configure --enable-multithreading
+%make_build squashfuse_ll
+popd
+%endif
+
 %if "%{?SOURCE1}" != ""
 GOVERSION="$(echo %SOURCE1|sed 's,.*/,,;s/go//;s/\.src.*//')"
 if ! ./mlocal/scripts/check-min-go-version go $GOVERSION; then
@@ -135,6 +166,9 @@ export PATH=$PWD/go/bin:$PATH
 %endif
 
 %make_install -C builddir V=
+%if "%{?squashfuse_version}" != ""
+install -m 755 ../squashfuse-%{squashfuse_version}/squashfuse_ll %{buildroot}%{_libexecdir}/%{name}/bin/squashfuse_ll
+%endif
 
 %if 0%{?el7}
 # Check for fuse2fs only as a pre-install so that an rpm built on el7 can
@@ -162,6 +196,9 @@ rmdir %{_sysconfdir}/singularity/* %{_sysconfdir}/singularity 2>/dev/null || tru
 %dir %{_libexecdir}/%{name}
 %dir %{_libexecdir}/%{name}/bin
 %{_libexecdir}/%{name}/bin/starter
+%if "%{?squashfuse_version}" != ""
+%{_libexecdir}/%{name}/bin/squashfuse_ll
+%endif
 %{_libexecdir}/%{name}/cni
 %{_libexecdir}/%{name}/lib
 %dir %{_sysconfdir}/%{name}

--- a/e2e/internal/e2e/config.go
+++ b/e2e/internal/e2e/config.go
@@ -24,7 +24,7 @@ func SetupDefaultConfig(t *testing.T, path string) {
 		t.Fatalf("while generating apptainer configuration: %s", err)
 	}
 	apptainerconf.SetCurrentConfig(c)
-	apptainerconf.SetBinaryPath(true)
+	apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, true)
 
 	Privileged(func(t *testing.T) {
 		f, err := os.Create(path)

--- a/internal/pkg/runtime/engine/apptainer/engine_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/engine_linux.go
@@ -48,7 +48,7 @@ func (e *EngineOperations) InitConfig(cfg *config.Common, privStageOne bool) {
 			apptainerconf.ApplyBuildConfig(e.EngineConfig.File)
 		}
 		apptainerconf.SetCurrentConfig(e.EngineConfig.File)
-		apptainerconf.SetBinaryPath(false)
+		apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, false)
 	} else {
 		// use the configuration passed in
 		apptainerconf.SetCurrentConfig(e.EngineConfig.File)

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -81,7 +81,7 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		return fmt.Errorf("unable to parse apptainer.conf file: %s", err)
 	}
 	apptainerconf.SetCurrentConfig(fileConfig)
-	apptainerconf.SetBinaryPath(!starterConfig.GetIsSUID())
+	apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, !starterConfig.GetIsSUID())
 
 	if starterConfig.GetIsSUID() {
 		if !fileConfig.AllowSetuid {

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -62,6 +62,7 @@ func FindBin(name string) (path string, err error) {
 		"rpm",
 		"rpmkeys",
 		"squashfuse",
+		"squashfuse_ll",
 		"SUSEConnect",
 		"unsquashfs",
 		"yum",
@@ -89,7 +90,7 @@ func findOnPath(name string, useSuidPath bool) (path string, err error) {
 	}
 	if cfg.SuidBinaryPath == "" {
 		if strings.HasSuffix(os.Args[0], ".test") {
-			apptainerconf.SetBinaryPath(true)
+			apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, true)
 		} else {
 			sylog.Fatalf("SetBinaryPath has not been run before findOnPath")
 		}

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -8,7 +8,8 @@
 
 # install dependencies
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y \
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y \
     build-essential \
     libseccomp-dev \
     pkg-config \
@@ -22,12 +23,16 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl wget git
 apt-get install -y \
     devscripts \
+    debhelper \
+    dh-autoreconf \
     help2man \
     libarchive-dev \
     libssl-dev \
-    python \
+    python2 \
     uuid-dev \
     golang-go
+# for squashfuse_ll build
+apt-get install -y autoconf automake libtool pkg-config libfuse-dev zlib1g-dev
 
 # move source code down a level because debuild writes into parent dir
 shopt -s extglob
@@ -61,6 +66,22 @@ su testuser -c '
     fi
   fi
   go version
+  # download additional source & patch urls listed in rpm
+  SPEC=dist/rpm/apptainer.spec.in
+  DOWNLOADURL="$(sed -n "s/^Source[1-9][0-9]*: //p" $SPEC)"
+  DOWNLOADURL="$DOWNLOADURL $(sed -n "s/^Patch[1-9][0-9]*: //p" $SPEC)"
+  SUBS="$(sed -n "s/.*%global //p" $SPEC)"
+  for URL in $DOWNLOADURL; do
+      if [[ "$URL" != http* ]]; then
+	  continue
+      fi
+      URL=$(echo "$SUBS" | (while read FROM TO; do
+	      URL="$(echo $URL|sed "s,%{$FROM},$TO,g")"
+	    done
+	    echo $URL))
+      BASE="$(basename $URL)"
+      curl -f -L -sS -o debian/$BASE $URL
+  done
   export DEB_FULLNAME="'"${DEB_FULLNAME:-CI Test}"'"
   export DEBEMAIL="'${DEBEMAIL:-citest@example.com}'"
   debuild --build=binary --no-sign --lintian-opts --display-info --show-overrides

--- a/scripts/ci-docker-run
+++ b/scripts/ci-docker-run
@@ -23,7 +23,7 @@ if [ "$OS_TYPE" = "debian" ] || [ "$OS_TYPE" = "ubuntu" ]; then
 fi
 
 docker run --privileged --network=host \
-  -v "$(pwd):/build:rw" -e GO_ARCH=$GO_ARCH \
+  -v "$(pwd):/build:rw" -e OS_TYPE=$OS_TYPE -e GO_ARCH=$GO_ARCH \
   --name "$DOCKER_CONTAINER_NAME" "$DOCKER_HUB_URI" /bin/bash -exc \
 	"cd /build && scripts/ci-${PKGTYPE}-build-test"
 

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -9,8 +9,11 @@
 # install dependencies
 yum install -y rpm-build make yum-utils gcc binutils util-linux-ng which git
 yum install -y libseccomp-devel e2fsprogs cryptsetup
-yum install -y epel-release
+if [ $OS_TYPE != fedora ]; then
+  yum install -y epel-release
+fi
 yum install -y golang squashfuse fuse-overlayfs fakeroot /usr/*bin/fuse2fs
+yum install -y autoconf automake libtool pkgconfig fuse3-devel zlib-devel # for squashfuse_ll build
 
 # switch to an unprivileged user with sudo privileges
 yum install -y sudo
@@ -38,6 +41,22 @@ su testuser -c '
     fi
   fi
   go version
+  # enable the multithreading squashfuse
+  sed -i "s/^# %\(%global squashfuse_version\)/\1/" apptainer.spec
+  # download any additional source & patch urls
+  DOWNLOADURL="$(sed -n "s/^Source[1-9][0-9]*: //p" apptainer.spec)"
+  DOWNLOADURL="$DOWNLOADURL $(sed -n "s/^Patch[1-9][0-9]*: //p" apptainer.spec)"
+  SUBS="$(sed -n "s/^%global //p" apptainer.spec)"
+  for URL in $DOWNLOADURL; do
+      if [[ "$URL" != http* ]]; then
+	  continue
+      fi
+      URL=$(echo "$SUBS" | (while read FROM TO; do
+	      URL="$(echo $URL|sed "s,%{$FROM},$TO,g")"
+	    done
+	    echo $URL))
+      curl -f -L -sS -O $URL
+  done
   # eliminate the "dist" part in the rpm name, for the release_assets
   echo "%dist %{nil}" >$HOME/.rpmmacros
   make -C builddir rpm


### PR DESCRIPTION
This greatly improves the performance of unprivileged SIF file mounts by using `squashfuse_ll` when available and making sure that a patched version with multithreading is available in rpm and debian packages.

- Fixes #665 