### PR TITLE
Change oras:// reference to repo:tag to image:tag (release-1.1)

### DIFF
--- a/docs/content.go
+++ b/docs/content.go
@@ -646,7 +646,7 @@ Enterprise Performance Computing (EPC)`
       library://user/collection/container[:tag]
 
   oras:
-      oras://registry/namespace/repo:tag
+      oras://registry/namespace/image:tag
 
 
   NOTE: It's always good practice to sign your containers before


### PR DESCRIPTION
This cherry-picks #704 to the release-1.1 branch