### PR TITLE
Fix --rocm option, /dev/dri/render devices needed as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   point-in-time usage.
 - Support for `DOCKER_HOST` parsing when using `docker-daemon://`
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
+- `--rocm` flag in combination with `-c` / `-C` fixed by forwarding all
+  `/dri/render*` devices into the container.
 
 ## v1.1.0 - \[2022-09-27\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@
 - Daniele Tamino <daniele.tamino@gmail.com>
 - Dave Godlove <d@sylabs.io>, <davidgodlove@gmail.com>
 - Dave Love <d.love@liverpool.ac.uk>
+- David Rohr <drohr@jwdt.org>
 - David Trudgian <david.trudgian@utsouthwestern.edu>,
   <david.trudgian@sylabs.io>, <dave@trudgian.net>
 - Diana Langenbach <dcl@dcl.sh>

--- a/internal/pkg/util/gpu/rocm.go
+++ b/internal/pkg/util/gpu/rocm.go
@@ -39,6 +39,12 @@ func RocmDevices(withGPU bool) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not list rocm devices: %v", err)
 	}
+	// render devices needed as well
+	rocmGlob2 := "/dev/dri/render*"
+	devs2, err2 := filepath.Glob(rocmGlob2)
+	if err2 == nil && devs2 != nil {
+		devs = append(devs, devs2...)
+	}
 	// /dev/kfd is also required
 	devs = append(devs, "/dev/kfd")
 	return devs, nil


### PR DESCRIPTION
On el8 with AMD ROCm 5.1.2 (I didn't check other versions), the `/dev/dri/render*` devices are needed in addition to the `/dev/dri/card*` devices, in order for the ROCm application to access the GPU device. This PR adds the bind-mounts for these devices (in addition to the existing `/dev/kfd` and `/dev/dri/card*`) in case the `apptainer exec -c --rocm` command line options are used.