### PR TITLE
Add support for x509

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Support for `DOCKER_HOST` parsing when using `docker-daemon://`
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
 
+- Added support for signing and validating images using X509 certificates. For
+  the signing the flags --pkcs8Key and --x509cert are added. In the respective
+  order, the flags load the private key and the certificate of the authority
+  signing the image (signer). For the validation, --x509cert, --x509RootCA,
+  and --x509IntermediateCerts. In the respective order, the load the signer's
+  certificate, the certificate of the Root CA who signed the signer's certificate,
+  and the certificates of intermediate CAs.
+
 ## v1.1.2 - \[2022-10-06\]
 
 ### Changes since last release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   the signing the flags --pkcs8Key and --x509cert are added. In the respective
   order, the flags load the private key and the certificate of the authority
   signing the image (signer). For the validation, --x509cert, --x509RootCA,
-  and --x509IntermediateCerts. In the respective order, the load the signer's
+  and --x509IntermediateCerts. In the respective order, they load the signer's
   certificate, the certificate of the Root CA who signed the signer's certificate,
   and the certificates of intermediate CAs.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,6 +31,7 @@
 - Eng Zer Jun <engzerjun@gmail.com>
 - Eric Müller <mueller@kip.uni-heidelberg.de>
 - Felix Abecassis <fabecassis@nvidia.com>
+- Fotis Nikolaidis <nikolaidis.fotis@gmail.com>
 - Geoffroy Vallee <geoffroy@sylabs.io>, <geoffroy.vallee@gmail.com>
 - George Hartzell <hartzell@alerce.com>
 - Gert Hulselmans <gert.hulselmans@kuleuven.vib.be>

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/apex/log v1.9.0
 	github.com/apptainer/container-key-client v0.8.0
 	github.com/apptainer/container-library-client v1.3.3
-	github.com/apptainer/sif/v2 v2.8.1
+	github.com/apptainer/sif/v2 v2.8.1-0.20221005170741-1d8027b2898d
 	github.com/blang/semver/v4 v4.0.0
 	github.com/buger/goterm v1.0.4
 	github.com/buger/jsonparser v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/apex/log v1.9.0
 	github.com/apptainer/container-key-client v0.8.0
 	github.com/apptainer/container-library-client v1.3.3
-	github.com/apptainer/sif/v2 v2.8.1-0.20221005170741-1d8027b2898d
+	github.com/apptainer/sif/v2 v2.8.1-0.20221006193710-34d1c7fdf4fb
 	github.com/blang/semver/v4 v4.0.0
 	github.com/buger/goterm v1.0.4
 	github.com/buger/jsonparser v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/apptainer/container-key-client v0.8.0 h1:K181Zrejb53mR2YQZwCathSj8YRe
 github.com/apptainer/container-key-client v0.8.0/go.mod h1:wMeJdiMXlPRiwJfUyae2WRHsZlHG9Af6iPQ9TZcBnS8=
 github.com/apptainer/container-library-client v1.3.3 h1:xd0/27nB8mAtyJAwG/7tTOoWAhjMiZPyZy4fzzQHMak=
 github.com/apptainer/container-library-client v1.3.3/go.mod h1:B+ARx/+WaE/E2pkv2qZUQeoEBO89PUpmLKsTJmbM5eQ=
-github.com/apptainer/sif/v2 v2.8.1-0.20221005170741-1d8027b2898d h1:W2jVXBNTe4WRlaGjfe98ICpxjrvWMKMsOax2HDwfYqk=
-github.com/apptainer/sif/v2 v2.8.1-0.20221005170741-1d8027b2898d/go.mod h1:ELUI9IzDd9fuNN099gwA0bUvoR2I5LSZWYcqCqvLw/0=
+github.com/apptainer/sif/v2 v2.8.1-0.20221006193710-34d1c7fdf4fb h1:HhrpOt4xXWC3IiQuTVEF9GBNQSl9URLK5NUgJQxVjBs=
+github.com/apptainer/sif/v2 v2.8.1-0.20221006193710-34d1c7fdf4fb/go.mod h1:ELUI9IzDd9fuNN099gwA0bUvoR2I5LSZWYcqCqvLw/0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/apptainer/container-key-client v0.8.0 h1:K181Zrejb53mR2YQZwCathSj8YRe
 github.com/apptainer/container-key-client v0.8.0/go.mod h1:wMeJdiMXlPRiwJfUyae2WRHsZlHG9Af6iPQ9TZcBnS8=
 github.com/apptainer/container-library-client v1.3.3 h1:xd0/27nB8mAtyJAwG/7tTOoWAhjMiZPyZy4fzzQHMak=
 github.com/apptainer/container-library-client v1.3.3/go.mod h1:B+ARx/+WaE/E2pkv2qZUQeoEBO89PUpmLKsTJmbM5eQ=
-github.com/apptainer/sif/v2 v2.8.1 h1:c8WSyIZ/Jujf3GijgkCLNEvwusvNIGn8fUBgkCv/8F0=
-github.com/apptainer/sif/v2 v2.8.1/go.mod h1:ELUI9IzDd9fuNN099gwA0bUvoR2I5LSZWYcqCqvLw/0=
+github.com/apptainer/sif/v2 v2.8.1-0.20221005170741-1d8027b2898d h1:W2jVXBNTe4WRlaGjfe98ICpxjrvWMKMsOax2HDwfYqk=
+github.com/apptainer/sif/v2 v2.8.1-0.20221005170741-1d8027b2898d/go.mod h1:ELUI9IzDd9fuNN099gwA0bUvoR2I5LSZWYcqCqvLw/0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=

--- a/internal/app/apptainer/sign.go
+++ b/internal/app/apptainer/sign.go
@@ -37,6 +37,15 @@ func OptSignEntitySelector(f sypgp.EntitySelector) SignOpt {
 	}
 }
 
+// OptSignX509 specifies the entity to use to generate signature(s).
+func OptSignX509(f *integrity.X509Signer) SignOpt {
+	return func(s *signer) error {
+		s.opts = append(s.opts, integrity.OptSignWithX509Issuer(f))
+
+		return nil
+	}
+}
+
 // OptSignGroup specifies that a signature be applied to cover all objects in the group with the
 // specified groupID. This may be called multiple times to add multiple group signatures.
 func OptSignGroup(groupID uint32) SignOpt {

--- a/internal/app/apptainer/verify_test.go
+++ b/internal/app/apptainer/verify_test.go
@@ -371,7 +371,7 @@ func TestVerify(t *testing.T) {
 					}
 				}
 
-				if got, want := r.Entity().PrimaryKey, tt.wantEntity.PrimaryKey; !reflect.DeepEqual(got, want) {
+				if got, want := r.Entity().(*openpgp.Entity).PrimaryKey, tt.wantEntity.PrimaryKey; !reflect.DeepEqual(got, want) {
 					t.Errorf("got entity public key %+v, want %+v", got, want)
 				}
 
@@ -543,7 +543,7 @@ func TestVerifyFingerPrint(t *testing.T) {
 					}
 				}
 
-				if got, want := r.Entity().PrimaryKey, tt.wantEntity.PrimaryKey; !reflect.DeepEqual(got, want) {
+				if got, want := r.Entity().(*openpgp.Entity).PrimaryKey, tt.wantEntity.PrimaryKey; !reflect.DeepEqual(got, want) {
 					t.Errorf("got entity public key %+v, want %+v", got, want)
 				}
 


### PR DESCRIPTION
Signed-off-by: Fotis Nikolaidis <nikolaidis.fotis@gmail.com>


This PR follows the discussion on https://github.com/apptainer/sif/pull/149

== Use-Case ==
Singularity/Apptainer supports the capability to use PGP keys for signing and verifying containers, thus improving the level of trust for users that need to share containers.

PGP is based on the "Web of Trust" principle, where communicating parties must have at least one trusted party in common, who will sign both keys. PGP relies on asymmetric cryptography (i.e., the creation and usage of public-private key pairs).

X.509 is an alternative security approach, also relying on asymmetric cryptography, but is usually deployed in environments where certification authorities (CAs) vouch for each certificate, meaning the overall system architecture needs a CA. Anyone who wants to participate in the system must have their keys signed by that CA. Certificate creation and validation rely on a chain of trust established among CAs.

However, sharing containers among Supercomputing Center (SC) customers assumes a trusting relationship with the code providers and the SC itself. We advocate that a Supercomputing Center can provide Public Key Infrastructure (PKI) services to its customers, assuming the CA's role in the trusted sharing of pre-validated codes that are packaged as container images. We consider use cases where containers include specialized software packages and libraries, including their configuration parameter settings, for HPC codes expected to operate on sensitive datasets in a wide range of scientific domains.

This PR implements the proposed extensions to the codebase of Singularity/Apptainer so that X.509 certificates, signed by the SC's CA, can be embedded in SIF-formatted container binary image files and then be checked online for validity (incl. checks for revocation).

Important Note: the X.509 certificates are supported without removing the existing support for PGP certificates.
