### PR TITLE
Use ELF interpreter to run unsquashfs command

### DIFF
--- a/internal/pkg/image/unpacker/squashfs_apptainer.go
+++ b/internal/pkg/image/unpacker/squashfs_apptainer.go
@@ -42,10 +42,10 @@ type libBind struct {
 
 // getLibraryBinds returns the library bind mounts required by an elf binary.
 // The binary path must be absolute.
-func getLibraryBinds(binary string) ([]libBind, error) {
+func getLibraryBinds(binary string) (string, []libBind, error) {
 	exe, err := elf.Open(binary)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	defer exe.Close()
 
@@ -59,9 +59,9 @@ func getLibraryBinds(binary string) ([]libBind, error) {
 		buf := make([]byte, 4096)
 		n, err := p.ReadAt(buf, 0)
 		if err != nil && err != io.EOF {
-			return nil, err
+			return "", nil, err
 		} else if n > cap(buf) {
-			return nil, fmt.Errorf("buffer too small to store interpreter")
+			return "", nil, fmt.Errorf("buffer too small to store interpreter")
 		}
 		// trim null byte to avoid an execution failure with
 		// an invalid argument error
@@ -70,7 +70,7 @@ func getLibraryBinds(binary string) ([]libBind, error) {
 
 	// this is a static binary, nothing to do
 	if interp == "" {
-		return []libBind{}, nil
+		return "", []libBind{}, nil
 	}
 
 	// run interpreter to list library dependencies for the
@@ -91,10 +91,11 @@ func getLibraryBinds(binary string) ([]libBind, error) {
 	cmd.Env = []string{}
 
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("while getting library dependencies: %s\n%s", err, errBuf.String())
+		return "", nil, fmt.Errorf("while getting library dependencies: %s\n%s", err, errBuf.String())
 	}
 
-	return parseLibraryBinds(buf)
+	libs, err := parseLibraryBinds(buf)
+	return interp, libs, err
 }
 
 // parseLibrary binds parses `ld-linux-x86-64.so.2 --list <binary>` output.
@@ -213,7 +214,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	}
 
 	// get the library dependencies of unsquashfs
-	libs, err := getLibraryBinds(unsquashfs)
+	interp, libs, err := getLibraryBinds(unsquashfs)
 	if err != nil {
 		return nil, err
 	}
@@ -266,6 +267,9 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	args = append(args, rootfs)
 
 	// unsquashfs execution arguments
+	if interp != "" {
+		args = append(args, interp)
+	}
 	args = append(args, unsquashfs)
 	args = append(args, opts...)
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

If unsquashfs is dynamically linked as has a relative RPATH set the ELF interpreter requires /proc to be mounted to discover the path to the currently running executable. If we run the ELF interpreter directly we don't need /proc to be mounted as it already knows the absolute path of the executable.

### This fixes or addresses the following GitHub issues:

 - Fixes #760


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
