### PR TITLE
Always disable the ecl config when ecl e2e tests are finished

### DIFF
--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -41,6 +41,13 @@ func (c *ctx) eclConfig(t *testing.T) {
 	unsigned := filepath.Join(tmpDir, "unsigned.sif")
 
 	defer func() {
+		fn := func(t *testing.T) {
+			err := syecl.PutConfig(syecl.EclConfig{}, buildcfg.ECL_FILE)
+			if err != nil {
+				t.Errorf("while disabling ecl config: %s", err)
+			}
+		}
+		e2e.Privileged(fn)(t)
 		c.env.KeyringDir = ""
 		remove(t)
 	}()


### PR DESCRIPTION
This always disable the ecl configuration when the e2e tests exit.  This fixes a bug introduced in #689 that causes e2e tests to fail.