### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -94,7 +93,7 @@ func convertImage(filename string, unsquashfsPath string, tmpDir string) (rootfs
 	}
 
 	// create temporary sandbox
-	rootfsDir, err = ioutil.TempDir(tmpDir, "rootfs-")
+	rootfsDir, err = os.MkdirTemp(tmpDir, "rootfs-")
 	if err != nil {
 		return "", "", fmt.Errorf("could not create temporary sandbox: %s", err)
 	}
@@ -717,7 +716,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			"APPTAINER_IMAGE="+engineConfig.GetImage(),
 		)
 
-		content, err := ioutil.ReadFile(ApptainerEnvFile)
+		content, err := os.ReadFile(ApptainerEnvFile)
 		if err != nil {
 			sylog.Fatalf("Could not read %q environment file: %s", ApptainerEnvFile, err)
 		}

--- a/cmd/internal/cli/apptainer_test.go
+++ b/cmd/internal/cli/apptainer_test.go
@@ -10,7 +10,6 @@
 package cli
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -33,7 +32,7 @@ func TestCreateConfDir(t *testing.T) {
 		t.Errorf("failed to create directory %s", dir)
 	} else {
 		// stick something in the directory and make sure it isn't deleted
-		ioutil.WriteFile(dir+"/foo", []byte(""), 0o655)
+		os.WriteFile(dir+"/foo", []byte(""), 0o655)
 		handleConfDir(dir, "")
 		if _, err := os.Stat(dir + "/foo"); os.IsNotExist(err) {
 			t.Errorf("inadvertently overwrote existing directory %s", dir)

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -12,7 +12,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"syscall"
 
@@ -361,7 +360,7 @@ func checkBuildTarget(path string) error {
 		// image and inform users to check its content and use --force option if
 		// the sandbox image is not an Apptainer image
 		if f.IsDir() && !forceOverwrite {
-			files, err := ioutil.ReadDir(abspath)
+			files, err := os.ReadDir(abspath)
 			if err != nil {
 				return fmt.Errorf("could not read sandbox directory %s: %s", abspath, err)
 			} else if len(files) > 0 {

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -573,7 +572,7 @@ func getSIFMetadata(img *image.Image, dataType uint32) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("while reading SIF section: %s", err)
 		}
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			return nil, fmt.Errorf("while reading metadata: %s", err)
 		}

--- a/cmd/internal/cli/key_newpair_test.go
+++ b/cmd/internal/cli/key_newpair_test.go
@@ -12,7 +12,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -66,7 +65,7 @@ func Test_collectInput_flags(t *testing.T) {
 }
 
 func TestCollectInput(t *testing.T) {
-	tf, err := ioutil.TempFile("", "collect-test-")
+	tf, err := os.CreateTemp("", "collect-test-")
 	assert.NilError(t, err)
 	defer tf.Close()
 

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -11,7 +11,7 @@
 package cli
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -357,7 +357,7 @@ var RemoteLoginCmd = &cobra.Command{
 		loginArgs.Insecure = loginInsecure
 
 		if loginPasswordStdin {
-			p, err := ioutil.ReadAll(os.Stdin)
+			p, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				sylog.Fatalf("Failed to read password from stdin: %s", err)
 			}

--- a/dist/nfpm/generate.go
+++ b/dist/nfpm/generate.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -68,7 +67,7 @@ func main() {
 	}
 
 	file := "dist/nfpm/nfpm.yaml"
-	t, err := ioutil.ReadFile(file)
+	t, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatalf("while reading %s: %s", file, err)
 	}

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -13,7 +13,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -718,7 +717,7 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 	require.Command(t, "mksquashfs")
 	require.Command(t, "dd")
 
-	testdir, err := ioutil.TempDir(c.env.TestDir, "persistent-overlay-")
+	testdir, err := os.MkdirTemp(c.env.TestDir, "persistent-overlay-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -743,13 +742,13 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 	sandboxImage := filepath.Join(testdir, "sandbox")
 
 	// create an overlay directory
-	dir, err := ioutil.TempDir(testdir, "overlay-dir-")
+	dir, err := os.MkdirTemp(testdir, "overlay-dir-")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// create root directory for squashfs image
-	squashDir, err := ioutil.TempDir(testdir, "root-squash-dir-")
+	squashDir, err := os.MkdirTemp(testdir, "root-squash-dir-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1647,12 +1646,12 @@ func (c actionTests) fuseMount(t *testing.T) {
 			if t.Failed() {
 				return
 			}
-			content, err := ioutil.ReadFile(rootPrivKey)
+			content, err := os.ReadFile(rootPrivKey)
 			if err != nil {
 				t.Errorf("could not read ssh private key: %s", err)
 				return
 			}
-			if err := ioutil.WriteFile(userPrivKey, content, 0o600); err != nil {
+			if err := os.WriteFile(userPrivKey, content, 0o600); err != nil {
 				t.Errorf("could not write ssh user private key: %s", err)
 				return
 			}
@@ -1832,7 +1831,7 @@ func (c actionTests) bindImage(t *testing.T) {
 	require.Command(t, "mksquashfs")
 	require.Command(t, "dd")
 
-	testdir, err := ioutil.TempDir(c.env.TestDir, "bind-image-")
+	testdir, err := os.MkdirTemp(c.env.TestDir, "bind-image-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1860,7 +1859,7 @@ func (c actionTests) bindImage(t *testing.T) {
 	ext3Img := filepath.Join(testdir, "ext3_fs.img")
 
 	// create root directory for squashfs image
-	squashDir, err := ioutil.TempDir(testdir, "root-squash-dir-")
+	squashDir, err := os.MkdirTemp(testdir, "root-squash-dir-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -10,7 +10,6 @@
 package cmdenvvars
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,7 +24,7 @@ type ctx struct {
 }
 
 func setupTemporaryDir(t *testing.T, testdir, label string) (string, func(*testing.T)) {
-	tmpdir, err := ioutil.TempDir(testdir, label+".")
+	tmpdir, err := os.MkdirTemp(testdir, label+".")
 	if err != nil {
 		t.Fatalf("failed to create '%s' directory for test %s: %s (%#[3]v)",
 			label, t.Name(), err)
@@ -69,7 +68,7 @@ func (c *ctx) setupTemporaryKeyringDir(t *testing.T) func(*testing.T) {
 // exercise the image cache. It returns the full path to the image.
 func (c ctx) pullTestImage(t *testing.T) string {
 	// create a temporary directory for the destination image
-	tmpdir, err := ioutil.TempDir(c.env.TestDir, "image-cache.")
+	tmpdir, err := os.MkdirTemp(c.env.TestDir, "image-cache.")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory for test %s: %s (%#v)", t.Name(), err, err)
 	}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -11,7 +11,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -802,7 +801,7 @@ func (c configTests) configFile(t *testing.T) {
 			e2e.WithGlobalOptions("--config", configFile),
 			e2e.WithProfile(tt.profile),
 			e2e.PreRun(func(t *testing.T) {
-				if err := ioutil.WriteFile(configFile, []byte(tt.conf), 0o644); err != nil {
+				if err := os.WriteFile(configFile, []byte(tt.conf), 0o644); err != nil {
 					t.Errorf("could not write configuration file %s: %s", configFile, err)
 				}
 			}),

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -14,7 +14,6 @@ package e2e
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -111,7 +110,7 @@ func killAllChilds() {
 		switch match {
 		case "/proc/net/stat", "/proc/self/stat", "/proc/thread-self/stat":
 		default:
-			d, err := ioutil.ReadFile(match)
+			d, err := os.ReadFile(match)
 			if err != nil {
 				continue
 			}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -13,7 +13,6 @@
 package apptainerenv
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -450,7 +449,7 @@ func (c ctx) apptainerEnvFile(t *testing.T) {
 			args = append(args, "--env", strings.Join(tt.envOpt, ","))
 		}
 		if tt.envFile != "" {
-			ioutil.WriteFile(p, []byte(tt.envFile), 0o644)
+			os.WriteFile(p, []byte(tt.envFile), 0o644)
 			args = append(args, "--env-file", p)
 		}
 		args = append(args, tt.image, "/bin/sh", "-c", "echo $"+tt.matchEnv)

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -11,7 +11,6 @@ package imgbuild
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -70,7 +69,7 @@ func (c *imgBuildTests) issue4407(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	sandboxDir := func() string {
-		name, err := ioutil.TempDir(c.env.TestDir, "sandbox.")
+		name, err := os.MkdirTemp(c.env.TestDir, "sandbox.")
 		if err != nil {
 			log.Fatalf("failed to create temporary directory for sandbox: %v", err)
 		}
@@ -269,7 +268,7 @@ func (c *imgBuildTests) issue5166(t *testing.T) {
 	sensibleDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "sensible-dir-", "")
 
 	secret := filepath.Join(sensibleDir, "secret")
-	if err := ioutil.WriteFile(secret, []byte("secret"), 0o644); err != nil {
+	if err := os.WriteFile(secret, []byte("secret"), 0o644); err != nil {
 		t.Fatalf("could not create %s: %s", secret, err)
 	}
 
@@ -490,7 +489,7 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-3848-", "")
 	defer cleanup(t)
 
-	f, err := ioutil.TempFile(tmpDir, "test-def-")
+	f, err := os.CreateTemp(tmpDir, "test-def-")
 	if err != nil {
 		t.Fatalf("failed to open temp file: %v", err)
 	}

--- a/e2e/instance/checkpoint.go
+++ b/e2e/instance/checkpoint.go
@@ -9,7 +9,7 @@
 package instance
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -52,7 +52,7 @@ func getServerState(t *testing.T, address, expected string) {
 		t.Fatal(err)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func setServerState(t *testing.T, address, val string) {
 		t.Fatal(err)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -11,7 +11,6 @@ package instance
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -105,7 +104,7 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 	fileContents := []byte("world")
 
 	// Create a temporary directory to serve as a home directory.
-	dir, err := ioutil.TempDir(c.env.TestDir, "TestInstance")
+	dir, err := os.MkdirTemp(c.env.TestDir, "TestInstance")
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory: %v", err)
 	}
@@ -113,7 +112,7 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 
 	// Create and populate a temporary file.
 	tempFile := filepath.Join(dir, fileName)
-	err = ioutil.WriteFile(tempFile, fileContents, 0o644)
+	err = os.WriteFile(tempFile, fileContents, 0o644)
 	err = errors.Wrapf(err, "creating temporary test file %s", tempFile)
 	if err != nil {
 		t.Fatalf("Failed to create file: %+v", err)
@@ -162,7 +161,7 @@ func (c *ctx) testContain(t *testing.T) {
 	const fileName = "thegreattestfile"
 
 	// Create a temporary directory to serve as a contain directory.
-	dir, err := ioutil.TempDir("", "TestInstance")
+	dir, err := os.MkdirTemp("", "TestInstance")
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory: %v", err)
 	}
@@ -255,7 +254,7 @@ func (c *ctx) testGhostInstance(t *testing.T) {
 			t.Fatalf("instance %s failed to start correctly", instanceName)
 		}
 
-		d, err := ioutil.ReadFile(pidfile)
+		d, err := os.ReadFile(pidfile)
 		if err != nil {
 			t.Fatalf("failed to read pid file: %s", err)
 		}

--- a/e2e/internal/e2e/encrypt.go
+++ b/e2e/internal/e2e/encrypt.go
@@ -11,7 +11,7 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -49,14 +49,14 @@ func CheckCryptsetupVersion() error {
 // GeneratePemFiles creates a new PEM file for testing purposes.
 func GeneratePemFiles(t *testing.T, basedir string) (string, string) {
 	// Temporary file to save the PEM public file. The caller is in charge of cleanup
-	tempPemPubFile, err := ioutil.TempFile(basedir, "pem-pub-")
+	tempPemPubFile, err := os.CreateTemp(basedir, "pem-pub-")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}
 	tempPemPubFile.Close()
 
 	// Temporary file to save the PEM file. The caller is in charge of cleanup
-	tempPemPrivFile, err := ioutil.TempFile(basedir, "pem-priv-")
+	tempPemPrivFile, err := os.CreateTemp(basedir, "pem-priv-")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}

--- a/e2e/internal/e2e/fileutil.go
+++ b/e2e/internal/e2e/fileutil.go
@@ -10,7 +10,6 @@
 package e2e
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -22,7 +21,7 @@ import (
 // directory or in os.TempDir if dir is ""
 // returns the file name or an error
 func WriteTempFile(dir, pattern, content string) (string, error) {
-	tmpfile, err := ioutil.TempFile(dir, pattern)
+	tmpfile, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return "", err
 	}

--- a/e2e/internal/e2e/home.go
+++ b/e2e/internal/e2e/home.go
@@ -11,7 +11,6 @@ package e2e
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -158,12 +157,12 @@ func SetupHomeDirectories(t *testing.T, testRegistry string) {
 
 		// create .rpmmacros files for yum bootstrap builds
 		macrosFile := filepath.Join(unprivSessionHome, ".rpmmacros")
-		if err := ioutil.WriteFile(macrosFile, []byte(rpmMacrosContent), 0o444); err != nil {
+		if err := os.WriteFile(macrosFile, []byte(rpmMacrosContent), 0o444); err != nil {
 			err = errors.Wrapf(err, "writing macros file at %s", macrosFile)
 			t.Fatalf("could not write macros file: %+v", err)
 		}
 		macrosFile = filepath.Join(privSessionHome, ".rpmmacros")
-		if err := ioutil.WriteFile(macrosFile, []byte(rpmMacrosContent), 0o444); err != nil {
+		if err := os.WriteFile(macrosFile, []byte(rpmMacrosContent), 0o444); err != nil {
 			err = errors.Wrapf(err, "writing macros file at %s", macrosFile)
 			t.Fatalf("could not write macros file: %+v", err)
 		}
@@ -203,7 +202,7 @@ func SetupHomeDirectories(t *testing.T, testRegistry string) {
 			err = errors.Wrapf(err, "creating directory at %s", registryDir)
 			t.Fatalf("could not create directory: %+v", err)
 		}
-		if err := ioutil.WriteFile(registryFile, registriesContent, 0o444); err != nil {
+		if err := os.WriteFile(registryFile, registriesContent, 0o444); err != nil {
 			err = errors.Wrapf(err, "writing macros file at %s", macrosFile)
 			t.Fatalf("could not write registries.conf file: %+v", err)
 		}
@@ -214,7 +213,7 @@ func SetupHomeDirectories(t *testing.T, testRegistry string) {
 			err = errors.Wrapf(err, "creating directory at %s", registryDir)
 			t.Fatalf("could not create directory: %+v", err)
 		}
-		if err := ioutil.WriteFile(registryFile, registriesContent, 0o444); err != nil {
+		if err := os.WriteFile(registryFile, registriesContent, 0o444); err != nil {
 			err = errors.Wrapf(err, "writing macros file at %s", macrosFile)
 			t.Fatalf("could not write registries.conf file: %+v", err)
 		}

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -11,7 +11,7 @@ package e2e
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"sync"
@@ -170,7 +170,7 @@ func CopyImage(t *testing.T, source, dest string, insecureSource, insecureDest b
 	}
 
 	_, err = copy.Image(context.Background(), policyCtx, dstRef, srcRef, &copy.Options{
-		ReportWriter:   ioutil.Discard,
+		ReportWriter:   io.Discard,
 		SourceCtx:      srcCtx,
 		DestinationCtx: dstCtx,
 	})

--- a/e2e/internal/e2e/imagebuild.go
+++ b/e2e/internal/e2e/imagebuild.go
@@ -12,8 +12,8 @@ package e2e
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"testing"
 	"text/template"
@@ -81,7 +81,7 @@ func PrepareDefFile(dfd DefFileDetails) (outputPath string) {
 		log.Fatalf("failed to parse template: %v", err)
 	}
 
-	f, err := ioutil.TempFile("", "TestTemplate-")
+	f, err := os.CreateTemp("", "TestTemplate-")
 	if err != nil {
 		log.Fatalf("failed to open temp file: %v", err)
 	}
@@ -109,7 +109,7 @@ func PrepareMultiStageDefFile(dfd []DefFileDetails) (outputPath string) {
 		}
 	}
 
-	f, err := ioutil.TempFile("", "TestTemplate-")
+	f, err := os.CreateTemp("", "TestTemplate-")
 	if err != nil {
 		log.Fatalf("failed to open temp file: %v", err)
 	}

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -12,7 +12,6 @@ package e2e
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -308,12 +307,12 @@ func verifyFile(t *testing.T, original, copy string) error {
 		return fmt.Errorf("incorrect file modes. Original: %v, Copy: %v", ofi.Mode(), cfi.Mode())
 	}
 
-	o, err := ioutil.ReadFile(original)
+	o, err := os.ReadFile(original)
 	if err != nil {
 		t.Fatalf("While reading file: %v", err)
 	}
 
-	c, err := ioutil.ReadFile(copy)
+	c, err := os.ReadFile(copy)
 	if err != nil {
 		t.Fatalf("While reading file: %v", err)
 	}
@@ -336,7 +335,7 @@ func verifyHelp(t *testing.T, fileName string, contents []string) error {
 		return fmt.Errorf("incorrect help script perms: %v", fi.Mode().Perm())
 	}
 
-	s, err := ioutil.ReadFile(fileName)
+	s, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatalf("While reading file: %v", err)
 	}
@@ -362,7 +361,7 @@ func verifyScript(t *testing.T, fileName string, contents []string) error {
 		return fmt.Errorf("incorrect script perms: %v", fi.Mode().Perm())
 	}
 
-	s, err := ioutil.ReadFile(fileName)
+	s, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatalf("While reading file: %v", err)
 	}

--- a/e2e/internal/e2e/remote.go
+++ b/e2e/internal/e2e/remote.go
@@ -10,7 +10,7 @@
 package e2e
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,11 +24,11 @@ func SetupSystemRemoteFile(t *testing.T, testDir string) {
 		dest := filepath.Join(buildcfg.APPTAINER_CONFDIR, "remote.yaml")
 		source := filepath.Join(testDir, "remote.yaml")
 
-		data, err := ioutil.ReadFile(orig)
+		data, err := os.ReadFile(orig)
 		if err != nil {
 			t.Fatalf("while reading %s: %s", orig, err)
 		}
-		if err := ioutil.WriteFile(source, data, 0o644); err != nil {
+		if err := os.WriteFile(source, data, 0o644); err != nil {
 			t.Fatalf("while creating %s: %s", source, err)
 		}
 		if err := unix.Mount(source, dest, "", unix.MS_BIND, ""); err != nil {

--- a/e2e/oci/oci.go
+++ b/e2e/oci/oci.go
@@ -11,7 +11,7 @@ package oci
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -63,7 +63,7 @@ func genericOciMount(t *testing.T, c *ctx) (string, func()) {
 	require.Seccomp(t)
 	require.Filesystem(t, "overlay")
 
-	bundleDir, err := ioutil.TempDir(c.env.TestDir, "bundle-")
+	bundleDir, err := os.MkdirTemp(c.env.TestDir, "bundle-")
 	if err != nil {
 		err = errors.Wrapf(err, "creating temporary bundle directory at %q", c.env.TestDir)
 		t.Fatalf("failed to create bundle directory: %+v", err)

--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -6,7 +6,6 @@
 package pull
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -93,7 +92,7 @@ func (c ctx) testConcurrentPulls(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			tmpdir, err := ioutil.TempDir(c.env.TestDir, "pull_test.")
+			tmpdir, err := os.MkdirTemp(c.env.TestDir, "pull_test.")
 			if err != nil {
 				t.Fatalf("Failed to create temporary directory for pull test: %+v", err)
 			}

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -14,7 +14,6 @@ package pull
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,7 +113,7 @@ func (c *ctx) setup(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	// setup file and dir to use as invalid images
-	orasInvalidDir, err := ioutil.TempDir(c.env.TestDir, "oras_push_dir-")
+	orasInvalidDir, err := os.MkdirTemp(c.env.TestDir, "oras_push_dir-")
 	if err != nil {
 		t.Fatalf("unable to create src dir for push tests: %v", err)
 	}
@@ -338,14 +337,14 @@ func (c ctx) testPullCmd(t *testing.T) {
 			continue
 		}
 		t.Run(tt.desc, func(t *testing.T) {
-			tmpdir, err := ioutil.TempDir(c.env.TestDir, "pull_test.")
+			tmpdir, err := os.MkdirTemp(c.env.TestDir, "pull_test.")
 			if err != nil {
 				t.Fatalf("Failed to create temporary directory for pull test: %+v", err)
 			}
 			defer os.RemoveAll(tmpdir)
 
 			if tt.setPullDir {
-				tt.pullDir, err = ioutil.TempDir(tmpdir, "pull_dir.")
+				tt.pullDir, err = os.MkdirTemp(tmpdir, "pull_dir.")
 				if err != nil {
 					t.Fatalf("Failed to create temporary directory for pull dir: %+v", err)
 				}
@@ -477,7 +476,7 @@ func orasPushNoCheck(path, ref, layerMediaType string) error {
 }
 
 func (c ctx) testPullDisableCacheCmd(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "e2e-imgcache-")
+	cacheDir, err := os.MkdirTemp("", "e2e-imgcache-")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -12,7 +12,6 @@ package push
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,7 +61,7 @@ func (c ctx) testPushCmd(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	// setup file and dir to use as invalid sources
-	orasInvalidDir, err := ioutil.TempDir(c.env.TestDir, "oras_push_dir-")
+	orasInvalidDir, err := os.MkdirTemp(c.env.TestDir, "oras_push_dir-")
 	if err != nil {
 		err = errors.Wrap(err, "creating oras temporary directory")
 		t.Fatalf("unable to create src dir for push tests: %+v", err)
@@ -115,7 +114,7 @@ func (c ctx) testPushCmd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tmpdir, err := ioutil.TempDir(c.env.TestDir, "pull_test.")
+		tmpdir, err := os.MkdirTemp(c.env.TestDir, "pull_test.")
 		if err != nil {
 			t.Fatalf("Failed to create temporary directory for pull test: %+v", err)
 		}

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -13,7 +13,6 @@ package remote
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -31,7 +30,7 @@ type ctx struct {
 // It Verifies that adding valid endpoints results in success and invalid
 // one's results in failure.
 func (c ctx) remoteAdd(t *testing.T) {
-	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
+	config, err := os.CreateTemp(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -85,7 +84,7 @@ func (c ctx) remoteAdd(t *testing.T) {
 // 2. Deletes the already added entries
 // 3. Verfies that removing an invalid entry results in a failure
 func (c ctx) remoteRemove(t *testing.T) {
-	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
+	config, err := os.CreateTemp(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -158,7 +157,7 @@ func (c ctx) remoteRemove(t *testing.T) {
 // 1. Tries to use non-existing remote entry
 // 2. Adds remote entries and tries to use those
 func (c ctx) remoteUse(t *testing.T) {
-	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
+	config, err := os.CreateTemp(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -232,7 +231,7 @@ func (c ctx) remoteUse(t *testing.T) {
 // 2. Verifies that remote status command succeeds on existing endpoints
 // 3. Verifies that remote status command fails on non-existing endpoints
 func (c ctx) remoteStatus(t *testing.T) {
-	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
+	config, err := os.CreateTemp(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -303,7 +302,7 @@ func (c ctx) remoteStatus(t *testing.T) {
 
 // remoteList tests the functionality of "apptainer remote list" command
 func (c ctx) remoteList(t *testing.T) {
-	config, err := ioutil.TempFile(c.env.TestDir, "testConfig-")
+	config, err := os.CreateTemp(c.env.TestDir, "testConfig-")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -11,7 +11,6 @@ package run
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -239,7 +238,7 @@ func (c ctx) testFuseSquashMount(t *testing.T) {
 	dataDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
 	defer cleanup(t)
 
-	file, err := ioutil.TempFile(dataDir, "")
+	file, err := os.CreateTemp(dataDir, "")
 	if err != nil {
 		t.Fatalf("failed to create temp file under temp data dir: %s", dataDir)
 	}
@@ -269,7 +268,7 @@ func (c ctx) testFuseExt3Mount(t *testing.T) {
 	dataDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
 	defer cleanup(t)
 
-	file, err := ioutil.TempFile(dataDir, "")
+	file, err := os.CreateTemp(dataDir, "")
 	if err != nil {
 		t.Fatalf("failed to create temp file under temp data dir: %s", dataDir)
 	}
@@ -299,7 +298,7 @@ func (c ctx) testAddPackageWithFakerootAndTmpfs(t *testing.T) {
 	tempDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
 	defer e2e.Privileged(cleanup)
 
-	sandbox, err := ioutil.TempDir(tempDir, "sandbox")
+	sandbox, err := os.MkdirTemp(tempDir, "sandbox")
 	if err != nil {
 		t.Fatalf("could not create sandbox folder inside tempdir: %s", tempDir)
 	}

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -10,7 +10,6 @@
 package sign
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,7 +46,7 @@ func (c ctx) apptainerSignHelpOption(t *testing.T) {
 
 func (c *ctx) prepareImage(t *testing.T) (string, func(*testing.T)) {
 	// Get a refresh unsigned image
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}
@@ -236,7 +235,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"ordered": func(t *testing.T) {
 			var err error
 			// To speed up the tests, we use a common image cache (we pull the same image several times)
-			c.imgCache, err = ioutil.TempDir("", "e2e-sign-imgcache-")
+			c.imgCache, err = os.MkdirTemp("", "e2e-sign-imgcache-")
 			if err != nil {
 				t.Fatalf("failed to create temporary directory: %s", err)
 			}
@@ -248,7 +247,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			}()
 
 			// We need one single key pair in a single keyring for all the tests
-			c.keyringDir, err = ioutil.TempDir("", "e2e-sign-keyring-")
+			c.keyringDir, err = os.MkdirTemp("", "e2e-sign-keyring-")
 			if err != nil {
 				t.Fatalf("failed to create temporary directory: %s", err)
 			}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -13,7 +13,6 @@ package e2e
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -89,7 +88,7 @@ func Run(t *testing.T) {
 	}
 
 	// Make temp dir for tests
-	name, err := ioutil.TempDir("", "stest.")
+	name, err := os.MkdirTemp("", "stest.")
 	if err != nil {
 		log.Fatalf("failed to create temporary directory: %v", err)
 	}

--- a/etc/conf/gen_test.go
+++ b/etc/conf/gen_test.go
@@ -11,7 +11,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -47,12 +46,12 @@ func TestGenConf(t *testing.T) {
 }
 
 func compareFile(p1, p2 string) (bool, error) {
-	f1, err := ioutil.ReadFile(p1)
+	f1, err := os.ReadFile(p1)
 	if err != nil {
 		return false, err
 	}
 
-	f2, err := ioutil.ReadFile(p2)
+	f2, err := os.ReadFile(p2)
 	if err != nil {
 		return false, err
 	}

--- a/internal/app/apptainer/cache_list_linux.go
+++ b/internal/app/apptainer/cache_list_linux.go
@@ -11,7 +11,6 @@ package apptainer
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +31,7 @@ func listTypeCache(printList bool, name, cachePath string) (int, int64, error) {
 		return 0, 0, fmt.Errorf("unable to open cache %s at directory %s: %v", name, cachePath, err)
 	}
 
-	cacheEntries, err := ioutil.ReadDir(cachePath)
+	cacheEntries, err := os.ReadDir(cachePath)
 	if err != nil {
 		return 0, 0, fmt.Errorf("unable to open cache %s at directory %s: %v", name, cachePath, err)
 	}
@@ -40,15 +39,19 @@ func listTypeCache(printList bool, name, cachePath string) (int, int64, error) {
 	var totalSize int64
 
 	for _, entry := range cacheEntries {
+		fi, err := entry.Info()
+		if err != nil {
+			continue
+		}
 
 		if printList {
 			fmt.Printf("%-24.22s %-22s %-16s %s\n",
-				entry.Name(),
-				entry.ModTime().Format("2006-01-02 15:04:05"),
-				fs.FindSize(entry.Size()),
+				fi.Name(),
+				fi.ModTime().Format("2006-01-02 15:04:05"),
+				fs.FindSize(fi.Size()),
 				name)
 		}
-		totalSize += entry.Size()
+		totalSize += fi.Size()
 	}
 
 	return len(cacheEntries), totalSize, nil

--- a/internal/app/apptainer/oci_attach_linux.go
+++ b/internal/app/apptainer/oci_attach_linux.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	osignal "os/signal"
@@ -139,7 +138,7 @@ func attach(engineConfig *oci.EngineConfig, run bool) error {
 		return nil
 	}
 
-	io.Copy(ioutil.Discard, conn)
+	io.Copy(io.Discard, conn)
 	return nil
 }
 

--- a/internal/app/apptainer/oci_create_linux.go
+++ b/internal/app/apptainer/oci_create_linux.go
@@ -12,7 +12,7 @@ package apptainer
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -54,7 +54,7 @@ func OciCreate(containerID string, args *OciArgs) error {
 		return fmt.Errorf("oci specification file %q is missing or cannot be read", configJSON)
 	}
 
-	data, err := ioutil.ReadAll(fb)
+	data, err := io.ReadAll(fb)
 	if err != nil {
 		return fmt.Errorf("failed to read OCI specification file %s: %s", configJSON, err)
 	}

--- a/internal/app/apptainer/oci_update_linux.go
+++ b/internal/app/apptainer/oci_update_linux.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/apptainer/apptainer/internal/pkg/cgroups"
@@ -54,7 +53,7 @@ func OciUpdate(containerID string, args *OciArgs) error {
 		reader = f
 	}
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("failed to read cgroups config file: %s", err)
 	}

--- a/internal/app/apptainer/overlay_create.go
+++ b/internal/app/apptainer/overlay_create.go
@@ -12,7 +12,6 @@ package apptainer
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -102,6 +101,7 @@ func findConvertCommand(overlaySparse bool) (string, error) {
 }
 
 // OverlayCreate creates the overlay with an optional size, image path, dirs, fakeroot and sparse option.
+//
 //nolint:maintidx
 func OverlayCreate(size int, imgPath string, overlaySparse bool, isFakeroot bool, overlayDirs ...string) error {
 	if size < 64 {
@@ -200,7 +200,7 @@ func OverlayCreate(size int, imgPath string, overlaySparse bool, isFakeroot bool
 		return fmt.Errorf("while setting 0600 permission on %s: %s", tmpFile, err)
 	}
 
-	tmpDir, err := ioutil.TempDir("", "overlay-")
+	tmpDir, err := os.MkdirTemp("", "overlay-")
 	if err != nil {
 		return fmt.Errorf("while creating temporary overlay directory: %s", err)
 	}

--- a/internal/app/apptainer/plugin_compile_linux.go
+++ b/internal/app/apptainer/plugin_compile_linux.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -68,14 +67,14 @@ func getApptainerSrcDir() (string, error) {
 func checkGoVersion(goPath string) error {
 	var out bytes.Buffer
 
-	tmpDir, err := ioutil.TempDir("", "plugin-")
+	tmpDir, err := os.MkdirTemp("", "plugin-")
 	if err != nil {
 		return errors.New("temporary directory creation failed")
 	}
 	defer os.RemoveAll(tmpDir)
 
 	path := filepath.Join(tmpDir, "rt_version.go")
-	if err := ioutil.WriteFile(path, []byte(goVersionFile), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(goVersionFile), 0o600); err != nil {
 		return fmt.Errorf("while writing go file %s: %s", path, err)
 	}
 	defer os.Remove(path)

--- a/internal/app/apptainer/remote_add_test.go
+++ b/internal/app/apptainer/remote_add_test.go
@@ -10,7 +10,6 @@
 package apptainer
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,7 +27,7 @@ const (
 )
 
 func createInvalidCfgFile(t *testing.T) string {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("cannot create temporary configuration file for testing: %s\n", err)
 	}
@@ -57,7 +56,7 @@ func createInvalidCfgFile(t *testing.T) string {
 }
 
 func createValidCfgFile(t *testing.T) string {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("cannot create temporary configuration file for testing: %s\n", err)
 	}

--- a/internal/app/apptainer/sign_test.go
+++ b/internal/app/apptainer/sign_test.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +35,7 @@ func tempFileFrom(path string) (string, error) {
 		pattern = fmt.Sprintf("*.%s", ext)
 	}
 
-	tf, err := ioutil.TempFile("", pattern)
+	tf, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -247,7 +246,7 @@ func (pl *BuildApp) createAllApps(b *types.Bundle) error {
 		globalEnv94 += globalAppEnv(b, app)
 	}
 
-	return ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/env/94-appsbase.sh"), []byte(globalEnv94), 0o755)
+	return os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/env/94-appsbase.sh"), []byte(globalEnv94), 0o755)
 }
 
 func createAppRoot(b *types.Bundle, a *App) error {
@@ -281,7 +280,7 @@ func createAppRoot(b *types.Bundle, a *App) error {
 // %appenv and 01-base.sh
 func writeEnvFile(b *types.Bundle, a *App) error {
 	content := fmt.Sprintf(scifEnv01Base, a.Name)
-	if err := ioutil.WriteFile(filepath.Join(appMeta(b, a), "/env/01-base.sh"), []byte(content), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(appMeta(b, a), "/env/01-base.sh"), []byte(content), 0o755); err != nil {
 		return err
 	}
 
@@ -289,7 +288,7 @@ func writeEnvFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/env/90-environment.sh"), []byte(a.Env), 0o755)
+	return os.WriteFile(filepath.Join(appMeta(b, a), "/env/90-environment.sh"), []byte(a.Env), 0o755)
 }
 
 func globalAppEnv(b *types.Bundle, a *App) string {
@@ -319,7 +318,7 @@ func writeRunscriptFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifRunscriptBase, a.Run)
-	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/runscript"), []byte(content), 0o755)
+	return os.WriteFile(filepath.Join(appMeta(b, a), "/runscript"), []byte(content), 0o755)
 }
 
 // %apptest
@@ -329,7 +328,7 @@ func writeTestFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifTestBase, a.Test)
-	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/test"), []byte(content), 0o755)
+	return os.WriteFile(filepath.Join(appMeta(b, a), "/test"), []byte(content), 0o755)
 }
 
 // %apphelp
@@ -338,7 +337,7 @@ func writeHelpFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return ioutil.WriteFile(filepath.Join(appMeta(b, a), "/runscript.help"), []byte(a.Help), 0o644)
+	return os.WriteFile(filepath.Join(appMeta(b, a), "/runscript.help"), []byte(a.Help), 0o644)
 }
 
 // %appfile
@@ -411,7 +410,7 @@ func writeLabels(b *types.Bundle, a *App) error {
 	}
 
 	appBase := filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
-	err = ioutil.WriteFile(filepath.Join(appBase, "scif/labels.json"), text, 0o644)
+	err = os.WriteFile(filepath.Join(appBase, "scif/labels.json"), text, 0o644)
 	return err
 }
 

--- a/internal/pkg/build/assemblers/sif.go
+++ b/internal/pkg/build/assemblers/sif.go
@@ -12,7 +12,6 @@ package assemblers
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"runtime"
@@ -159,7 +158,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 	s := packer.NewSquashfs()
 	s.MksquashfsPath = a.MksquashfsPath
 
-	f, err := ioutil.TempFile(b.TmpDir, "squashfs-")
+	f, err := os.CreateTemp(b.TmpDir, "squashfs-")
 	if err != nil {
 		return fmt.Errorf("while creating temporary file for squashfs: %v", err)
 	}

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -12,7 +12,6 @@ package build
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -115,7 +114,7 @@ func newBuild(defs []types.Definition, conf Config) (*Build, error) {
 		if conf.Format == "sandbox" {
 			rootfsParent = filepath.Dir(conf.Dest)
 		}
-		parentPath, err := ioutil.TempDir(rootfsParent, "build-temp-")
+		parentPath, err := os.MkdirTemp(rootfsParent, "build-temp-")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create build parent dir: %w", err)
 		}
@@ -230,7 +229,7 @@ func ensureGzipComp(tmpdir, mksquashfsPath string) (bool, error) {
 	s := packer.NewSquashfs()
 	s.MksquashfsPath = mksquashfsPath
 
-	srcf, err := ioutil.TempFile(tmpdir, "squashfs-gzip-comp-test-src")
+	srcf, err := os.CreateTemp(tmpdir, "squashfs-gzip-comp-test-src")
 	if err != nil {
 		return false, fmt.Errorf("while creating temporary file for squashfs source: %v", err)
 	}
@@ -238,7 +237,7 @@ func ensureGzipComp(tmpdir, mksquashfsPath string) (bool, error) {
 	srcf.Write([]byte("Test File Content"))
 	srcf.Close()
 
-	f, err := ioutil.TempFile(tmpdir, "squashfs-gzip-comp-test-")
+	f, err := os.CreateTemp(tmpdir, "squashfs-gzip-comp-test-")
 	if err != nil {
 		return false, fmt.Errorf("while creating temporary file for squashfs: %v", err)
 	}
@@ -265,7 +264,7 @@ func ensureGzipComp(tmpdir, mksquashfsPath string) (bool, error) {
 		return false, fmt.Errorf("while creating squashfs: %v", err)
 	}
 
-	content, err := ioutil.ReadFile(f.Name())
+	content, err := os.ReadFile(f.Name())
 	if err != nil {
 		return false, fmt.Errorf("while reading test squashfs: %v", err)
 	}
@@ -287,7 +286,7 @@ func ensureGzipComp(tmpdir, mksquashfsPath string) (bool, error) {
 		return false, fmt.Errorf("could not build squashfs with required gzip compression")
 	}
 
-	content, err = ioutil.ReadFile(f.Name())
+	content, err = os.ReadFile(f.Name())
 	if err != nil {
 		return false, fmt.Errorf("while reading test squashfs: %v", err)
 	}

--- a/internal/pkg/build/files/copy_test.go
+++ b/internal/pkg/build/files/copy_test.go
@@ -10,7 +10,6 @@
 package files
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -90,12 +89,12 @@ func TestCopyFromHost(t *testing.T) {
 
 	// Source Files
 	srcFile := filepath.Join(dir, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := os.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	srcFileGlob := filepath.Join(dir, "srcFi?*")
 	srcSpaceFile := filepath.Join(dir, "src File")
-	if err := ioutil.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := os.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
@@ -111,7 +110,7 @@ func TestCopyFromHost(t *testing.T) {
 	srcGlob := filepath.Join(dir, "src*")
 	// Nested File (to test multi level glob)
 	srcFileNested := filepath.Join(dir, "srcDir/srcFileNested")
-	if err := ioutil.WriteFile(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
+	if err := os.WriteFile(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	srcFileNestedGlob := filepath.Join(dir, "srcDi?/srcFil?Nested")
@@ -377,7 +376,7 @@ func TestCopyFromHostNested(t *testing.T) {
 	}
 	// Source Files
 	srcFile := filepath.Join(innerDir, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := os.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
@@ -477,11 +476,11 @@ func TestCopyFromStage(t *testing.T) {
 
 	// Source Files
 	srcFile := filepath.Join(srcRoot, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := os.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	srcSpaceFile := filepath.Join(srcRoot, "src File")
-	if err := ioutil.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := os.WriteFile(srcSpaceFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs
@@ -495,7 +494,7 @@ func TestCopyFromStage(t *testing.T) {
 	}
 	// Nested File (to test multi level glob)
 	srcFileNested := filepath.Join(srcRoot, "srcDir/srcFileNested")
-	if err := ioutil.WriteFile(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
+	if err := os.WriteFile(srcFileNested, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Symlinks
@@ -779,7 +778,7 @@ func TestCopyFromStageNested(t *testing.T) {
 	}
 	// Source Files
 	srcFile := filepath.Join(innerDir, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
+	if err := os.WriteFile(srcFile, []byte(sourceFileContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -12,7 +12,7 @@ package build
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -79,7 +79,7 @@ func insertEnvScript(b *types.Bundle) error {
 		envScriptPath := filepath.Join(b.RootfsPath, "/.singularity.d/env/90-environment.sh")
 		_, err := os.Stat(envScriptPath)
 		if os.IsNotExist(err) {
-			err := ioutil.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Environment.Script+"\n"), 0o755)
+			err := os.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Environment.Script+"\n"), 0o755)
 			if err != nil {
 				return err
 			}
@@ -126,7 +126,7 @@ func insertRunScript(b *types.Bundle) error {
 	if b.RunSection("runscript") && b.Recipe.ImageData.Runscript.Script != "" {
 		sylog.Infof("Adding runscript")
 		shebang, script := handleShebangScript(b.Recipe.ImageData.Runscript)
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func insertStartScript(b *types.Bundle) error {
 	if b.RunSection("startscript") && b.Recipe.ImageData.Startscript.Script != "" {
 		sylog.Infof("Adding startscript")
 		shebang, script := handleShebangScript(b.Recipe.ImageData.Startscript)
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -150,7 +150,7 @@ func insertTestScript(b *types.Bundle) error {
 	if b.RunSection("test") && b.Recipe.ImageData.Test.Script != "" {
 		sylog.Infof("Adding testscript")
 		shebang, script := handleShebangScript(b.Recipe.ImageData.Test)
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -163,7 +163,7 @@ func insertHelpScript(b *types.Bundle) error {
 		_, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"))
 		if err != nil || b.Opts.Force {
 			sylog.Infof("Adding help info")
-			err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.ImageData.Help.Script+"\n"), 0o644)
+			err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.ImageData.Help.Script+"\n"), 0o644)
 			if err != nil {
 				return err
 			}
@@ -186,7 +186,7 @@ func insertDefinition(b *types.Bundle) error {
 		}
 
 		// look at number of files in bootstrap_history to give correct file name
-		files, err := ioutil.ReadDir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"))
+		files, err := os.ReadDir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"))
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ func insertDefinition(b *types.Bundle) error {
 		}
 	}
 
-	err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.Raw, 0o644)
+	err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.Raw, 0o644)
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 
 	// get labels added through APPTAINER_LABELS environment variables
 	buildLabels := filepath.Join(b.RootfsPath, sLabelsPath)
-	content, err := ioutil.ReadFile(buildLabels)
+	content, err := os.ReadFile(buildLabels)
 	if err == nil {
 		if err := os.Remove(filepath.Join(b.RootfsPath, sLabelsPath)); err != nil {
 			return err
@@ -261,7 +261,7 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
+	err = os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
 	return err
 }
 
@@ -299,7 +299,7 @@ func getExistingLabels(labels map[string]string, b *types.Bundle) error {
 		}
 		defer jsonFile.Close()
 
-		jsonBytes, err := ioutil.ReadAll(jsonFile)
+		jsonBytes, err := io.ReadAll(jsonFile)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -14,7 +14,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -99,7 +98,7 @@ func createIndexFile(t *testing.T, dir string, sum string) {
 	if jsonErr != nil {
 		t.Fatalf("cannot unmarshal JSON: %s\n", jsonErr)
 	}
-	err := ioutil.WriteFile(path, data, 0o664)
+	err := os.WriteFile(path, data, 0o664)
 	if err != nil {
 		t.Fatalf("cannot create index file: %s\n", err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -219,7 +218,7 @@ func (cp *ArchConveyorPacker) getBootstrapOptions() (err error) {
 }
 
 func (cp *ArchConveyorPacker) getPacConf(pacmanConfURL string) (pacConf string, err error) {
-	pacConfFile, err := ioutil.TempFile(cp.b.RootfsPath, "pac-conf-")
+	pacConfFile, err := os.CreateTemp(cp.b.RootfsPath, "pac-conf-")
 	if err != nil {
 		return
 	}
@@ -246,7 +245,7 @@ func (cp *ArchConveyorPacker) insertBaseEnv() (err error) {
 }
 
 func (cp *ArchConveyorPacker) insertRunScript() (err error) {
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -82,15 +81,15 @@ func (cp *BusyBoxConveyorPacker) Pack(context.Context) (b *types.Bundle, err err
 }
 
 func (c *BusyBoxConveyor) insertBaseFiles() error {
-	if err := ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0o664); err != nil {
+	if err := os.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0o664); err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/group"), []byte(" root:x:0:"), 0o664); err != nil {
+	if err := os.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/group"), []byte(" root:x:0:"), 0o664); err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0o664)
+	return os.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0o664)
 }
 
 func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, err error) {
@@ -142,7 +141,7 @@ func (c *BusyBoxConveyor) insertBaseEnv() (err error) {
 }
 
 func (cp *BusyBoxConveyorPacker) insertRunScript() error {
-	return ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	return os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 }
 
 // CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -206,7 +205,7 @@ func (cp *DebootstrapConveyorPacker) Get(ctx context.Context, b *types.Bundle) (
 			}
 			defer fh.Close()
 
-			log, err := ioutil.ReadAll(fh)
+			log, err := io.ReadAll(fh)
 			if err != nil {
 				sylog.Debugf("Cannot read %s: %#v", fn, err)
 				return

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -193,7 +192,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 			cp.srcRef, err = ociarchive.ParseReference(ref)
 		} else {
 			// As non-root we need to do a dumb tar extraction first
-			tmpDir, err := ioutil.TempDir(b.TmpDir, "temp-oci-")
+			tmpDir, err := os.MkdirTemp(b.TmpDir, "temp-oci-")
 			if err != nil {
 				return fmt.Errorf("could not create temporary oci directory: %v", err)
 			}
@@ -287,7 +286,7 @@ func (cp *OCIConveyorPacker) Pack(ctx context.Context) (*sytypes.Bundle, error) 
 func (cp *OCIConveyorPacker) fetch(ctx context.Context) error {
 	// cp.srcRef contains the cache source reference
 	_, err := copy.Image(ctx, cp.policyCtx, cp.tmpfsRef, cp.srcRef, &copy.Options{
-		ReportWriter: ioutil.Discard,
+		ReportWriter: io.Discard,
 		SourceCtx:    cp.sysCtx,
 	})
 	return err
@@ -539,7 +538,7 @@ func (cp *OCIConveyorPacker) insertOCILabels() (err error) {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
+	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
 	return err
 }
 

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -12,7 +12,6 @@ package sources_test
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -285,7 +284,7 @@ func TestOCIPacker(t *testing.T) {
 }
 
 func getTestTar(url string) (path string, err error) {
-	dl, err := ioutil.TempFile("", "oci-test")
+	dl, err := os.CreateTemp("", "oci-test")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_scratch.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch.go
@@ -12,7 +12,7 @@ package sources
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/apptainer/apptainer/pkg/build/types"
@@ -58,7 +58,7 @@ func (c *ScratchConveyor) insertBaseEnv() (err error) {
 }
 
 func (cp *ScratchConveyorPacker) insertRunScript() (err error) {
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -256,7 +255,7 @@ func (c *YumConveyor) genYumConfig() (err error) {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, "/etc"), err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(c.b.RootfsPath, yumConf), []byte(fileContent), 0o664)
+	err = os.WriteFile(filepath.Join(c.b.RootfsPath, yumConf), []byte(fileContent), 0o664)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, yumConf), err)
 	}
@@ -346,7 +345,7 @@ func (cp *YumConveyorPacker) insertBaseEnv() (err error) {
 }
 
 func (cp *YumConveyorPacker) insertRunScript() (err error) {
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -175,7 +174,7 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err e
 			return fmt.Errorf("malformed Product setting")
 		}
 		if slepgpOk {
-			tmpfile, err := ioutil.TempFile("/tmp", "apptainer-pgp")
+			tmpfile, err := os.CreateTemp("/tmp", "apptainer-pgp")
 			if err != nil {
 				return fmt.Errorf("cannot create pgp-file: %v", err)
 			}
@@ -393,7 +392,7 @@ func (cp *ZypperConveyorPacker) genZypperConfig() (err error) {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(cp.b.RootfsPath, "/etc/zypp"), err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(cp.b.RootfsPath, zypperConf), []byte("[main]\ncachedir=/val/cache/zypp-bootstrap\n\n"), 0o664)
+	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, zypperConf), []byte("[main]\ncachedir=/val/cache/zypp-bootstrap\n\n"), 0o664)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/packer_ext3.go
+++ b/internal/pkg/build/sources/packer_ext3.go
@@ -12,7 +12,6 @@ package sources
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"syscall"
 
@@ -59,7 +58,7 @@ func unpackExt3(b *types.Bundle, img *image.Image) error {
 		return fmt.Errorf("while attaching image to loop device: %v", err)
 	}
 
-	tmpmnt, err := ioutil.TempDir(b.TmpDir, "mnt")
+	tmpmnt, err := os.MkdirTemp(b.TmpDir, "mnt")
 	if err != nil {
 		return fmt.Errorf("while making tmp mount point: %v", err)
 	}

--- a/internal/pkg/build/sources/packer_sif.go
+++ b/internal/pkg/build/sources/packer_sif.go
@@ -12,7 +12,7 @@ package sources
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/apptainer/apptainer/internal/pkg/image/unpacker"
 	"github.com/apptainer/apptainer/pkg/build/types"
@@ -86,7 +86,7 @@ func unpackSIF(b *types.Bundle, img *image.Image) (err error) {
 	} else if err != nil {
 		return fmt.Errorf("could not get OCI config section reader: %v", err)
 	} else {
-		ociConfig, err := ioutil.ReadAll(ociReader)
+		ociConfig, err := io.ReadAll(ociReader)
 		if err != nil {
 			return fmt.Errorf("could not read OCI config: %v", err)
 		}

--- a/internal/pkg/build/util.go
+++ b/internal/pkg/build/util.go
@@ -12,7 +12,6 @@ package build
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,7 +69,7 @@ func createStageFile(source string, b *types.Bundle, warnMsg string) (string, er
 	}
 	defer stageFile.Close()
 
-	content, err := ioutil.ReadFile(source)
+	content, err := os.ReadFile(source)
 	if err != nil {
 		return "", fmt.Errorf("failed to read %s: %s", source, err)
 	}

--- a/internal/pkg/buildcfg/confgen/gen.go
+++ b/internal/pkg/buildcfg/confgen/gen.go
@@ -13,7 +13,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -129,7 +128,7 @@ func main() {
 	defer outFile.Close()
 
 	// Determine if this is a setuid install
-	b, err := ioutil.ReadFile(os.Args[1])
+	b, err := os.ReadFile(os.Args[1])
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -146,7 +145,7 @@ func main() {
 	}
 
 	// Parse the config.h file
-	inFile, err := ioutil.ReadFile(os.Args[1])
+	inFile, err := os.ReadFile(os.Args[1])
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/internal/pkg/cgroups/config_linux.go
+++ b/internal/pkg/cgroups/config_linux.go
@@ -11,7 +11,7 @@ package cgroups
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -202,7 +202,7 @@ func LoadConfig(confPath string) (config Config, err error) {
 	}
 
 	// read in the Cgroups config file
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}
@@ -219,7 +219,7 @@ func SaveConfig(config Config, confPath string) (err error) {
 		return
 	}
 
-	return ioutil.WriteFile(confPath, data, 0o600)
+	return os.WriteFile(confPath, data, 0o600)
 }
 
 // LoadResources loads a cgroups config file into a LinuxResources struct

--- a/internal/pkg/cgroups/manager_linux_v1_test.go
+++ b/internal/pkg/cgroups/manager_linux_v1_test.go
@@ -10,7 +10,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -126,7 +125,7 @@ func testNewUpdateV1(t *testing.T, systemd bool) {
 
 	// Write a new config with [pids] limit = 512
 	content := []byte("[pids]\nlimit = 512")
-	tmpfile, err := ioutil.TempFile("", "cgroups")
+	tmpfile, err := os.CreateTemp("", "cgroups")
 	if err != nil {
 		t.Fatalf("While creating update file: %v", err)
 	}

--- a/internal/pkg/cgroups/manager_linux_v2_test.go
+++ b/internal/pkg/cgroups/manager_linux_v2_test.go
@@ -10,7 +10,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -116,7 +115,7 @@ func testNewUpdateV2(t *testing.T, systemd bool) {
 
 	// Write a new config with [pids] limit = 512
 	content := []byte("[pids]\nlimit = 512")
-	tmpfile, err := ioutil.TempFile("", "cgroups")
+	tmpfile, err := os.CreateTemp("", "cgroups")
 	if err != nil {
 		t.Fatalf("While creating update file: %v", err)
 	}

--- a/internal/pkg/checkpoint/dmtcp/checkpoint.go
+++ b/internal/pkg/checkpoint/dmtcp/checkpoint.go
@@ -11,7 +11,6 @@ package dmtcp
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -93,7 +92,7 @@ func (checkpointManager) Get(name string) (*Entry, error) {
 }
 
 func (checkpointManager) List() ([]*Entry, error) {
-	fis, err := ioutil.ReadDir(dmtcpDir())
+	fis, err := os.ReadDir(dmtcpDir())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/checkpoint/dmtcp/dmtcp.go
+++ b/internal/pkg/checkpoint/dmtcp/dmtcp.go
@@ -9,7 +9,7 @@
 package dmtcp
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -42,7 +42,7 @@ type Config struct {
 
 func parseConfig() (*Config, error) {
 	confPath := filepath.Join(buildcfg.APPTAINER_CONFDIR, "dmtcp-conf.yaml")
-	buf, err := ioutil.ReadFile(confPath)
+	buf, err := os.ReadFile(confPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -112,7 +111,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom *libClient.Ref, 
 	directTo := ""
 
 	if imgCache.IsDisabled() {
-		file, err := ioutil.TempFile(tmpDir, "sbuild-tmp-cache-")
+		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
 		if err != nil {
 			return "", fmt.Errorf("unable to create tmp file: %v", err)
 		}

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -15,7 +15,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -182,7 +181,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, tmpDir s
 	directTo := ""
 
 	if imgCache.IsDisabled() {
-		file, err := ioutil.TempFile(tmpDir, "sbuild-tmp-cache-")
+		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
 		if err != nil {
 			return "", fmt.Errorf("unable to create tmp file: %v", err)
 		}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -13,7 +13,7 @@ package oci
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/apptainer/apptainer/internal/pkg/build"
@@ -88,7 +88,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 	directTo := ""
 
 	if imgCache.IsDisabled() {
-		file, err := ioutil.TempFile(tmpDir, "sbuild-tmp-cache-")
+		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
 		if err != nil {
 			return "", fmt.Errorf("unable to create tmp file: %v", err)
 		}

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -304,7 +303,7 @@ func ImageSHA(ctx context.Context, uri string, ociAuth *ocitypes.DockerAuthConfi
 	}
 	defer rc.Close()
 
-	b, err := ioutil.ReadAll(rc)
+	b, err := io.ReadAll(rc)
 	if err != nil {
 		return "", fmt.Errorf("while reading manifest: %v", err)
 	}

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -12,7 +12,7 @@ package oras
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
@@ -71,7 +71,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 	directTo := ""
 
 	if imgCache.IsDisabled() {
-		file, err := ioutil.TempFile(tmpDir, "sbuild-tmp-cache-")
+		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
 		if err != nil {
 			return "", fmt.Errorf("unable to create tmp file: %v", err)
 		}

--- a/internal/pkg/client/shub/api.go
+++ b/internal/pkg/client/shub/api.go
@@ -13,7 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -101,7 +101,7 @@ func GetManifest(uri URI, noHTTPS bool) (APIResponse, error) {
 		return APIResponse{}, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return APIResponse{}, err
 	}

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -12,7 +12,6 @@ package shub
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -185,7 +184,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 	directTo := ""
 
 	if imgCache.IsDisabled() {
-		file, err := ioutil.TempFile(tmpDir, "sbuild-tmp-cache-")
+		file, err := os.CreateTemp(tmpDir, "sbuild-tmp-cache-")
 		if err != nil {
 			return "", fmt.Errorf("unable to create tmp file: %v", err)
 		}

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -11,7 +11,6 @@ package driver
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -308,7 +307,7 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 				// Using unix.Access is not sufficient here
 				// so have to attempt to create a file
 				binpath := params.Target + "/usr/bin"
-				tmpfile, err := ioutil.TempFile(binpath, ".tmp*")
+				tmpfile, err := os.CreateTemp(binpath, ".tmp*")
 				if err != nil {
 					sylog.Debugf("%v not writable: %v", binpath, err)
 					sylog.Infof("/usr/bin not writable in container")
@@ -346,7 +345,8 @@ func (d *fuseappsDriver) Start(params *image.DriverParams, containerPid int) err
 
 // Stop the process associated with the mount target, if there is one.
 // If kill is not true, an unmount should already have happened so at
-//   first just wait for the process to exit.
+//
+//	first just wait for the process to exit.
 func (f *fuseappsFeature) stop(target string, kill bool) error {
 	for _, instance := range f.instances {
 		if instance.params.Target != target {

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -345,8 +345,7 @@ func (d *fuseappsDriver) Start(params *image.DriverParams, containerPid int) err
 
 // Stop the process associated with the mount target, if there is one.
 // If kill is not true, an unmount should already have happened so at
-//
-//	first just wait for the process to exit.
+//   first just wait for the process to exit.
 func (f *fuseappsFeature) stop(target string, kill bool) error {
 	for _, instance := range f.instances {
 		if instance.params.Target != target {

--- a/internal/pkg/image/packer/squashfs_test.go
+++ b/internal/pkg/image/packer/squashfs_test.go
@@ -10,7 +10,6 @@
 package packer
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,7 +43,7 @@ func isExist(path string) bool {
 }
 
 func createSquashfs(t *testing.T, s *Squashfs) (string, error) {
-	image, err := ioutil.TempFile("", "packer-")
+	image, err := os.CreateTemp("", "packer-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/image/unpacker/squashfs.go
+++ b/internal/pkg/image/unpacker/squashfs.go
@@ -13,7 +13,6 @@ package unpacker
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -91,7 +90,7 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 
 		// unsquashfs doesn't support to send file content over
 		// a stdin pipe since it use lseek for every read it does
-		tmp, err := ioutil.TempFile(tmpdir, "archive-")
+		tmp, err := os.CreateTemp(tmpdir, "archive-")
 		if err != nil {
 			return fmt.Errorf("failed to create staging file: %s", err)
 		}
@@ -199,7 +198,7 @@ func (s *Squashfs) ExtractFiles(files []string, reader io.Reader, dest string) e
 
 // TestUserXattr tries to set a user xattr on PATH to ensure they are supported on this fs
 func TestUserXattr(path string) (ok bool, err error) {
-	tmp, err := ioutil.TempFile(path, "uxattr-")
+	tmp, err := os.CreateTemp(path, "uxattr-")
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/image/unpacker/squashfs_apptainer.go
+++ b/internal/pkg/image/unpacker/squashfs_apptainer.go
@@ -18,7 +18,6 @@ import (
 	"debug/elf"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -157,7 +156,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 
 	// create the sandbox temporary directory
 	tmpdir := filepath.Dir(dest)
-	rootfs, err := ioutil.TempDir(tmpdir, "tmp-rootfs-")
+	rootfs, err := os.MkdirTemp(tmpdir, "tmp-rootfs-")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create chroot directory: %s", err)
 	}
@@ -227,7 +226,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 		if err := os.MkdirAll(rootfsDir, 0o700); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", rootfsDir, err)
 		}
-		if err := ioutil.WriteFile(rootfsFile, []byte(""), 0o600); err != nil {
+		if err := os.WriteFile(rootfsFile, []byte(""), 0o600); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", rootfsFile, err)
 		}
 		// Simple read-only bind, dest in container same as source on host
@@ -243,7 +242,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 		if err := os.MkdirAll(rootfsDir, 0o700); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", rootfsDir, err)
 		}
-		if err := ioutil.WriteFile(rootfsFile, []byte(""), 0o600); err != nil {
+		if err := os.WriteFile(rootfsFile, []byte(""), 0o600); err != nil {
 			return nil, fmt.Errorf("while creating %s: %s", rootfsFile, err)
 		}
 		// Read only bind, dest in container may not match source on host due

--- a/internal/pkg/image/unpacker/squashfs_test.go
+++ b/internal/pkg/image/unpacker/squashfs_test.go
@@ -12,7 +12,6 @@ package unpacker
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,7 +23,7 @@ func createArchive(t *testing.T) *os.File {
 	if err != nil {
 		t.SkipNow()
 	}
-	f, err := ioutil.TempFile("", "archive-")
+	f, err := os.CreateTemp("", "archive-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -12,7 +12,6 @@ package instance
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -219,7 +218,7 @@ func (i *File) isExited() bool {
 		// we would have obtained permission denied error,
 		// now check if it's an instance parent process
 		cmdline := fmt.Sprintf("/proc/%d/cmdline", i.PPid)
-		d, err := ioutil.ReadFile(cmdline)
+		d, err := os.ReadFile(cmdline)
 		if err != nil {
 			// this is racy and not accurate but as the process
 			// may have exited during above read, check again

--- a/internal/pkg/instance/logger_test.go
+++ b/internal/pkg/instance/logger_test.go
@@ -11,7 +11,6 @@ package instance
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -77,7 +76,7 @@ func TestLogger(t *testing.T) {
 		},
 	}
 
-	logfile, err := ioutil.TempFile("", "log-")
+	logfile, err := os.CreateTemp("", "log-")
 	if err != nil {
 		t.Errorf("failed to create temporary log file: %s", err)
 	}
@@ -97,7 +96,7 @@ func TestLogger(t *testing.T) {
 
 		logger.Close()
 
-		d, err := ioutil.ReadFile(filename)
+		d, err := os.ReadFile(filename)
 		if err != nil {
 			t.Errorf("failed to read log data: %s", err)
 		}

--- a/internal/pkg/plugin/binary.go
+++ b/internal/pkg/plugin/binary.go
@@ -13,7 +13,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -185,7 +184,7 @@ func Inspect(name string) (pluginapi.Manifest, error) {
 		// Replace the original name, which seems to be
 		// the name of a plugin, by the path to the
 		// installed manifest file for that plugin.
-		data, err := ioutil.ReadFile(meta.manifestName())
+		data, err := os.ReadFile(meta.manifestName())
 		if err != nil {
 			return manifest, err
 		}

--- a/internal/pkg/plugin/create.go
+++ b/internal/pkg/plugin/create.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -72,13 +71,13 @@ func Create(path, name string) error {
 	// create main.go skeleton
 	filename := filepath.Join(dir, "main.go")
 	content := fmt.Sprintf(mainGo, name)
-	if err := ioutil.WriteFile(filename, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filename, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("while creating plugin %s: %s", filename, err)
 	}
 
 	// create .gitignore skeleton
 	filename = filepath.Join(dir, ".gitignore")
-	if err := ioutil.WriteFile(filename, []byte(gitIgnore), 0o644); err != nil {
+	if err := os.WriteFile(filename, []byte(gitIgnore), 0o644); err != nil {
 		return fmt.Errorf("while creating plugin %s: %s", filename, err)
 	}
 

--- a/internal/pkg/remote/endpoint/config.go
+++ b/internal/pkg/remote/endpoint/config.go
@@ -13,7 +13,6 @@ package endpoint
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -120,5 +119,5 @@ func updateCachedConfig(uri string, data []byte) {
 		return
 	}
 	config := filepath.Join(dir, uri+".json")
-	ioutil.WriteFile(config, data, 0o600)
+	os.WriteFile(config, data, 0o600)
 }

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -14,7 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -150,7 +150,7 @@ func (config *Config) GetAllServices() (map[string][]Service, error) {
 	}
 	defer reader.Close()
 
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("while reading response body: %v", err)
 	}

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -71,7 +70,7 @@ func ReadFrom(r io.Reader) (*Config, error) {
 	}
 
 	// read all data from r into b
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from io.Reader: %s", err)
 	}

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -12,7 +12,7 @@ package apptainer
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -590,6 +590,7 @@ func (c *container) chdirFinal(system *mount.System) error {
 }
 
 // mount any generic mount (not loop dev)
+//
 //nolint:maintidx
 func (c *container) mountGeneric(mnt *mount.Point, tag mount.AuthorizedTag) (err error) {
 	flags, opts := mount.ConvertOptions(mnt.Options)
@@ -2312,7 +2313,7 @@ func (c *container) addResolvConfMount(system *mount.System) error {
 			if err != nil {
 				return err
 			}
-			content, err = ioutil.ReadAll(r)
+			content, err = io.ReadAll(r)
 			r.Close()
 			if err != nil {
 				return err

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -818,7 +817,7 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 		}
 
 		// we must read "appinit\n"
-		b, err := ioutil.ReadFile("comm")
+		b, err := os.ReadFile("comm")
 		if err != nil {
 			return fmt.Errorf("failed to read %s: %s", path, err)
 		}

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -933,7 +932,7 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 // getDockerRunscript returns the content as a reader of
 // the default runscript set for docker images if any.
 func getDockerRunscript(path string) (io.Reader, error) {
-	r, err := ioutil.ReadFile(path)
+	r, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("while reading %s: %s", path, err)
 	}

--- a/internal/pkg/runtime/engine/apptainer/rpc/args.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/args.go
@@ -112,7 +112,7 @@ type ReadDirArgs struct {
 
 // ReadDirReply defines the reply for readdir.
 type ReadDirReply struct {
-	Files []os.FileInfo
+	Files []os.DirEntry
 }
 
 // ChownArgs defines the arguments to chown/lchown.

--- a/internal/pkg/runtime/engine/apptainer/rpc/args.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/args.go
@@ -112,7 +112,7 @@ type ReadDirArgs struct {
 
 // ReadDirReply defines the reply for readdir.
 type ReadDirReply struct {
-	Files []os.DirEntry
+	Files []os.FileInfo
 }
 
 // ChownArgs defines the arguments to chown/lchown.

--- a/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
@@ -184,7 +184,7 @@ func (t *RPC) Symlink(old string, new string) error {
 }
 
 // ReadDir calls the readdir RPC using the supplied arguments.
-func (t *RPC) ReadDir(dir string) ([]os.DirEntry, error) {
+func (t *RPC) ReadDir(dir string) ([]os.FileInfo, error) {
 	arguments := &args.ReadDirArgs{
 		Dir: dir,
 	}

--- a/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
@@ -184,7 +184,7 @@ func (t *RPC) Symlink(old string, new string) error {
 }
 
 // ReadDir calls the readdir RPC using the supplied arguments.
-func (t *RPC) ReadDir(dir string) ([]os.FileInfo, error) {
+func (t *RPC) ReadDir(dir string) ([]os.DirEntry, error) {
 	arguments := &args.ReadDirArgs{
 		Dir: dir,
 	}

--- a/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
@@ -11,7 +11,6 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
@@ -377,9 +376,9 @@ func (t *Methods) Symlink(arguments *args.SymlinkArgs, reply *int) error {
 
 // ReadDir performs a readdir with the specified arguments.
 func (t *Methods) ReadDir(arguments *args.ReadDirArgs, reply *args.ReadDirReply) error {
-	files, err := ioutil.ReadDir(arguments.Dir)
-	for i, file := range files {
-		files[i] = args.FileInfo(file)
+	files, err := os.ReadDir(arguments.Dir)
+	if err != nil {
+		return err
 	}
 	reply.Files = files
 	return err

--- a/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
@@ -380,7 +380,15 @@ func (t *Methods) ReadDir(arguments *args.ReadDirArgs, reply *args.ReadDirReply)
 	if err != nil {
 		return err
 	}
-	reply.Files = files
+	infos := make([]os.FileInfo, 0, len(files))
+	for _, file := range files {
+		info, err := file.Info()
+		if err != nil {
+			continue
+		}
+		infos = append(infos, args.FileInfo(info))
+	}
+	reply.Files = infos
 	return err
 }
 

--- a/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate_test.go
@@ -11,7 +11,6 @@ package generate
 
 import (
 	"io"
-	"io/ioutil"
 	"reflect"
 	"sync"
 	"testing"
@@ -206,7 +205,7 @@ func TestSave(t *testing.T) {
 		defer r.Close()
 		defer wg.Done()
 
-		d, err := ioutil.ReadAll(r)
+		d, err := io.ReadAll(r)
 		if err != nil {
 			t.Errorf("while reading pipe: %s", err)
 			return

--- a/internal/pkg/runtime/engine/oci/process_linux.go
+++ b/internal/pkg/runtime/engine/oci/process_linux.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	osexec "os/exec"
@@ -214,7 +213,7 @@ func (e *EngineOperations) PreStartProcess(ctx context.Context, pid int, masterC
 
 	pidFile := e.EngineConfig.GetPidFile()
 	if pidFile != "" {
-		if err := ioutil.WriteFile(pidFile, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		if err := os.WriteFile(pidFile, []byte(strconv.Itoa(pid)), 0o644); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/security/apparmor/apparmor_supported.go
+++ b/internal/pkg/security/apparmor/apparmor_supported.go
@@ -13,13 +13,12 @@ package apparmor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
 // Enabled returns whether AppArmor is enabled.
 func Enabled() bool {
-	data, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
+	data, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
 	if err == nil && len(data) > 0 && data[0] == 'Y' {
 		return true
 	}

--- a/internal/pkg/security/seccomp/seccomp_supported.go
+++ b/internal/pkg/security/seccomp/seccomp_supported.go
@@ -13,7 +13,7 @@ package seccomp
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"syscall"
 
@@ -200,7 +200,7 @@ func LoadProfileFromFile(profile string, generator *generate.Generator) error {
 	}
 	defer file.Close()
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/security/seccomp/seccomp_supported_test.go
+++ b/internal/pkg/security/seccomp/seccomp_supported_test.go
@@ -12,7 +12,6 @@
 package seccomp
 
 import (
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -43,7 +42,7 @@ func defaultProfile() *specs.LinuxSeccomp {
 }
 
 func testFchmod(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "chmod_file")
+	tmpfile, err := os.CreateTemp("", "chmod_file")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,7 +60,7 @@ type Execgroup struct {
 // LoadConfig opens an ECL config file and unmarshals it into structures
 func LoadConfig(confPath string) (ecl EclConfig, err error) {
 	// read in the ECL config file
-	b, err := ioutil.ReadFile(confPath)
+	b, err := os.ReadFile(confPath)
 	if err != nil {
 		return
 	}
@@ -78,7 +77,7 @@ func PutConfig(ecl EclConfig, confPath string) (err error) {
 		return
 	}
 
-	return ioutil.WriteFile(confPath, data, 0o644)
+	return os.WriteFile(confPath, data, 0o644)
 }
 
 // ValidateConfig makes sure paths from configs are fully resolved and that

--- a/internal/pkg/syecl/syecl_test.go
+++ b/internal/pkg/syecl/syecl_test.go
@@ -12,7 +12,6 @@ package syecl
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -105,7 +104,7 @@ func TestAPutConfig(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			tf, err := ioutil.TempFile("", "eclconfig-test")
+			tf, err := os.CreateTemp("", "eclconfig-test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -116,7 +115,7 @@ func TestAPutConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			b, err := ioutil.ReadFile(tf.Name())
+			b, err := os.ReadFile(tf.Name())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -13,7 +13,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -201,7 +200,7 @@ func CgroupsV2Delegated(t *testing.T, controller string) {
 
 	delegatePath := filepath.Join("/sys/fs/cgroup", cgPath, "cgroup.controllers")
 
-	data, err := ioutil.ReadFile(delegatePath)
+	data, err := os.ReadFile(delegatePath)
 	if err != nil {
 		t.Skipf("while reading delegation file: %s", err)
 	}

--- a/internal/pkg/util/auth/token.go
+++ b/internal/pkg/util/auth/token.go
@@ -14,7 +14,6 @@ package auth
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -40,7 +39,7 @@ func ReadToken(tokenPath string) (token string, err error) {
 		return "", ErrTokenFileNotFound
 	}
 
-	buf, err := ioutil.ReadFile(tokenPath)
+	buf, err := os.ReadFile(tokenPath)
 	if err != nil {
 		return "", ErrCouldntReadFile
 	}

--- a/internal/pkg/util/crypt/crypt_dev.go
+++ b/internal/pkg/util/crypt/crypt_dev.go
@@ -13,7 +13,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -125,7 +124,7 @@ func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) 
 	fSize := f.Size()
 
 	// Create a temporary file to format with crypt header
-	cryptF, err := ioutil.TempFile("", "crypt-")
+	cryptF, err := os.CreateTemp("", "crypt-")
 	if err != nil {
 		sylog.Debugf("Error creating temporary crypt file")
 		return "", err

--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -10,7 +10,6 @@
 package crypt
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,7 +26,7 @@ func TestEncrypt(t *testing.T) {
 
 	dev := &Device{}
 
-	emptyFile, err := ioutil.TempFile("", "")
+	emptyFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}
@@ -56,7 +55,7 @@ func TestEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get path to squashfs binary: %s", err)
 	}
-	tempTargetFile, err := ioutil.TempFile("", "")
+	tempTargetFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}

--- a/internal/pkg/util/fs/files/files_linux_test.go
+++ b/internal/pkg/util/fs/files/files_linux_test.go
@@ -11,7 +11,6 @@ package files
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -34,7 +33,7 @@ func TestGroup(t *testing.T) {
 		t.Errorf("should have passed with correct group file")
 	}
 	// with an empty file
-	f, err := ioutil.TempFile("", "empty-group-")
+	f, err := os.CreateTemp("", "empty-group-")
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,7 +62,7 @@ func TestPasswd(t *testing.T) {
 		t.Errorf("should have passed with correct passwd file")
 	}
 	// with an empty file
-	f, err := ioutil.TempFile("", "empty-passwd-")
+	f, err := os.CreateTemp("", "empty-passwd-")
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/pkg/util/fs/files/group.go
+++ b/internal/pkg/util/fs/files/group.go
@@ -11,7 +11,7 @@ package files
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
@@ -64,7 +64,7 @@ func Group(path string, uid int, gids []int) (content []byte, err error) {
 			groups = append(groups, int(pwInfo.GID))
 		}
 	}
-	content, err = ioutil.ReadAll(groupFile)
+	content, err = io.ReadAll(groupFile)
 	if err != nil {
 		return content, fmt.Errorf("failed to read group file content in container: %s", err)
 	}

--- a/internal/pkg/util/fs/files/passwd.go
+++ b/internal/pkg/util/fs/files/passwd.go
@@ -11,7 +11,7 @@ package files
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
@@ -27,7 +27,7 @@ func Passwd(path string, home string, uid int) (content []byte, err error) {
 	}
 
 	sylog.Verbosef("Creating passwd content")
-	content, err = ioutil.ReadFile(path)
+	content, err = os.ReadFile(path)
 	if err != nil {
 		return content, fmt.Errorf("failed to read passwd file content in container: %s", err)
 	}

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -12,7 +12,6 @@ package fs
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -283,7 +282,7 @@ func Touch(path string) error {
 // basedir exists, so it's the caller's responsibility to create
 // it before calling it.
 func MakeTmpDir(basedir, pattern string, mode os.FileMode) (string, error) {
-	name, err := ioutil.TempDir(basedir, pattern)
+	name, err := os.MkdirTemp(basedir, pattern)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory: %s", err)
 	}
@@ -298,7 +297,7 @@ func MakeTmpDir(basedir, pattern string, mode os.FileMode) (string, error) {
 // basedir exists, so it's the caller's responsibility to create
 // it before calling it.
 func MakeTmpFile(basedir, pattern string, mode os.FileMode) (*os.File, error) {
-	f, err := ioutil.TempFile(basedir, pattern)
+	f, err := os.CreateTemp(basedir, pattern)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary file: %s", err)
 	}

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -11,7 +11,6 @@ package fs
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -472,7 +471,7 @@ func testCopyFileFunc(t *testing.T, fn copyFileFunc) {
 	tmpDir := t.TempDir()
 
 	source := filepath.Join(tmpDir, "source")
-	err := ioutil.WriteFile(source, testData, 0o644)
+	err := os.WriteFile(source, testData, 0o644)
 	if err != nil {
 		t.Fatalf("failed to create test source file: %v", err)
 	}
@@ -526,7 +525,7 @@ func testCopyFileFunc(t *testing.T, fn copyFileFunc) {
 			}
 
 			if tc.expectError == "" {
-				actual, err := ioutil.ReadFile(tc.to)
+				actual, err := os.ReadFile(tc.to)
 				if err != nil {
 					t.Fatalf("could not read copied file: %v", err)
 				}

--- a/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
@@ -198,7 +198,7 @@ func (u *Underlay) duplicateDir(dir string, system *mount.System, existingPath s
 				return fmt.Errorf("can't add bind mount point: %s", err)
 			}
 			binds++
-		} else if file.Mode()&os.ModeSymlink != 0 {
+		} else if file.Type()&os.ModeSymlink != 0 {
 			tgt, err := u.session.VFS.Readlink(src)
 			if err != nil {
 				return fmt.Errorf("can't read symlink information for %s: %s", src, err)

--- a/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
@@ -198,7 +198,7 @@ func (u *Underlay) duplicateDir(dir string, system *mount.System, existingPath s
 				return fmt.Errorf("can't add bind mount point: %s", err)
 			}
 			binds++
-		} else if file.Type()&os.ModeSymlink != 0 {
+		} else if file.Mode()&os.ModeSymlink != 0 {
 			tgt, err := u.session.VFS.Readlink(src)
 			if err != nil {
 				return fmt.Errorf("can't read symlink information for %s: %s", src, err)

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -52,7 +52,7 @@ type VFS interface {
 	Lchown(string, int, int) error
 	Mkdir(string, os.FileMode) error
 	Readlink(string) (string, error)
-	ReadDir(string) ([]os.DirEntry, error)
+	ReadDir(string) ([]os.FileInfo, error)
 	Stat(string) (os.FileInfo, error)
 	Symlink(string, string) error
 	Umask(int) int
@@ -81,8 +81,20 @@ func (v *defaultVFS) Readlink(name string) (string, error) {
 	return os.Readlink(name)
 }
 
-func (v *defaultVFS) ReadDir(dir string) ([]os.DirEntry, error) {
-	return os.ReadDir(dir)
+func (v *defaultVFS) ReadDir(dir string) ([]os.FileInfo, error) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]os.FileInfo, 0, len(files))
+	for _, file := range files {
+		info, err := file.Info()
+		if err != nil {
+			continue
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
 }
 
 func (v *defaultVFS) Stat(name string) (os.FileInfo, error) {

--- a/internal/pkg/util/fs/layout/manager.go
+++ b/internal/pkg/util/fs/layout/manager.go
@@ -11,7 +11,6 @@ package layout
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +52,7 @@ type VFS interface {
 	Lchown(string, int, int) error
 	Mkdir(string, os.FileMode) error
 	Readlink(string) (string, error)
-	ReadDir(string) ([]os.FileInfo, error)
+	ReadDir(string) ([]os.DirEntry, error)
 	Stat(string) (os.FileInfo, error)
 	Symlink(string, string) error
 	Umask(int) int
@@ -82,8 +81,8 @@ func (v *defaultVFS) Readlink(name string) (string, error) {
 	return os.Readlink(name)
 }
 
-func (v *defaultVFS) ReadDir(dir string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(dir)
+func (v *defaultVFS) ReadDir(dir string) ([]os.DirEntry, error) {
+	return os.ReadDir(dir)
 }
 
 func (v *defaultVFS) Stat(name string) (os.FileInfo, error) {

--- a/internal/pkg/util/interactive/interactive_test.go
+++ b/internal/pkg/util/interactive/interactive_test.go
@@ -11,7 +11,6 @@ package interactive
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -24,7 +23,7 @@ func generateQuestionInput(t *testing.T, input string) (*os.File, *os.File) {
 	testBytes := []byte(input)
 
 	// we create a temporary file that will act as Stdin
-	testFile, err := ioutil.TempFile("", "inputTest")
+	testFile, err := os.CreateTemp("", "inputTest")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}

--- a/internal/pkg/util/machine/machine.go
+++ b/internal/pkg/util/machine/machine.go
@@ -17,7 +17,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -243,21 +242,21 @@ func canEmulate(arch string) bool {
 	}
 
 	// look at /proc/sys/fs/binfmt_misc
-	content, _ := ioutil.ReadFile(filepath.Join(binfmtMisc, "status"))
+	content, _ := os.ReadFile(filepath.Join(binfmtMisc, "status"))
 	if string(content) != "enabled\n" {
 		return false
 	}
 
-	infos, err := ioutil.ReadDir(binfmtMisc)
+	entries, err := os.ReadDir(binfmtMisc)
 	if err != nil {
 		return false
 	}
 
 	archMagic := hex.EncodeToString(format.ElfMagic)
 
-	for _, fi := range infos {
-		f := filepath.Join(binfmtMisc, fi.Name())
-		b, err := ioutil.ReadFile(f)
+	for _, entry := range entries {
+		f := filepath.Join(binfmtMisc, entry.Name())
+		b, err := os.ReadFile(f)
 		if err != nil {
 			continue
 		}

--- a/internal/pkg/util/paths/resolve.go
+++ b/internal/pkg/util/paths/resolve.go
@@ -12,7 +12,6 @@ package paths
 import (
 	"debug/elf"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +71,7 @@ func Resolve(fileList []string) ([]string, []string, error) {
 	}
 
 	boundLibsDir := "/.singularity.d/libs"
-	boundLibs, err := ioutil.ReadDir(boundLibsDir)
+	boundLibs, err := os.ReadDir(boundLibsDir)
 	if err != nil {
 		boundLibs = nil // just in case
 	}

--- a/internal/pkg/util/paths/resolve_test.go
+++ b/internal/pkg/util/paths/resolve_test.go
@@ -12,7 +12,6 @@
 package paths
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -62,7 +61,7 @@ func TestSoLinks(t *testing.T) {
 	aFile := filepath.Join(tmpDir, "a.so")
 	a1Link := filepath.Join(tmpDir, "a.so.1")
 	a12Link := filepath.Join(tmpDir, "a.so.1.2")
-	if err := ioutil.WriteFile(aFile, nil, 0o644); err != nil {
+	if err := os.WriteFile(aFile, nil, 0o644); err != nil {
 		t.Fatalf("Could not create file: %v", err)
 	}
 	if err := os.Symlink(aFile, a1Link); err != nil {
@@ -72,7 +71,7 @@ func TestSoLinks(t *testing.T) {
 		t.Fatalf("Could not symlink: %v", err)
 	}
 	bFile := filepath.Join(tmpDir, "b.so")
-	err := ioutil.WriteFile(bFile, nil, 0o644)
+	err := os.WriteFile(bFile, nil, 0o644)
 	if err != nil {
 		t.Fatalf("Could not create file: %v", err)
 	}

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -11,7 +11,6 @@ package types
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,7 +166,7 @@ func cleanupDir(path string) {
 func newBundle(parentPath, tempDir string, keyInfo *cryptkey.KeyInfo) (*Bundle, error) {
 	rootfsPath := filepath.Join(parentPath, "rootfs")
 
-	tmpPath, err := ioutil.TempDir(tempDir, "bundle-temp-")
+	tmpPath, err := os.MkdirTemp(tempDir, "bundle-temp-")
 	if err != nil {
 		return nil, fmt.Errorf("could not create temp dir in %q: %v", tempDir, err)
 	}
@@ -194,7 +193,7 @@ func newBundle(parentPath, tempDir string, keyInfo *cryptkey.KeyInfo) (*Bundle, 
 		// If the supplied rootfs was not inside tempDir (as is the case during a sandbox build),
 		// try tempDir as a fallback.
 		if !strings.HasPrefix(parentPath, tempDir) {
-			parentPath, err = ioutil.TempDir(tempDir, "build-temp-")
+			parentPath, err = os.MkdirTemp(tempDir, "build-temp-")
 			if err != nil {
 				cleanupDir(tmpPath)
 				return nil, fmt.Errorf("failed to create rootfs directory: %v", err)

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -422,7 +421,7 @@ func doHeader(h string, d *types.Definition) error {
 // and parse it into a Definition struct or return error if
 // the definition file has a bad section.
 func ParseDefinitionFile(r io.Reader) (d types.Definition, err error) {
-	d.Raw, err = ioutil.ReadAll(r)
+	d.Raw, err = io.ReadAll(r)
 	if err != nil {
 		return d, fmt.Errorf("while attempting to read in definition: %v", err)
 	}
@@ -454,7 +453,7 @@ func ParseDefinitionFile(r io.Reader) (d types.Definition, err error) {
 func All(r io.Reader) ([]types.Definition, error) {
 	var stages []types.Definition
 
-	raw, err := ioutil.ReadAll(r)
+	raw, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("while attempting to read in definition: %v", err)
 	}

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -13,7 +13,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -58,7 +57,7 @@ func TestScanDefinitionFile(t *testing.T) {
 			for s.Scan() && s.Text() == "" && s.Err() == nil {
 			}
 
-			b, err := ioutil.ReadFile(tt.sections)
+			b, err := os.ReadFile(tt.sections)
 			if err != nil {
 				t.Fatal("failed to read JSON:", err)
 			}

--- a/pkg/image/ext3_test.go
+++ b/pkg/image/ext3_test.go
@@ -11,7 +11,6 @@ package image
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -137,7 +136,7 @@ func TestInitializer(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	// Create a temporary image which is obviously an invalid ext3 image
-	f, err := ioutil.TempFile("", "image-")
+	f, err := os.CreateTemp("", "image-")
 	if err != nil {
 		t.Fatalf("cannot create temporary file: %s\n", err)
 	}

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -49,7 +48,7 @@ type groupTest struct {
 
 // Copy the test image to a temporary location so we don't accidentally clobber the original
 func copyImage(t *testing.T) string {
-	f, err := ioutil.TempFile("", "image-")
+	f, err := os.CreateTemp("", "image-")
 	if err != nil {
 		t.Fatalf("cannot create temporary file: %s\n", err)
 	}

--- a/pkg/image/sandbox_test.go
+++ b/pkg/image/sandbox_test.go
@@ -10,7 +10,6 @@
 package image
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -59,7 +58,7 @@ func TestSandboxInitializer(t *testing.T) {
 	}
 
 	// Invalid case using a file
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("cannot create temporary file: %s\n", err)
 	}

--- a/pkg/image/squashfs_test.go
+++ b/pkg/image/squashfs_test.go
@@ -11,7 +11,6 @@ package image
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -20,7 +19,7 @@ import (
 // createSquashfs creates a small but valid squashfs file that can be used
 // with an image.
 func createSquashfs(t *testing.T) string {
-	sqshFile, fileErr := ioutil.TempFile("", "")
+	sqshFile, fileErr := os.CreateTemp("", "")
 	if fileErr != nil {
 		t.Fatalf("impossible to create temporary file: %s\n", fileErr)
 	}
@@ -161,7 +160,7 @@ func TestSquashfsCompression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b, err := ioutil.ReadFile(tt.path)
+			b, err := os.ReadFile(tt.path)
 			if err != nil {
 				t.Errorf("Failed to read file: %v", err)
 			}

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -490,7 +489,7 @@ func testHTTPPortmap(nsPath string, cniPath *CNIPath, stdin io.WriteCloser, stdo
 	}
 	conn.Close()
 
-	received, err := ioutil.ReadAll(stdout)
+	received, err := io.ReadAll(stdout)
 	if err != nil {
 		return err
 	}
@@ -603,7 +602,7 @@ func TestMain(m *testing.M) {
 
 	test.EnsurePrivilege(nil)
 
-	defaultCNIConfPath, err = ioutil.TempDir("", "conf_test_")
+	defaultCNIConfPath, err = os.MkdirTemp("", "conf_test_")
 	if err != nil {
 		os.Exit(1)
 	}
@@ -611,7 +610,7 @@ func TestMain(m *testing.M) {
 	for _, conf := range confFiles {
 		testNetworks = append(testNetworks, conf.name)
 		path := filepath.Join(defaultCNIConfPath, conf.file)
-		if err := ioutil.WriteFile(path, []byte(conf.content), 0o644); err != nil {
+		if err := os.WriteFile(path, []byte(conf.content), 0o644); err != nil {
 			os.RemoveAll(defaultCNIConfPath)
 			os.Exit(1)
 		}

--- a/pkg/ocibundle/sif/bundle_linux_test.go
+++ b/pkg/ocibundle/sif/bundle_linux_test.go
@@ -10,7 +10,6 @@
 package sifbundle
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -31,7 +30,7 @@ func TestFromSif(t *testing.T) {
 	test.EnsurePrivilege(t)
 
 	bundlePath := t.TempDir()
-	f, err := ioutil.TempFile("", "busybox")
+	f, err := os.CreateTemp("", "busybox")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sylog/sylog.go
+++ b/pkg/sylog/sylog.go
@@ -14,7 +14,6 @@ package sylog
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
@@ -155,10 +154,10 @@ func GetEnvVar() string {
 }
 
 // Writer returns an io.Writer to pass to an external packages logging utility.
-// i.e when --quiet option is set, this function returns ioutil.Discard writer to ignore output
+// i.e when --quiet option is set, this function returns io.Discard writer to ignore output
 func Writer() io.Writer {
 	if loggerLevel <= LogLevel {
-		return ioutil.Discard
+		return io.Discard
 	}
 
 	return logWriter

--- a/pkg/sylog/sylog_dummy.go
+++ b/pkg/sylog/sylog_dummy.go
@@ -13,7 +13,6 @@ package sylog
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -55,9 +54,9 @@ func GetEnvVar() string {
 	return "APPTAINER_MESSAGELEVEL=-1"
 }
 
-// Writer is a dummy function returning ioutil.Discard writer.
+// Writer is a dummy function returning io.Discard writer.
 func Writer() io.Writer {
-	return ioutil.Discard
+	return io.Discard
 }
 
 // DebugLogger is an implementation of the go-log/log Logger interface that will

--- a/pkg/sylog/sylog_dummy_test.go
+++ b/pkg/sylog/sylog_dummy_test.go
@@ -12,7 +12,7 @@
 package sylog
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/test"
@@ -45,8 +45,8 @@ func TestWriter(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	w := Writer()
-	if w != ioutil.Discard {
-		t.Fatalf("Writer() did not return ioutil.Discard as expected")
+	if w != io.Discard {
+		t.Fatalf("Writer() did not return io.Discard as expected")
 	}
 }
 

--- a/pkg/sylog/sylog_test.go
+++ b/pkg/sylog/sylog_test.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -136,7 +135,7 @@ func TestWriter(t *testing.T) {
 		{
 			name:           "undefined level",
 			loggerLevel:    int(FatalLevel - 1),
-			expectedResult: ioutil.Discard,
+			expectedResult: io.Discard,
 		},
 		{
 			name:           "no logger",
@@ -155,8 +154,8 @@ func TestWriter(t *testing.T) {
 			SetLevel(tt.loggerLevel, true)
 			w := Writer()
 			if w != tt.expectedResult {
-				if w == ioutil.Discard {
-					fmt.Printf("%s returned ioutil.Discard\n", tt.name)
+				if w == io.Discard {
+					fmt.Printf("%s returned io.Discard\n", tt.name)
 				}
 				if w == os.Stderr {
 					fmt.Printf("%s returned os.Stderr\n", tt.name)

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -264,7 +263,7 @@ func (keyring *Handle) LoadPubKeyring() (openpgp.EntityList, error) {
 func loadKeysFromFile(fn string) (openpgp.EntityList, error) {
 	// use an intermediary bytes.Reader to support key import from
 	// stdin for the seek operation below
-	data, err := ioutil.ReadFile(fn)
+	data, err := os.ReadFile(fn)
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +631,7 @@ const (
 	tagField = iota
 )
 
-//nolint
+// nolint
 const (
 	// info:<version>:<count>
 
@@ -643,7 +642,7 @@ const (
 	infoFieldsCount = iota
 )
 
-//nolint
+// nolint
 const (
 	// pub:<keyid>:<algo>:<keylen>:<creationdate>:<expirationdate>:<flags>
 
@@ -658,7 +657,7 @@ const (
 	pubFieldsCount = iota
 )
 
-//nolint
+// nolint
 const (
 	// uid:<escaped uid string>:<creationdate>:<expirationdate>:<flags>
 

--- a/pkg/util/apptainerconf/parser.go
+++ b/pkg/util/apptainerconf/parser.go
@@ -12,7 +12,6 @@ package apptainerconf
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
@@ -34,7 +33,7 @@ func GetDirectives(reader io.Reader) (Directives, error) {
 		return make(Directives), nil
 	}
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("while reading data: %s", err)
 	}

--- a/pkg/util/apptainerconf/parser_test.go
+++ b/pkg/util/apptainerconf/parser_test.go
@@ -12,14 +12,13 @@ package apptainerconf
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 )
 
 func TestGenerate(t *testing.T) {
-	discard := ioutil.Discard
+	discard := io.Discard
 
 	if err := Generate(discard, "/non-existent/template", nil); err == nil {
 		t.Fatalf("unexpected success with non-existent template")
@@ -30,7 +29,7 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestParser(t *testing.T) {
-	f, err := ioutil.TempFile("", "apptainer.conf-")
+	f, err := os.CreateTemp("", "apptainer.conf-")
 	if err != nil {
 		t.Fatalf("failed to create temporary configuration file: %s", err)
 	}

--- a/pkg/util/archive/copy_test.go
+++ b/pkg/util/archive/copy_test.go
@@ -10,7 +10,6 @@
 package archive
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -39,7 +38,7 @@ func testCopyWithTar(t *testing.T) {
 
 	// Source Files
 	srcFile := filepath.Join(srcRoot, "srcFile")
-	if err := ioutil.WriteFile(srcFile, []byte("test"), 0o644); err != nil {
+	if err := os.WriteFile(srcFile, []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Source Dirs

--- a/pkg/util/capabilities/config.go
+++ b/pkg/util/capabilities/config.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
@@ -37,7 +36,7 @@ func ReadFrom(r io.Reader) (*Config, error) {
 	}
 
 	// read all data from r into b
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from io.Reader: %s", err)
 	}

--- a/pkg/util/cryptkey/key.go
+++ b/pkg/util/cryptkey/key.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -146,7 +145,7 @@ func PlaintextKey(k KeyInfo, image string) ([]byte, error) {
 }
 
 func LoadPEMPrivateKey(fn string) (*rsa.PrivateKey, error) {
-	b, err := ioutil.ReadFile(fn)
+	b, err := os.ReadFile(fn)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +163,7 @@ func LoadPEMPrivateKey(fn string) (*rsa.PrivateKey, error) {
 }
 
 func LoadPEMPublicKey(fn string) (*rsa.PublicKey, error) {
-	b, err := ioutil.ReadFile(fn)
+	b, err := os.ReadFile(fn)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +177,7 @@ func LoadPEMPublicKey(fn string) (*rsa.PublicKey, error) {
 }
 
 func loadPEMMessage(r io.Reader) ([]byte, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/fs/lock/lock_test.go
+++ b/pkg/util/fs/lock/lock_test.go
@@ -10,7 +10,6 @@
 package lock
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -60,7 +59,7 @@ func TestByteRange(t *testing.T) {
 	}
 
 	// create the temporary test file used for locking
-	f, err := ioutil.TempFile("", "byterange-")
+	f, err := os.CreateTemp("", "byterange-")
 	if err != nil {
 		t.Fatalf("failed to create temporary lock file: %s", err)
 	}
@@ -70,7 +69,7 @@ func TestByteRange(t *testing.T) {
 	f.Close()
 
 	// write some content in test file
-	if err := ioutil.WriteFile(testFile, []byte("testing\n"), 0o644); err != nil {
+	if err := os.WriteFile(testFile, []byte("testing\n"), 0o644); err != nil {
 		t.Fatalf("failed to write content in testfile %s: %s", testFile, err)
 	}
 

--- a/pkg/util/fs/proc/proc_linux_test.go
+++ b/pkg/util/fs/proc/proc_linux_test.go
@@ -10,7 +10,6 @@
 package proc
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"syscall"
@@ -140,7 +139,7 @@ func TestGetMountInfo(t *testing.T) {
 		t.Fatalf("unexpected success while parsing bad path")
 	}
 
-	tmpfile, err := ioutil.TempFile("", "mountinfo")
+	tmpfile, err := os.CreateTemp("", "mountinfo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +266,7 @@ func TestGetMountPointMap(t *testing.T) {
 	if _, err := GetMountPointMap("/proc/self/fakemountinfo"); err == nil {
 		t.Errorf("should have failed with non existent path")
 	}
-	tmpfile, err := ioutil.TempFile("", "mountinfo")
+	tmpfile, err := os.CreateTemp("", "mountinfo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,7 +373,7 @@ func TestReadIDMap(t *testing.T) {
 	}
 
 	for _, e := range []string{"a a a", "0 a a"} {
-		f, err := ioutil.TempFile("", "uid_map-")
+		f, err := os.CreateTemp("", "uid_map-")
 		if err != nil {
 			t.Fatalf("failed to create temporary file")
 		}

--- a/pkg/util/namespaces/user_linux.go
+++ b/pkg/util/namespaces/user_linux.go
@@ -12,7 +12,6 @@ package namespaces
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -53,7 +52,7 @@ func IsInsideUserNamespace(pid int) (bool, bool) {
 		insideUserNs = true
 
 		// should not fail if open call passed
-		d, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/setgroups", pid))
+		d, err := os.ReadFile(fmt.Sprintf("/proc/%d/setgroups", pid))
 		if err != nil {
 			return insideUserNs, setgroupsAllowed
 		}

--- a/pkg/util/sysctl/sysctl_linux.go
+++ b/pkg/util/sysctl/sysctl_linux.go
@@ -11,7 +11,6 @@ package sysctl
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,7 +39,7 @@ func Get(key string) (string, error) {
 		return "", fmt.Errorf("can't retrieve key %s: %s", key, err)
 	}
 
-	value, err := ioutil.ReadFile(path)
+	value, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("can't retrieve value for key %s: %s", key, err)
 	}
@@ -57,5 +56,5 @@ func Set(key string, value string) error {
 		return fmt.Errorf("can't retrieve key %s: %s", key, err)
 	}
 
-	return ioutil.WriteFile(path, []byte(value), 0o000)
+	return os.WriteFile(path, []byte(value), 0o000)
 }

--- a/scripts/expand-env.go
+++ b/scripts/expand-env.go
@@ -14,13 +14,13 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 )
 
 func main() {
-	stdin, err := ioutil.ReadAll(os.Stdin)
+	stdin, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "E: Cannot read stdin. Abort.\n")
 		os.Exit(1)


### PR DESCRIPTION
## Description of the Pull Request (PR):

The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir


### This fixes or addresses the following GitHub issues:


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
