### PR TITLE
Prefer fakeroot-sysv over fakeroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Support for `DOCKER_HOST` parsing when using `docker-daemon://`
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
 
+### Bug fixes
+
+- Prefer the `fakeroot-sysv` command over the `fakeroot` command because
+  the latter can be linked to either `fakeroot-sysv` or `fakeroot-tcp`,
+  but `fakeroot-sysv` is much faster.
+
 ## v1.1.2 - \[2022-10-06\]
 
 ### Changes since last release

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -55,16 +55,21 @@ func UnshareRootMapped(args []string) error {
 	return nil
 }
 
-// This just adds debug messages around bin.FindBin("fakeroot")
+// Look for fakeroot-sysv first and then fakeroot, since fakeroot-sysv
+// is much faster than fakeroot-tcp.
 func FindFake() (string, error) {
-	sylog.Debugf("looking for the fakeroot command")
-	fakerootPath, err := bin.FindBin("fakeroot")
-	if err != nil {
-		sylog.Debugf("failure finding fakeroot: %v", err)
-		return "", err
+	var err error
+	for _, cmd := range []string{"fakeroot-sysv", "fakeroot"} {
+		sylog.Debugf("looking for the %v command", cmd)
+		var fakerootPath string
+		fakerootPath, err = bin.FindBin(cmd)
+		if err == nil {
+			sylog.Debugf("%v found at %v", cmd, fakerootPath)
+			return fakerootPath, nil
+		}
+		sylog.Debugf("failure finding %v: %v", cmd, err)
 	}
-	sylog.Debugf("fakeroot found at %v", fakerootPath)
-	return fakerootPath, nil
+	return "", err
 }
 
 // Get the args needed to execute the fakeroot mapped into the container

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -51,6 +51,7 @@ func FindBin(name string) (path string, err error) {
 		"debootstrap",
 		"dnf",
 		"fakeroot",
+		"fakeroot-sysv",
 		"fuse-overlayfs",
 		"fuse2fs",
 		"go",


### PR DESCRIPTION
This makes the `--fakeroot` option search for the `fakeroot-sysv` command before the `fakeroot` command.

- Fixes #744