### PR TITLE
e2e: switch to shared cache by default and re-work docker / pull related e2e tests, from sylabs 975 & 982 & 984 & 986

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -385,20 +385,6 @@ func (c actionTests) STDPipe(t *testing.T) {
 			input:   "false",
 			exit:    1,
 		},
-		{
-			name:    "TrueDocker",
-			command: "shell",
-			argv:    []string{"docker://busybox"},
-			input:   "true",
-			exit:    0,
-		},
-		{
-			name:    "FalseDocker",
-			command: "shell",
-			argv:    []string{"docker://busybox"},
-			input:   "false",
-			exit:    1,
-		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
 		// 	name:    "TrueShub",
@@ -509,20 +495,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 	}{
 		// Run from supported URI's and check the runscript call works
 		{
-			name:    "RunFromDockerOK",
-			command: "run",
-			argv:    []string{"--bind", bind, "docker://busybox:latest", size},
-			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
-			name:    "RunFromDockerWithoutShellOK",
-			command: "run",
-			argv:    []string{"docker://hello-world"},
-			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
 			name:    "RunFromLibraryOK",
 			command: "run",
 			argv:    []string{"--bind", bind, "oras://ghcr.io/apptainer/busybox:1.31.1", size},
@@ -542,13 +514,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			command: "run",
 			argv:    []string{"--bind", bind, c.env.OrasTestImage, size},
 			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
-			name:    "RunFromDockerKO",
-			command: "run",
-			argv:    []string{"--bind", bind, "docker://busybox:latest", "0"},
-			exit:    1,
 			profile: e2e.UserProfile,
 		},
 		{
@@ -573,22 +538,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			exit:    1,
 			profile: e2e.UserProfile,
 		},
-
-		// exec from a supported URI's and check the exit code
-		{
-			name:    "ExecTrueDocker",
-			command: "exec",
-			argv:    []string{"docker://busybox:latest", "true"},
-			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
-			name:    "ExecTrueLibrary",
-			command: "exec",
-			argv:    []string{"oras://ghcr.io/apptainer/busybox:1.31.1", "true"},
-			exit:    0,
-			profile: e2e.UserProfile,
-		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
 		// 	name:    "ExecTrueShub",
@@ -602,13 +551,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			command: "exec",
 			argv:    []string{c.env.OrasTestImage, "true"},
 			exit:    0,
-			profile: e2e.UserProfile,
-		},
-		{
-			name:    "ExecFalseDocker",
-			command: "exec",
-			argv:    []string{"docker://busybox:latest", "false"},
-			exit:    1,
 			profile: e2e.UserProfile,
 		},
 		{
@@ -636,13 +578,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 
 		// exec from URI with user namespace enabled
 		{
-			name:    "ExecTrueDockerUserns",
-			command: "exec",
-			argv:    []string{"docker://busybox:latest", "true"},
-			exit:    0,
-			profile: e2e.UserNamespaceProfile,
-		},
-		{
 			name:    "ExecTrueLibraryUserns",
 			command: "exec",
 			argv:    []string{"oras://ghcr.io/apptainer/busybox:1.31.1", "true"},
@@ -662,13 +597,6 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			command: "exec",
 			argv:    []string{c.env.OrasTestImage, "true"},
 			exit:    0,
-			profile: e2e.UserNamespaceProfile,
-		},
-		{
-			name:    "ExecFalseDockerUserns",
-			command: "exec",
-			argv:    []string{"docker://busybox:latest", "false"},
-			exit:    1,
 			profile: e2e.UserNamespaceProfile,
 		},
 		{

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -306,7 +306,7 @@ func (c actionTests) issue4823(t *testing.T) {
 			expected = e2e.ExpectError(e2e.ContainMatch, "Using image from cache")
 		}
 
-		c.env.ImgCacheDir = cacheDir
+		c.env.UnprivCacheDir = cacheDir
 		c.env.RunApptainer(
 			t,
 			e2e.AsSubtest(tt.name),

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -38,7 +38,7 @@ func prepTest(t *testing.T, testEnv e2e.TestEnv, testName string, cacheParentDir
 		ensureNotCached(t, testName, imagePath, cacheParentDir)
 	}
 
-	testEnv.ImgCacheDir = cacheParentDir
+	testEnv.UnprivCacheDir = cacheParentDir
 	testEnv.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -132,7 +132,7 @@ func (c cacheTests) testNoninteractiveCacheCmds(t *testing.T) {
 			prepTest(t, c.env, tt.name, cacheDir, imagePath)
 		}
 
-		c.env.ImgCacheDir = cacheDir
+		c.env.UnprivCacheDir = cacheDir
 		c.env.RunApptainer(
 			t,
 			e2e.AsSubtest(tt.name),
@@ -233,7 +233,7 @@ func (c cacheTests) testInteractiveCacheCmds(t *testing.T) {
 			t.Fatalf("Could not create image cache handle: %v", err)
 		}
 
-		c.env.ImgCacheDir = cacheDir
+		c.env.UnprivCacheDir = cacheDir
 		prepTest(t, c.env, tc.name, cacheDir, imagePath)
 
 		c.env.RunApptainer(

--- a/e2e/cache/regressions.go
+++ b/e2e/cache/regressions.go
@@ -25,7 +25,7 @@ import (
 func (c cacheTests) issue5097(t *testing.T) {
 	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
 	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
+	c.env.UnprivCacheDir = imgCacheDir
 
 	tempDir, imgStoreCleanup := e2e.MakeTempDir(t, "", "", "image store")
 	defer imgStoreCleanup(t)
@@ -86,7 +86,7 @@ func (c cacheTests) issue5350(t *testing.T) {
 
 	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, outerDir)
 	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
+	c.env.UnprivCacheDir = imgCacheDir
 
 	if err := os.Chmod(outerDir, 0o000); err != nil {
 		t.Fatalf("Could not chmod 000 cache outer dir: %v", err)

--- a/e2e/cmdenvvars/cmdenvvars.go
+++ b/e2e/cmdenvvars/cmdenvvars.go
@@ -40,14 +40,14 @@ func setupTemporaryDir(t *testing.T, testdir, label string) (string, func(*testi
 	}
 }
 
-// setupTemporaryCache creates a temporary cache directory and modifies
+// setupTemporaryCache creates temporary cache directories and modifies
 // the test environment to use it. The code calling this function is
 // responsible for calling the returned function when its done using the
 // temporary directory.
 func (c *ctx) setupTemporaryCache(t *testing.T) func(*testing.T) {
 	cacheDir, cleanup := setupTemporaryDir(t, c.env.TestDir, "cache-dir")
 
-	c.env.ImgCacheDir = cacheDir
+	c.env.UnprivCacheDir = cacheDir
 
 	return cleanup
 }
@@ -96,10 +96,10 @@ func (c ctx) assertLibraryCacheEntryExists(t *testing.T, imgPath, imgName string
 		t.Fatalf("Cannot get the shasum for image %s: %s", imgPath, err)
 	}
 
-	cacheEntryPath := filepath.Join(c.env.ImgCacheDir, "cache", "oras", shasum)
+	cacheEntryPath := filepath.Join(c.env.UnprivCacheDir, "cache", "oras", shasum)
 	if _, err := os.Stat(cacheEntryPath); os.IsNotExist(err) {
 		ls(t, c.env.TestDir)
-		ls(t, c.env.ImgCacheDir)
+		ls(t, c.env.UnprivCacheDir)
 		t.Fatalf("Cache entry %s for image %s with name %s does not exists: %s",
 			cacheEntryPath, imgPath, imgName, err)
 	}
@@ -108,7 +108,7 @@ func (c ctx) assertLibraryCacheEntryExists(t *testing.T, imgPath, imgName string
 // assertCacheDoesNotExist checks that the image cache that is associated to the
 // test DOES NOT exists.
 func (c ctx) assertCacheDoesNotExist(t *testing.T) {
-	cacheRoot := filepath.Join(c.env.ImgCacheDir, "cache")
+	cacheRoot := filepath.Join(c.env.UnprivCacheDir, "cache")
 	if _, err := os.Stat(cacheRoot); !os.IsNotExist(err) {
 		// The root of the cache does exists
 		t.Fatalf("cache has been incorrectly created (cache root: %s)", cacheRoot)
@@ -207,7 +207,7 @@ func (c ctx) testApptainerReadOnlyCacheDir(t *testing.T) {
 	defer cleanup(t)
 
 	// Change the mode of the image cache to read-only
-	err := os.Chmod(c.env.ImgCacheDir, 0o555)
+	err := os.Chmod(c.env.UnprivCacheDir, 0o555)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}
@@ -218,7 +218,7 @@ func (c ctx) testApptainerReadOnlyCacheDir(t *testing.T) {
 	// can delete the cache if it was created. Do this _before_
 	// calling c.assertCacheDoesNotExist because that function will
 	// fail if it find a cache.
-	err = os.Chmod(c.env.ImgCacheDir, 0o755)
+	err = os.Chmod(c.env.UnprivCacheDir, 0o755)
 	if err != nil {
 		t.Fatalf("failed to change the access mode to read-only: %s", err)
 	}

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -891,6 +891,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 			t.Run("issue 4524", c.issue4524)
 			t.Run("issue 4943", c.issue4943)
 			t.Run("issue 5172", c.issue5172)
+			t.Run("issue 274", c.issue274) // https://github.com/sylabs/singularity/issues/274
 		},
 	}
 }

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -111,3 +111,58 @@ func (c ctx) issue5172(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 }
+
+// https://github.com/sylabs/singularity/issues/274
+// The conda profile.d script must be able to be source'd from %environment.
+// This has been broken by changes to mvdan.cc/sh interacting badly with our
+// custom internalExecHandler.
+// The test is quite heavyweight, but is warranted IMHO to ensure that conda
+// environment activation works as expected, as this is a common use-case
+// for SingularityCE.
+func (c ctx) issue274(t *testing.T) {
+	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue274-", "")
+	defer cleanup(t)
+	imagePath := filepath.Join(imageDir, "container")
+
+	// Create a minimal conda environment on the current miniconda3 base.
+	// Source the conda profile.d code and activate the env from `%environment`.
+	def := `Bootstrap: docker
+From: continuumio/miniconda3:latest
+
+%post
+
+	. /opt/conda/etc/profile.d/conda.sh
+	conda create -n env
+
+%environment
+
+	source /opt/conda/etc/profile.d/conda.sh
+	conda activate env
+`
+	defFile, err := e2e.WriteTempFile(imageDir, "deffile", def)
+	if err != nil {
+		t.Fatalf("Unable to create test definition file: %v", err)
+	}
+
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("build"),
+		e2e.WithProfile(e2e.RootProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs(imagePath, defFile),
+		e2e.ExpectExit(0),
+	)
+	// An exec of `conda info` in the container should show environment active, no errors.
+	// I.E. the `%environment` section should have worked.
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("exec"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(imagePath, "conda", "info"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.ContainMatch, "active environment : env"),
+			e2e.ExpectError(e2e.ExactMatch, ""),
+		),
+	)
+}

--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -1,0 +1,113 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package docker
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/apptainer/apptainer/e2e/internal/e2e"
+	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
+)
+
+// This test will build a sandbox, as a non-root user from a dockerhub image
+// that contains a single folder and file with `000` permission.
+// It will verify that with `--fix-perms` we force files to be accessible,
+// moveable, removable by the user. We check for `700` and `400` permissions on
+// the folder and file respectively.
+func (c ctx) issue4524(t *testing.T) {
+	sandbox := filepath.Join(c.env.TestDir, "issue_4524")
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--fix-perms", "--sandbox", sandbox, "docker://ghcr.io/apptainer/issue4524"),
+		e2e.PostRun(func(t *testing.T) {
+			// If we failed to build the sandbox completely, leave what we have for
+			// investigation.
+			if t.Failed() {
+				t.Logf("Test %s failed, not removing directory %s", t.Name(), sandbox)
+				return
+			}
+
+			if !e2e.PathPerms(t, path.Join(sandbox, "directory"), 0o700) {
+				t.Error("Expected 0700 permissions on 000 test directory in rootless sandbox")
+			}
+			if !e2e.PathPerms(t, path.Join(sandbox, "file"), 0o600) {
+				t.Error("Expected 0600 permissions on 000 test file in rootless sandbox")
+			}
+
+			// If the permissions aren't as we expect them to be, leave what we have for
+			// investigation.
+			if t.Failed() {
+				t.Logf("Test %s failed, not removing directory %s", t.Name(), sandbox)
+				return
+			}
+
+			err := os.RemoveAll(sandbox)
+			if err != nil {
+				t.Logf("Cannot remove sandbox directory: %#v", err)
+			}
+		}),
+		e2e.ExpectExit(0),
+	)
+}
+
+func (c ctx) issue4943(t *testing.T) {
+	require.Arch(t, "amd64")
+
+	const (
+		image = "docker://ghcr.io/apptainer/cern-cc7-base:20191107"
+	)
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--force", "/dev/null", image),
+		e2e.ExpectExit(0),
+	)
+}
+
+func (c ctx) issue5172(t *testing.T) {
+	// create $HOME/.config/containers/registries.conf
+	regImage := fmt.Sprintf("docker://%s/my-busybox", c.env.TestRegistry)
+	imagePath := filepath.Join(c.env.TestDir, "issue-5172")
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--sandbox", imagePath, regImage),
+		e2e.PostRun(func(t *testing.T) {
+			if !t.Failed() {
+				os.RemoveAll(imagePath)
+			}
+		}),
+		e2e.ExpectExit(0),
+	)
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs(imagePath, regImage),
+		e2e.PostRun(func(t *testing.T) {
+			if !t.Failed() {
+				os.RemoveAll(imagePath)
+			}
+		}),
+		e2e.ExpectExit(0),
+	)
+}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -33,11 +33,6 @@ const (
 )
 
 func (c ctx) apptainerEnv(t *testing.T) {
-	// use a cache to not download images over and over
-	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
-	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
-
 	// Apptainer defines a path by default. See apptainerware/apptainer/etc/init.
 	defaultImage := "oras://ghcr.io/apptainer/alpine:latest"
 
@@ -135,11 +130,6 @@ func (c ctx) apptainerEnvOption(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	imageDefaultPath := defaultPath + ":/go/bin:/usr/local/go/bin"
-
-	// use a cache to not download images over and over
-	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
-	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
 
 	tests := []struct {
 		name     string
@@ -342,11 +332,6 @@ func (c ctx) apptainerEnvFile(t *testing.T) {
 	dir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "envfile-", "")
 	defer cleanup(t)
 	p := filepath.Join(dir, "env.file")
-
-	// use a cache to not download images over and over
-	imgCacheDir, cleanCache := e2e.MakeCacheDir(t, c.env.TestDir)
-	defer cleanCache(t)
-	c.env.ImgCacheDir = imgCacheDir
 
 	tests := []struct {
 		name     string

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -39,10 +39,10 @@ func (c ctx) apptainerEnv(t *testing.T) {
 	c.env.ImgCacheDir = imgCacheDir
 
 	// Apptainer defines a path by default. See apptainerware/apptainer/etc/init.
-	defaultImage := "docker://alpine:3.8"
+	defaultImage := "oras://ghcr.io/apptainer/alpine:latest"
 
 	// This image sets a custom path.
-	customImage := "docker://ghcr.io/apptainer/lolcow"
+	customImage := "oras://ghcr.io/apptainer/lolcow:sif"
 	customPath := "/usr/games:" + defaultPath
 
 	// Append or prepend this path.
@@ -151,43 +151,30 @@ func (c ctx) apptainerEnvOption(t *testing.T) {
 	}{
 		{
 			name:     "DefaultPath",
-			image:    "docker://alpine:3.8",
+			image:    "oras://ghcr.io/apptainer/alpine:latest",
 			matchEnv: "PATH",
 			matchVal: defaultPath,
 		},
 		{
 			name:     "DefaultPathOverride",
-			image:    "docker://alpine:3.8",
+			image:    "oras://ghcr.io/apptainer/alpine:latest",
 			envOpt:   []string{"PATH=/"},
 			matchEnv: "PATH",
 			matchVal: "/",
 		},
 		{
 			name:     "AppendDefaultPath",
-			image:    "docker://alpine:3.8",
+			image:    "oras://ghcr.io/apptainer/alpine:latest",
 			envOpt:   []string{"APPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: defaultPath + ":/foo",
 		},
 		{
 			name:     "PrependDefaultPath",
-			image:    "docker://alpine:3.8",
+			image:    "oras://ghcr.io/apptainer/alpine:latest",
 			envOpt:   []string{"PREPEND_PATH=/foo"},
 			matchEnv: "PATH",
 			matchVal: "/foo:" + defaultPath,
-		},
-		{
-			name:     "DockerImage",
-			image:    "docker://ghcr.io/apptainer/lolcow",
-			matchEnv: "LC_ALL",
-			matchVal: "C",
-		},
-		{
-			name:     "DockerImageOverride",
-			image:    "docker://ghcr.io/apptainer/lolcow",
-			envOpt:   []string{"LC_ALL=foo"},
-			matchEnv: "LC_ALL",
-			matchVal: "foo",
 		},
 		{
 			name:     "DefaultPathTestImage",

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -654,6 +654,5 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5057":               c.issue5057, // https://github.com/apptainer/singularity/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/apptainer/singularity/issues/5426
 		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
-		"issue 274":                c.issue274,  // https://github.com/sylabs/singularity/issues/274
 	}
 }

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -123,61 +122,6 @@ func (c ctx) issue43(t *testing.T) {
 		e2e.ExpectExit(
 			0,
 			e2e.ExpectOutput(e2e.ExactMatch, `/foo/bar/$LIB/baz.so`),
-		),
-	)
-}
-
-// https://github.com/sylabs/singularity/issues/274
-// The conda profile.d script must be able to be source'd from %environment.
-// This has been broken by changes to mvdan.cc/sh interacting badly with our
-// custom internalExecHandler.
-// The test is quite heavyweight, but is warranted IMHO to ensure that conda
-// environment activation works as expected, as this is a common use-case
-// for SingularityCE.
-func (c ctx) issue274(t *testing.T) {
-	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue274-", "")
-	defer cleanup(t)
-	imagePath := filepath.Join(imageDir, "container")
-
-	// Create a minimal conda environment on the current miniconda3 base.
-	// Source the conda profile.d code and activate the env from `%environment`.
-	def := `Bootstrap: docker
-From: continuumio/miniconda3:latest
-
-%post
-
-	. /opt/conda/etc/profile.d/conda.sh
-	conda create -n env
-
-%environment
-
-	source /opt/conda/etc/profile.d/conda.sh
-	conda activate env
-`
-	defFile, err := e2e.WriteTempFile(imageDir, "deffile", def)
-	if err != nil {
-		t.Fatalf("Unable to create test definition file: %v", err)
-	}
-
-	c.env.RunApptainer(
-		t,
-		e2e.AsSubtest("build"),
-		e2e.WithProfile(e2e.RootProfile),
-		e2e.WithCommand("build"),
-		e2e.WithArgs(imagePath, defFile),
-		e2e.ExpectExit(0),
-	)
-	// An exec of `conda info` in the container should show environment active, no errors.
-	// I.E. the `%environment` section should have worked.
-	c.env.RunApptainer(
-		t,
-		e2e.AsSubtest("exec"),
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("exec"),
-		e2e.WithArgs(imagePath, "conda", "info"),
-		e2e.ExpectExit(0,
-			e2e.ExpectOutput(e2e.ContainMatch, "active environment : env"),
-			e2e.ExpectError(e2e.ExactMatch, ""),
 		),
 	)
 }

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -341,8 +341,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			name: "FileCopySimple",
 			dfd: []e2e.DefFileDetails{
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "oras",
+					From:      "ghcr.io/apptainer/alpine:latest",
 					Stage:     "one",
 					Files: []e2e.FilePair{
 						{
@@ -356,8 +356,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "oras",
+					From:      "ghcr.io/apptainer/alpine:latest",
 					FilesFrom: []e2e.FileSection{
 						{
 							Stage: "one",
@@ -393,8 +393,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			name: "FileCopyComplex",
 			dfd: []e2e.DefFileDetails{
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "oras",
+					From:      "ghcr.io/apptainer/alpine:latest",
 					Stage:     "one",
 					Files: []e2e.FilePair{
 						{
@@ -408,8 +408,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "oras",
+					From:      "ghcr.io/apptainer/alpine:latest",
 					Stage:     "two",
 					Files: []e2e.FilePair{
 						{
@@ -423,8 +423,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "oras",
+					From:      "ghcr.io/apptainer/alpine:latest",
 					Stage:     "three",
 					FilesFrom: []e2e.FileSection{
 						{
@@ -456,8 +456,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "docker",
-					From:      "alpine:latest",
+					Bootstrap: "oras",
+					From:      "ghcr.io/apptainer/alpine:latest",
 					FilesFrom: []e2e.FileSection{
 						{
 							Stage: "three",
@@ -542,12 +542,12 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 
 	tt := map[string]e2e.DefFileDetails{
 		"Empty": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 		},
 		"Help": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Help: []string{
 				"help info line 1",
 				"help info line 2",
@@ -555,8 +555,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Files": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Files: []e2e.FilePair{
 				{
 					Src: tmpfile,
@@ -569,8 +569,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Test": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Test: []string{
 				"echo testscript line 1",
 				"echo testscript line 2",
@@ -578,8 +578,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Startscript": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			StartScript: []string{
 				"echo startscript line 1",
 				"echo startscript line 2",
@@ -587,8 +587,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Runscript": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			RunScript: []string{
 				"echo runscript line 1",
 				"echo runscript line 2",
@@ -596,8 +596,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Env": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Env: []string{
 				"testvar1=one",
 				"testvar2=two",
@@ -605,8 +605,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Labels": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Labels: map[string]string{
 				"customLabel1": "one",
 				"customLabel2": "two",
@@ -614,29 +614,29 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Pre": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Pre: []string{
 				filepath.Join(c.env.TestDir, "PreFile1"),
 			},
 		},
 		"Setup": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Setup: []string{
 				filepath.Join(c.env.TestDir, "SetupFile1"),
 			},
 		},
 		"Post": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Post: []string{
 				"PostFile1",
 			},
 		},
 		"AppHelp": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -657,8 +657,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppEnv": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -679,8 +679,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppLabels": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -701,8 +701,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppFiles": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -733,8 +733,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppInstall": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -751,8 +751,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppRun": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -773,8 +773,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppTest": {
-			Bootstrap: "docker",
-			From:      "alpine:latest",
+			Bootstrap: "oras",
+			From:      "ghcr.io/apptainer/alpine:latest",
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -58,7 +58,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 	e2e.EnsureORASImage(t, c.env)
 
 	// use a trailing slash in tests for sandbox intentionally to make sure
-	// `apptainer build -s /tmp/sand/ docker://alpine` works,
+	// `apptainer build -s /tmp/sand/ <URI>` works,
 	// see https://github.com/apptainer/singularity/issues/4407
 	tt := []struct {
 		name        string
@@ -77,14 +77,6 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 			name:       "Debootstrap",
 			dependency: "debootstrap",
 			buildSpec:  "../examples/debian/Apptainer",
-		},
-		{
-			name:      "DockerURI",
-			buildSpec: "docker://busybox",
-		},
-		{
-			name:      "DockerDefFile",
-			buildSpec: "../examples/docker/Apptainer",
 		},
 		// TODO(mem): reenable this; disabled while shub is down
 		// {
@@ -207,10 +199,6 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 		//		name:      "shub busybox",
 		//		buildSpec: "shub://GodloveD/busybox",
 		//},
-		{
-			name:      "docker busybox",
-			buildSpec: "docker://busybox:latest",
-		},
 	}
 
 	for _, tc := range tt {
@@ -1649,15 +1637,12 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 3848":                        c.issue3848,                            // https://github.com/apptainer/singularity/issues/3848
 		"issue 4203":                        c.issue4203,                            // https://github.com/apptainer/singularity/issues/4203
 		"issue 4407":                        c.issue4407,                            // https://github.com/apptainer/singularity/issues/4407
-		"issue 4524":                        c.issue4524,                            // https://github.com/apptainer/singularity/issues/4524
 		"issue 4583":                        c.issue4583,                            // https://github.com/apptainer/singularity/issues/4583
 		"issue 4820":                        c.issue4820,                            // https://github.com/apptainer/singularity/issues/4820
 		"issue 4837":                        c.issue4837,                            // https://github.com/apptainer/singularity/issues/4837
-		"issue 4943":                        c.issue4943,                            // https://github.com/apptainer/singularity/issues/4943
 		"issue 4967":                        c.issue4967,                            // https://github.com/apptainer/singularity/issues/4967
 		"issue 4969":                        c.issue4969,                            // https://github.com/apptainer/singularity/issues/4969
 		"issue 5166":                        c.issue5166,                            // https://github.com/apptainer/singularity/issues/5166
-		"issue 5172":                        c.issue5172,                            // https://github.com/apptainer/singularity/issues/5172
 		"issue 5250":                        c.issue5250,                            // https://github.com/apptainer/singularity/issues/5250
 		"issue 5315":                        c.issue5315,                            // https://github.com/apptainer/singularity/issues/5315
 		"issue 5435":                        c.issue5435,                            // https://github.com/apptainer/singularity/issues/5435

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -413,8 +413,8 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 		File: tmpfile,
 	}
 
-	defTmpl := `Bootstrap: docker
-From: alpine:latest
+	defTmpl := `Bootstrap: oras
+From: ghcr.io/apptainer/alpine:latest
 
 %files
 	{{ .File }}

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -202,42 +202,22 @@ func (c *ctx) testContain(t *testing.T) {
 
 // Test by running directly from URI
 func (c *ctx) testInstanceFromURI(t *testing.T) {
-	instances := []struct {
-		name string
-		uri  string
-	}{
-		{
-			name: "test_from_docker",
-			uri:  "docker://busybox",
-		},
-		{
-			name: "test_from_library",
-			uri:  "oras://ghcr.io/apptainer/busybox:1.31.1",
-		},
-		// TODO(mem): reenable this; disabled while shub is down
-		// {
-		// 	name: "test_from_shub",
-		// 	uri:  "shub://singularityhub/busybox",
-		// },
-	}
-
-	for _, i := range instances {
-		args := []string{i.uri, i.name}
-		c.env.RunApptainer(
-			t,
-			e2e.WithProfile(c.profile),
-			e2e.WithCommand("instance start"),
-			e2e.WithArgs(args...),
-			e2e.PostRun(func(t *testing.T) {
-				if t.Failed() {
-					return
-				}
-				c.execInstance(t, i.name, "id")
-				c.stopInstance(t, i.name)
-			}),
-			e2e.ExpectExit(0),
-		)
-	}
+	name := "test_from_library"
+	args := []string{"oras://ghcr.io/apptainer/busybox:latest", name}
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(c.profile),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs(args...),
+		e2e.PostRun(func(t *testing.T) {
+			if t.Failed() {
+				return
+			}
+			c.execInstance(t, name, "id")
+			c.stopInstance(t, name)
+		}),
+		e2e.ExpectExit(0),
+	)
 }
 
 // Execute an instance process, kill master process

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -21,7 +21,8 @@ type TestEnv struct {
 	TestRegistry         string
 	HomeDir              string // HomeDir sets the home directory that will be used for the execution of a command
 	KeyringDir           string // KeyringDir sets the directory where the keyring will be created for the execution of a command (instead of using APPTAINER_KEYSDIR which should be avoided when running e2e tests)
-	ImgCacheDir          string // ImgCacheDir sets the location of the image cache to be used by the Apptainer command to be executed (instead of using APPTAINER_CACHE_DIR which should be avoided when running e2e tests)
+	PrivCacheDir         string // PrivCacheDir sets the location of the image cache to be used by the Apptainer command to be executed as root (instead of using APPTAINER_CACHE_DIR which should be avoided when running e2e tests)
+	UnprivCacheDir       string // UnprivCacheDir sets the location of the image cache to be used by the Apptainer command to be executed as the unpriv user (instead of using APPTAINER_CACHE_DIR which should be avoided when running e2e tests)
 	RunDisabled          bool
 	DisableCache         bool   // DisableCache can be set to disable the cache during the execution of a e2e command
 	InsecureRegistry     string // Insecure registry replaced with nip.io

--- a/e2e/pull/concurrency.go
+++ b/e2e/pull/concurrency.go
@@ -7,6 +7,7 @@ package pull
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -134,26 +135,16 @@ func (c ctx) testConcurrentPulls(t *testing.T) {
 				envVars:          tt.envVars,
 			}
 
-			// Since we are not passing an image name, change the current
-			// working directory to the temporary directory we just created so
-			// that we know it's clean. We don't do this for the other case in
-			// order to catch spurious files showing up. Maybe later we can
-			// examine the directory and assert that it only contains what we
-			// expect.
-			oldwd, err := os.Getwd()
-			if err != nil {
-				t.Fatalf("Failed to get working directory for pull test: %+v", err)
-			}
-			defer os.Chdir(oldwd)
-
-			os.Chdir(tmpdir)
+			// No explicit image path specified. Will use temp dir as working directory,
+			// so we pull into a clean location.
+			ts.workDir = tmpdir
+			imageName := getImageNameFromURI(ts.srcURI)
+			ts.expectedImage = filepath.Join(tmpdir, imageName)
 
 			// if there's a pullDir, that's where we expect to find the image
 			if ts.pullDir != "" {
-				os.Chdir(ts.pullDir)
+				ts.expectedImage = filepath.Join(ts.pullDir, imageName)
 			}
-
-			ts.expectedImage = getImageNameFromURI(srcURI)
 
 			// pull image
 			c.imagePull(t, ts)

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -55,6 +55,12 @@ type testStruct struct {
 }
 
 func (c *ctx) imagePull(t *testing.T, tt testStruct) {
+	// Use a one-time cache directory specific to this pull. This ensures we are always
+	// testing an entire pull operation, performing the download into an empty cache.
+	cacheDir, cleanup := e2e.MakeCacheDir(t, "")
+	defer cleanup(t)
+	c.env.UnprivCacheDir = cacheDir
+
 	// We use a string rather than a slice of strings to avoid having an empty
 	// element in the slice, which would cause the command to fail, without
 	// over-complicating the code.
@@ -489,7 +495,7 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 		}
 	}()
 
-	c.env.ImgCacheDir = cacheDir
+	c.env.UnprivCacheDir = cacheDir
 
 	disableCacheTests := []struct {
 		name      string

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -646,24 +646,24 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		env: env,
 	}
 
-	// Run these pull tests sequentially among themselves, as they perform a lot
-	// of un-cached pulls which could otherwise lead to hitting rate limits.
-	return testhelper.Tests{
-		"ordered": func(t *testing.T) {
-			// Run the tests the do not require setup.
-			t.Run("pullUmaskCheck", c.testPullUmask)
+	np := testhelper.NoParallel
 
+	return testhelper.Tests{
+		// Run pull tests sequentially among themselves, as they perform a lot
+		// of un-cached pulls which could otherwise lead to hitting rate limits.
+		"ordered": func(t *testing.T) {
 			// Setup a test registry to pull from (for oras).
 			c.setup(t)
-
 			t.Run("pull", c.testPullCmd)
 			t.Run("pullDisableCache", c.testPullDisableCacheCmd)
 			t.Run("concurrencyConfig", c.testConcurrencyConfig)
 			t.Run("concurrentPulls", c.testConcurrentPulls)
-
 			// Regressions
 			// Disable for now, see issue #6299
 			// t.Run("issue5808", c.issue5808)
 		},
+		// Manipulates umask for the process, so must be run alone to avoid
+		// causing permission issues for other tests.
+		"pullUmaskCheck": np(c.testPullUmask),
 	}
 }

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -88,7 +88,6 @@ func (c ctx) apptainerSignIDOption(t *testing.T) {
 	}
 
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 
 	for _, tt := range tests {
 		c.env.RunApptainer(
@@ -128,7 +127,6 @@ func (c ctx) apptainerSignAllOption(t *testing.T) {
 	}
 
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 
 	for _, tt := range tests {
 		c.env.RunApptainer(
@@ -169,7 +167,6 @@ func (c ctx) apptainerSignGroupIDOption(t *testing.T) {
 	}
 
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 
 	for _, tt := range tests {
 		c.env.RunApptainer(
@@ -190,7 +187,6 @@ func (c ctx) apptainerSignKeyidxOption(t *testing.T) {
 
 	cmdArgs := []string{"--keyidx", "0", imgPath}
 	c.env.KeyringDir = c.keyringDir
-	c.env.ImgCacheDir = c.imgCache
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
@@ -234,18 +230,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	return testhelper.Tests{
 		"ordered": func(t *testing.T) {
 			var err error
-			// To speed up the tests, we use a common image cache (we pull the same image several times)
-			c.imgCache, err = os.MkdirTemp("", "e2e-sign-imgcache-")
-			if err != nil {
-				t.Fatalf("failed to create temporary directory: %s", err)
-			}
-			defer func() {
-				err := os.RemoveAll(c.imgCache)
-				if err != nil {
-					t.Fatalf("failed to delete temporary cache: %s", err)
-				}
-			}()
-
 			// We need one single key pair in a single keyring for all the tests
 			c.keyringDir, err = os.MkdirTemp("", "e2e-sign-keyring-")
 			if err != nil {

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -108,6 +108,20 @@ func Run(t *testing.T) {
 	testenv.TestRegistry = e2e.StartRegistry(t, testenv)
 	testenv.InsecureRegistry = strings.Replace(testenv.TestRegistry, "localhost", "127.0.0.1.nip.io", 1)
 
+	// Make shared cache dirs for privileged and unpriviliged E2E tests.
+	// Individual tests that depend on specific ordered cache behavior, or
+	// directly test the cache, should override the TestEnv values within the
+	// specific test.
+	privCacheDir, cleanPrivCache := e2e.MakeCacheDir(t, testenv.TestDir)
+	testenv.PrivCacheDir = privCacheDir
+	defer e2e.Privileged(func(t *testing.T) {
+		cleanPrivCache(t)
+	})
+
+	unprivCacheDir, cleanUnprivCache := e2e.MakeCacheDir(t, testenv.TestDir)
+	testenv.UnprivCacheDir = unprivCacheDir
+	defer cleanUnprivCache(t)
+
 	// e2e tests need to run in a somehow agnostic environment, so we
 	// don't use environment of user executing tests in order to not
 	// wrongly interfering with cache stuff, sylabs library tokens,

--- a/e2e/testdata/regressions/issue_4203.def
+++ b/e2e/testdata/regressions/issue_4203.def
@@ -1,5 +1,5 @@
-bootstrap: docker
-from: ubuntu:16.04
+bootstrap: oras
+from: ghcr.io/apptainer/ubuntu:18.04
 stage: build
 
 %post
@@ -35,8 +35,8 @@ rpc:            bad
 netgroup:       bad
 EOF
 
-bootstrap: docker
-from: ubuntu:16.04
+bootstrap: oras
+from: ghcr.io/apptainer/ubuntu:18.04
 stage: final
 
 %environment

--- a/e2e/testdata/regressions/issue_4820.def
+++ b/e2e/testdata/regressions/issue_4820.def
@@ -1,5 +1,5 @@
-Bootstrap: docker
-From: busybox:latest
+Bootstrap: oras
+From: ghcr.io/apptainer/alpine:latest
 
 %appinstall hdf5
 echo "installing hdf5..."

--- a/e2e/testdata/regressions/issue_4969.def
+++ b/e2e/testdata/regressions/issue_4969.def
@@ -1,5 +1,5 @@
-bootstrap: docker
-from: busybox
+bootstrap: oras
+from: ghcr.io/apptainer/alpine:latest
 
 %setup
     root=$APPTAINER_ROOTFS

--- a/e2e/testdata/regressions/issue_5250.def
+++ b/e2e/testdata/regressions/issue_5250.def
@@ -1,5 +1,5 @@
-BootStrap: docker
-From: centos:centos7
+BootStrap: oras
+From: ghcr.io/apptainer/centos:7
 
 %post
     yum -y reinstall setup

--- a/e2e/testdata/sshfs.def
+++ b/e2e/testdata/sshfs.def
@@ -1,5 +1,5 @@
-bootstrap: docker
-from: alpine:3.16
+bootstrap: oras
+from: ghcr.io/apptainer/alpine:latest
 
 %post
     apk update


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity#975
- sylabs/singularity#982
- sylabs/singularity#984
- sylabs/singularity#986
 which fixed
- sylabs/singularity#977

The original PR descriptions were:
> The SingularityCmd construct used to execute singularity in the e2e tests has defaulted to a fresh, empty cache directory for each execution.
> 
> This means that we are downloading full container images on every e2e execution of singularity against docker or library, which slows things down and creates uneccesary request load on the Sylabs Library, Docker Hub, etc.
> 
> Switch to using a shared cache by default. Our cache structure has been concurrency safe (given atomic operations on local filesystems) for some time now crossed_fingers ... this will also now test that.
> 
> Pull tests are modified so that they explicitly use an empty cache, to test the entire pull flow, including container image download.
> 
> Any future tests that depend on exercising downloads, the cache specifically, or depend on a specific state / order of cached operations will need to also specify their own cache directory.

> E2E tests using docker:// sources cannot run in parallel with caching, due to issues with concurrency and the containers/image oci/layout. We want to use caching as many tests rely on the same image, and Docker Hub rate limiting is still an issue where it is not trivial to provide credentials.
> 
> This changeset:
> 
> * Replaces some docker:// sources with equivalent library:// sources, in tests that are not explicitly for verifying docker specific
>       behavior. library:// caching is concurrency safe on local fs with atomic operations (such as CI), allowing a speed-up.
> 
> * Removes some redundant docker:// source tests from env/imgbuild etc. which are already covered by the docker group.
> 
> * Moves all remaining docker:// source tests into the e2e.docker group, so that all tests using Docker Hub are isolated there. This could be used in future to disable them for e2e runs without Docker Hub credentials etc.
> 
> * Runs the e2e.docker tests ordered sequentially, but parallel with respect to other non-docker tests.
> 
> * Replaces a problematic Chdir operation in the non-docker pull tests with specifying the working directory on the exec.Command, so that these pull tests can also be run ordered sequentially, but parallel with respect to other non-pull tests.
> 
> 
> Speed-up reported on CircleCI from these changes is ~20%

> Two e2e tests with docker sources were missed in sylabs/singularity#982 due to a case-sensitive search for bootstrap: docker.
> 
> Move one to the docker e2e group. Modify the other to use a library alpine image.

> One E2E PULL test manipulates the process umask. To avoid causing permissions issues in other tests it must be run alone, in the SEQ section of the E2E suit, via testhelper.NoParallel.
> 
> Convert IMGBUILD def file tests docker -> library