### PR TITLE
Document the fact that sessiondir max size also affects --writable-tmpfs (release-1.1)

### DIFF
--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -278,9 +278,10 @@ mount slave = {{ if eq .MountSlave true }}yes{{ else }}no{{ end }}
 
 # SESSIONDIR MAXSIZE: [STRING]
 # DEFAULT: 16
-# This specifies how large the default sessiondir should be (in MB) and it will
-# only affect users who use the "--contain" options and don't also specify a
-# location to do default read/writes to (e.g. "--workdir" or "--home").
+# This specifies how large the default sessiondir should be (in MB). It will
+# affect users who use the "--contain" options and don't also specify a
+# location to do default read/writes to (e.g. "--workdir" or "--home") and
+# it will also affect users of "--writable-tmpfs".
 sessiondir max size = {{ .SessiondirMaxSize }}
 
 # LIMIT CONTAINER OWNERS: [STRING]


### PR DESCRIPTION
This cherry-picks #705 into the release-1.1 branch