### PR TITLE
Add --unsquash action option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   Also, for even better parallel performance, include a patched multithreaded
   version of `squashfuse_ll` in rpm and debian packaging in
   `${prefix}/libexec/apptainer/bin`.
+- Add `--unsquash` action flag to temporarily convert a SIF file to a
+  sandbox before running.  In previous versions this was the default when
+  running a SIF file without setuid or with fakeroot, but now the default
+  is to instead mount with squashfuse.
 - Add `--sparse` flag to `overlay create` command to allow generation of a
   sparse ext3 overlay image.
 - Support for a custom hashbang in the `%test` section of an Apptainer recipe

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -88,6 +88,7 @@ var (
 	MemorySwap        string // bytes
 	OomKillDisable    bool
 	PidsLimit         int
+	Unsquash          bool
 
 	IgnoreSubuid      bool
 	IgnoreFakerootCmd bool
@@ -806,6 +807,16 @@ var actionPidsLimitFlag = cmdline.Flag{
 	EnvKeys:      []string{"PIDS_LIMIT"},
 }
 
+// --unsquash
+var actionUnsquashFlag = cmdline.Flag{
+	ID:           "actionUnsquashFlag",
+	Value:        &Unsquash,
+	DefaultValue: false,
+	Name:         "unsquash",
+	Usage:        "Convert SIF file to temporary sandbox before running",
+	EnvKeys:      []string{"UNSQUASH"},
+}
+
 // --ignore-subuid
 var actionIgnoreSubuidFlag = cmdline.Flag{
 	ID:           "actionIgnoreSubuidFlag",
@@ -930,6 +941,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionMemorySwapFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionOomKillDisableFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPidsLimitFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionUnsquashFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreSubuidFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreFakerootCommand, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreUsernsFlag, actionsInstanceCmd...)

--- a/e2e/testdata/Apptainer
+++ b/e2e/testdata/Apptainer
@@ -2,7 +2,7 @@ bootstrap: oras
 from: ghcr.io/apptainer/alpine:3.15.0
 
 %labels
-    maintainer "Sylabs Team <support@sylabs.io>"
+    maintainer "Apptainer Team <tsc@apptainer.org>"
 
 %help
     export BAD_GUY=Thanos

--- a/internal/pkg/build/sources/oci_unpack.go
+++ b/internal/pkg/build/sources/oci_unpack.go
@@ -106,7 +106,7 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 	if b.Opts.FixPerms {
 		sylog.Warningf("The --fix-perms option modifies the filesystem permissions on the resulting container.")
 		sylog.Debugf("Modifying permissions for file/directory owners")
-		return fixPerms(b.RootfsPath)
+		return sytypes.FixPerms(b.RootfsPath)
 	}
 
 	// If `--fix-perms` was not used and this is a sandbox, scan for restrictive
@@ -118,44 +118,6 @@ func unpackRootfs(ctx context.Context, b *sytypes.Bundle, tmpfsRef types.ImageRe
 	}
 
 	// No `--fix-perms` and no sandbox... we are fine
-	return err
-}
-
-// fixPerms will work through the rootfs of this bundle, making sure that all
-// files and directories have permissions set such that the owner can read,
-// modify, delete. This brings us to the situation of <=3.4
-func fixPerms(rootfs string) (err error) {
-	errors := 0
-	err = fs.PermWalk(rootfs, func(path string, f os.FileInfo, err error) error {
-		if err != nil {
-			sylog.Errorf("Unable to access rootfs path %s: %s", path, err)
-			errors++
-			return nil
-		}
-
-		switch mode := f.Mode(); {
-		// Directories must have the owner 'rx' bits to allow traversal and reading on move, and the 'w' bit
-		// so their content can be deleted by the user when the rootfs/sandbox is deleted
-		case mode.IsDir():
-			if err := os.Chmod(path, f.Mode().Perm()|0o700); err != nil {
-				sylog.Errorf("Error setting permission for %s: %s", path, err)
-				errors++
-			}
-		case mode.IsRegular():
-			// Regular files must have the owner 'r' bit so that everything can be read in order to
-			// copy or move the rootfs/sandbox around. Also, the `w` bit as the build does write into
-			// some files (e.g. resolv.conf) in the container rootfs.
-			if err := os.Chmod(path, f.Mode().Perm()|0o600); err != nil {
-				sylog.Errorf("Error setting permission for %s: %s", path, err)
-				errors++
-			}
-		}
-		return nil
-	})
-
-	if errors > 0 {
-		err = fmt.Errorf("%d errors were encountered when setting permissions", errors)
-	}
 	return err
 }
 

--- a/internal/pkg/build/sources/packer_sif.go
+++ b/internal/pkg/build/sources/packer_sif.go
@@ -74,7 +74,7 @@ func unpackSIF(b *types.Bundle, img *image.Image) (err error) {
 
 	if b.Opts.FixPerms {
 		sylog.Debugf("Modifying permissions for file/directory owners")
-		err = fixPerms(b.RootfsPath)
+		err = types.FixPerms(b.RootfsPath)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/crypt"
 	"github.com/apptainer/apptainer/internal/pkg/util/priv"
 	"github.com/apptainer/apptainer/internal/pkg/util/starter"
+	"github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/capabilities"
@@ -66,6 +67,10 @@ func (e *EngineOperations) CleanupContainer(ctx context.Context, fatal error, st
 			// the fakeroot engine
 			err = fakerootCleanup(tempDir)
 		} else {
+			err = types.FixPerms(tempDir)
+			if err != nil {
+				sylog.Debugf("FixPerms had a problem: %v", err)
+			}
 			err = os.RemoveAll(tempDir)
 		}
 		if err != nil {


### PR DESCRIPTION
This adds an `--unsquash` action option to convert a SIF file to a temporary sandbox.

- Replaces #668