### PR TITLE
Fix the mconfig -b option to avoid starter compile failure (release-1.1)

### DIFF
--- a/cmd/starter/main_linux.go
+++ b/cmd/starter/main_linux.go
@@ -9,6 +9,11 @@
 
 package main
 
+// Note that the inclusion of builddir here only works when mconfig -b has not
+//  renamed it; that is handled via a setting of CGO_CFLAGS in mconfig. It is
+//  included here also so that Go tools such as code editors and linters can
+//  find config.h when the default builddir is used.
+
 // #cgo CFLAGS: -I${SRCDIR}/../../builddir
 // #include <config.h>
 // #include "c/message.c"

--- a/mconfig
+++ b/mconfig
@@ -65,6 +65,7 @@ with_suid=-1
 with_seccomp_check=1
 do_go_version_check=1
 
+builddir=
 prefix=
 exec_prefix=
 bindir=
@@ -513,7 +514,7 @@ if [ "$builddir" = "" ]; then
 else
 	mkdir -p $builddir
 	if ! builddir=`(cd $builddir 2>/dev/null && pwd -P)`; then
-		echo "error: could not chdir to builddir"
+		echo "error: could not chdir to $builddir"
 		exit 2
 	fi
 fi
@@ -674,7 +675,7 @@ CFLAGS := $cflags
 
 GO := $hstgo
 
-CGO_CFLAGS := $CGO_CFLAGS
+CGO_CFLAGS := -I$builddir $CGO_CFLAGS
 CGO_LDFLAGS := $CGO_LDFLAGS
 CGO_CPPFLAGS := $CGO_CPPFLAGS
 CGO_CXXFLAGS := $CGO_CXXFLAGS


### PR DESCRIPTION
This cherry-picks #719 to the release-1.1 branch.