### PR TITLE
In fakeroot setuid hybrid mode, have image drivers enter container namespace (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   sparse ext3 overlay image.
 - Support for a custom hashbang in the `%test` section of an Apptainer recipe
   (akin to the runscript and start sections).
-- Skip trying to user kernel overlayfs when using writable overlay and the
+- When using fakeroot in setuid mode, have the image drivers first enter the
+  the container's user namespace to avoid write errors with overlays.
+- Skip trying to use kernel overlayfs when using writable overlay and the
   lower layer is FUSE, because of a kernel bug introduced in kernel 5.15.
 - Add additional hidden options to the action command for testing different fakeroot
   modes with `--fakeroot`: `--ignore-subuid`, `--ignore-fakeroot-command`,

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -305,7 +305,6 @@ func (c ctx) testAddPackageWithFakerootAndTmpfs(t *testing.T) {
 	}
 
 	sif := fmt.Sprintf("%s/centos7.sif", tempDir)
-	overlay := fmt.Sprintf("%s/overlay.img", tempDir)
 
 	c.env.RunApptainer(
 		t,
@@ -320,14 +319,6 @@ func (c ctx) testAddPackageWithFakerootAndTmpfs(t *testing.T) {
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--sandbox", "--force", sandbox, sif),
-		e2e.ExpectExit(0),
-	)
-
-	c.env.RunApptainer(
-		t,
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("overlay"),
-		e2e.WithArgs("create", "--fakeroot", "--size", "512", overlay),
 		e2e.ExpectExit(0),
 	)
 
@@ -354,8 +345,8 @@ func (c ctx) testAddPackageWithFakerootAndTmpfs(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.FakerootProfile),
 		e2e.WithCommand("exec"),
-		e2e.WithArgs("--overlay", overlay, sif, "yum", "install", "-y", "openssh"),
-		e2e.ExpectExit(0), // sif with --writable-tmpfs isn't working (see https://github.com/apptainer/apptainer/issues/651)
+		e2e.WithArgs("--writable-tmpfs", sif, "yum", "install", "-y", "openssh"),
+		e2e.ExpectExit(0),
 	)
 
 	// running under the mode 1, 1b (--without-suid) (https://apptainer.org/docs/user/main/fakeroot.html)

--- a/examples/plugins/ubuntu-userns-overlay-plugin/main.go
+++ b/examples/plugins/ubuntu-userns-overlay-plugin/main.go
@@ -62,7 +62,7 @@ func (d *ubuntuOvlDriver) Mount(params *image.MountParams, fn image.MountFunc) e
 	)
 }
 
-func (d *ubuntuOvlDriver) Start(params *image.DriverParams) error {
+func (d *ubuntuOvlDriver) Start(params *image.DriverParams, containerPid int) error {
 	return nil
 }
 

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -34,6 +34,7 @@ func FindBin(name string) (path string, err error) {
 		"mkfs.ext3",
 		"mknod",
 		"mount",
+		"nsenter",
 		"rm",
 		"stdbuf",
 		"true",

--- a/pkg/image/driver.go
+++ b/pkg/image/driver.go
@@ -57,7 +57,7 @@ type Driver interface {
 	// Mount is called each time an engine mount an image
 	Mount(*MountParams, MountFunc) error
 	// Start the driver for initialization.
-	Start(*DriverParams) error
+	Start(*DriverParams, int) error
 	// Stop the driver related to given mount target for cleanup.
 	Stop(string) error
 	// Features Feature returns supported features.


### PR DESCRIPTION
This cherry-picks #674 to the release-1.1 branch.