### PR TITLE
Use -o uid=N,gid=N with patched squashfuse_ll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Support for `DOCKER_HOST` parsing when using `docker-daemon://`
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
 
+### Bug fixes
+
+- Updated the included `squashfuse_ll` to have `-o uid=N` and `-o gid=N`
+  options and changed the corresponding image driver to use them when
+  available.  This makes files inside sif files appear to be owned by the
+  user instead of by the nobody id 65534 when running in non-setuid mode.
+
 ## v1.1.2 - \[2022-10-06\]
 
 ### Changes since last release

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -178,6 +178,9 @@ performance version of `squashfuse_ll`.
 As of this writing there is a patch pending to the squashfuse project to
 add multithreading support that significantly improves performance for
 applications that access a lot of small files from many cores at once.
+There's also another `squashfuse_ll` patch for supporting options to make
+files appear to be owned by the user
+(the same options that exist in `squashfuse`).
 
 First, make sure that additional required packages are installed.  On Debian:
 
@@ -194,9 +197,11 @@ To download the source code do this:
 
 ```sh
 SQUASHFUSEVERSION=0.1.105
-SQUASHFUSEPR=70
+SQUASHFUSEPRS="70 77"
 curl -L -O https://github.com/vasi/squashfuse/archive/$SQUASHFUSEVERSION/squashfuse-$SQUASHFUSEVERSION.tar.gz
-curl -L -O https://github.com/vasi/squashfuse/pull/$SQUASHFUSEPR.patch
+for PR in $SQUASHFUSEPRS; do
+    curl -L -O https://github.com/vasi/squashfuse/pull/$PR.patch
+done
 ```
 
 Then to compile and install do this:
@@ -204,7 +209,9 @@ Then to compile and install do this:
 ```sh
 tar xzf squashfuse-$SQUASHFUSEVERSION.tar.gz
 cd squashfuse-$SQUASHFUSEVERSION
-patch -p1 <../$SQUASHFUSEPR.patch
+for PR in $SQUASHFUSEPRS; do
+    patch -p1 <../$PR.patch
+done
 ./autogen.sh
 CFLAGS=-std=c99 ./configure --enable-multithreading
 make squashfuse_ll

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -51,6 +51,7 @@ Source: https://github.com/%{name}/%{name}/releases/download/v%{package_version}
 %if "%{?squashfuse_version}" != ""
 Source10: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squashfuse-%{squashfuse_version}.tar.gz
 Patch10: https://github.com/vasi/squashfuse/pull/70.patch
+Patch11: https://github.com/vasi/squashfuse/pull/77.patch
 %endif
 # The singularity package was renamed to apptainer after version 3.8.x.
 # The apptainer package reset numbering at 1.0.0, and some singularity
@@ -113,6 +114,7 @@ Provides the optional setuid-root portion of Apptainer.
 # so do main package last
 %setup -b 10 -n squashfuse-%{squashfuse_version}
 %patch -P 10 -p1
+%patch -P 11 -p1
 %setup -n %{name}-%{package_version}
 %else
 %autosetup -n %{name}-%{package_version}


### PR DESCRIPTION
## Description of the Pull Request (PR):

This adds `uid=N` and `gid=N` options to squashfuse_ll and uses them when they are available.  This makes files within SIF files appear to be owned by the current user instead of by nobody.

### This fixes or addresses the following GitHub issues:

 - Fixes #736

