### PR TITLE
Bump golangci-lint to v1.49, from sylabs 987

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   check_source:
     name: check_source
     runs-on: ubuntu-20.04
-    container: golangci/golangci-lint:v1.44
+    container: golangci/golangci-lint:v1.49
     steps:
       - uses: actions/checkout@v2
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   enable:
     - containedctx
     - contextcheck
-    - deadcode
     - decorder
     - dupl
     - gofumpt
@@ -23,6 +22,7 @@ linters:
     - nakedret
     - revive
     - staticcheck
+    - unused
 
 linters-settings:
   misspell:

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -76,7 +76,7 @@ var keyGlobalPubKeyFlag = cmdline.Flag{
 	Usage:        "manage global public keys (import/pull/remove are restricted to root user or unprivileged installation only)",
 }
 
-//--public
+// --public
 var keyRemovePublicKeyFlag = cmdline.Flag{
 	ID:           "keyRemovePublicKeyFlag",
 	Value:        &keyRemovePublic,
@@ -86,7 +86,7 @@ var keyRemovePublicKeyFlag = cmdline.Flag{
 	Usage:        "remove public keys only",
 }
 
-//--secret
+// --secret
 var keyRemovePrivateKeyFlag = cmdline.Flag{
 	ID:           "keyRemovePrivateKeyFlag",
 	Value:        &keyRemovePrivate,
@@ -96,7 +96,7 @@ var keyRemovePrivateKeyFlag = cmdline.Flag{
 	Usage:        "remove secret keys only",
 }
 
-//--both
+// --both
 var keyRemoveBothKeyFlag = cmdline.Flag{
 	ID:           "keyRemoveBothKeyFlag",
 	Value:        &keyRemoveBoth,
@@ -106,7 +106,7 @@ var keyRemoveBothKeyFlag = cmdline.Flag{
 	Usage:        "remove both public and private keys",
 }
 
-//--keysdir
+// --keysdir
 var keyLocalDirKeyFlag = cmdline.Flag{
 	ID:           "keyLocalDirKeyFlag",
 	Value:        &keyLocalDir,

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -31,23 +31,6 @@ type instance struct {
 
 type instanceList struct {
 	Instances []instance `json:"instances"`
-}
-
-func (c *ctx) listInstance(t *testing.T, listArgs ...string) (stdout string, stderr string, success bool) {
-	var args []string
-
-	c.env.RunApptainer(
-		t,
-		e2e.WithProfile(c.profile),
-		e2e.WithCommand("instance list"),
-		e2e.WithArgs(args...),
-		e2e.PostRun(func(t *testing.T) {
-			success = !t.Failed()
-		}),
-		e2e.ExpectExit(0, e2e.GetStreams(&stdout, &stderr)),
-	)
-
-	return
 }
 
 func (c *ctx) stopInstance(t *testing.T, instance string, stopArgs ...string) (stdout string, stderr string, success bool) {

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -20,7 +20,6 @@ import (
 
 type ctx struct {
 	env             e2e.TestEnv
-	imgCache        string
 	keyringDir      string
 	passphraseInput []e2e.ApptainerConsoleOp
 }

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -391,7 +391,7 @@ func (b *Build) Full(ctx context.Context) error {
 
 		// copy potential files from previous stage
 		if stage.b.RunSection("files") {
-			if err := stage.copyFilesFrom(b); err != nil {
+			if err := stage.copyFilesFrom(b); err != nil { //nolint:contextcheck
 				return fmt.Errorf("unable to copy files from stage to container fs: %v", err)
 			}
 		}
@@ -402,7 +402,7 @@ func (b *Build) Full(ctx context.Context) error {
 
 		// copy files from host
 		if stage.b.RunSection("files") {
-			if err := stage.copyFiles(); err != nil {
+			if err := stage.copyFiles(); err != nil { //nolint:contextcheck
 				return fmt.Errorf("unable to copy files from host to container fs: %v", err)
 			}
 		}

--- a/internal/pkg/build/sources/base_environment.go
+++ b/internal/pkg/build/sources/base_environment.go
@@ -20,50 +20,62 @@ import (
 )
 
 // Contents of /.singularity.d/actions/exec
+//
 //go:embed exec.sh
 var execFileContent string
 
 // Contents of /.singularity.d/actions/run
+//
 //go:embed run.sh
 var runFileContent string
 
 // Contents of /.singularity.d/actions/shell
+//
 //go:embed shell.sh
 var shellFileContent string
 
 // Contents of /.singularity.d/actions/start
+//
 //go:embed start.sh
 var startFileContent string
 
 // Contents of /.singularity.d/actions/test
+//
 //go:embed test.sh
 var testFileContent string
 
 // Contents of /.singularity.d/env/01-base.sh
+//
 //go:embed 01-base.sh
 var baseShFileContent string
 
 // Contents of /.singularity.d/env/90-environment.sh and /.singularity.d/env/91-environment.sh
+//
 //go:embed 90-environment.sh
 var environmentShFileContent string
 
 // Contents of /.singularity.d/env/95-apps.sh
+//
 //go:embed 95-apps.sh
 var appsShFileContent string
 
 // Contents of /.singularity.d/env/99-base.sh
+//
 //go:embed 99-base.sh
 var base99ShFileContent string
 
 // Contents of /.singularity.d/env/99-runtimevars.sh
+//
 //go:embed 99-runtimevars.sh
 var base99runtimevarsShFileContent string
 
 // Contents of /.singularity.d/runscript
+//
 //go:embed runscript.sh
 var runscriptFileContent string
 
 // Contents of /.singularity.d/startscript
+//
 //go:embed startscript.sh
 var startscriptFileContent string
 

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -41,7 +41,6 @@ var instList = []string{"base"}
 type ArchConveyorPacker struct {
 	b       *types.Bundle
 	confurl string
-	include string
 }
 
 // prepareFakerootEnv prepares a build environment to

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,7 +23,6 @@ import (
 // LocalConveyor only needs to hold the conveyor to have the needed data to pack
 type LocalConveyor struct {
 	src string
-	b   *types.Bundle
 }
 
 // LocalPacker ...

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -20,8 +20,7 @@ import (
 
 // ShubConveyorPacker only needs to hold the conveyor to have the needed data to pack.
 type ShubConveyorPacker struct {
-	recipe types.Definition
-	b      *types.Bundle
+	b *types.Bundle
 	LocalPacker
 }
 

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -204,21 +204,6 @@ func (h *Handle) CleanCache(cacheType string, dryRun bool, days int) (err error)
 	return err
 }
 
-// cleanAllCaches is an utility function that wipes all files in the
-// cache directory, will return a error if one occurs
-func (h *Handle) cleanAllCaches() {
-	if h.disabled {
-		return
-	}
-
-	for _, ct := range append(FileCacheTypes, OciCacheTypes...) {
-		dir := h.getCacheTypeDir(ct)
-		if err := os.RemoveAll(dir); err != nil {
-			sylog.Verbosef("unable to clean %s cache, directory %s: %v", ct, dir, err)
-		}
-	}
-}
-
 // IsDisabled returns true if the cache is disabled
 func (h *Handle) IsDisabled() bool {
 	return h.disabled

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -64,8 +64,7 @@ const (
 var sifLayerMediaTypes = []string{SifLayerMediaTypeV1, SifLayerMediaTypeProto}
 
 type orasUploadTransport struct {
-	rt    http.RoundTripper
-	scope string
+	rt http.RoundTripper
 }
 
 func (t *orasUploadTransport) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -61,7 +61,7 @@ func ProgressBarCallback(ctx context.Context) ProgressCallback {
 	}
 
 	return func(totalSize int64, r io.Reader, w io.Writer) error {
-		p, bar := initProgressBar(totalSize)
+		p, bar := initProgressBar(totalSize) //nolint:contextcheck
 
 		// create proxy reader
 		bodyProgress := bar.ProxyReader(r)

--- a/internal/pkg/fakeroot/fakeroot.go
+++ b/internal/pkg/fakeroot/fakeroot.go
@@ -71,8 +71,10 @@ type Config struct {
 type GetUserFn func(string) (*user.User, error)
 
 // Wrapped errors
-var errNoMappingEntry = errors.New("no mapping entry found")
-var errRangeTooLow = errors.New("range count lower than")
+var (
+	errNoMappingEntry = errors.New("no mapping entry found")
+	errRangeTooLow    = errors.New("range count lower than")
+)
 
 // GetConfig parses a subuid/subgid configuration file and returns
 // a Config holding all mapping entries, it allows to pass a custom
@@ -380,7 +382,7 @@ func GetIDRange(path string, uid uint32) (*specs.LinuxIDMapping, error) {
 }
 
 // IsUIDMapped returns true if the given uid is mapped in SubUIDFile
-//  and otherwise it returns false
+// and otherwise it returns false
 func IsUIDMapped(uid uint32) bool {
 	config, err := GetConfig(SubUIDFile, false, getPwNam)
 	if err != nil {

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -345,7 +345,7 @@ func (d *fuseappsDriver) Start(params *image.DriverParams, containerPid int) err
 
 // Stop the process associated with the mount target, if there is one.
 // If kill is not true, an unmount should already have happened so at
-//   first just wait for the process to exit.
+// first just wait for the process to exit.
 func (f *fuseappsFeature) stop(target string, kill bool) error {
 	for _, instance := range f.instances {
 		if instance.params.Target != target {

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -376,32 +376,9 @@ func (c *Config) SetNsPath(nstype specs.LinuxNamespaceType, path string) error {
 func (c *Config) SetNsPathFromSpec(namespaces []specs.LinuxNamespace) error {
 	for _, namespace := range namespaces {
 		if namespace.Path != "" {
-			cpath := unsafe.Pointer(C.CString(namespace.Path))
-			l := len(namespace.Path)
-			size := C.size_t(l)
-
-			if l > C.MAX_PATH_SIZE-1 {
-				return fmt.Errorf("%s namespace path too big", namespace.Type)
+			if err := c.SetNsPath(namespace.Type, namespace.Path); err != nil {
+				return err
 			}
-
-			switch namespace.Type {
-			case specs.UserNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.user[0]), cpath, size)
-			case specs.IPCNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.ipc[0]), cpath, size)
-			case specs.UTSNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.uts[0]), cpath, size)
-			case specs.PIDNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.pid[0]), cpath, size)
-			case specs.NetworkNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.network[0]), cpath, size)
-			case specs.MountNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.mount[0]), cpath, size)
-			case specs.CgroupNamespace:
-				C.memcpy(unsafe.Pointer(&c.config.container.namespace.cgroup[0]), cpath, size)
-			}
-
-			C.free(cpath)
 		}
 	}
 

--- a/internal/pkg/runtime/engine/oci/create_linux.go
+++ b/internal/pkg/runtime/engine/oci/create_linux.go
@@ -160,6 +160,7 @@ var statusChan = make(chan string, 1)
 //
 // However, most likely this still will be executed as root since `apptainer oci`
 // command set requires privileged execution.
+//
 //nolint:maintidx
 func (e *EngineOperations) CreateContainer(ctx context.Context, pid int, rpcConn net.Conn) error {
 	var err error

--- a/internal/pkg/runtime/engine/oci/prepare_linux.go
+++ b/internal/pkg/runtime/engine/oci/prepare_linux.go
@@ -40,6 +40,7 @@ var (
 // dropped by the time PrepareConfig is called. However, most likely this
 // still will be executed as root since `apptainer oci` command set
 // requires privileged execution.
+//
 //nolint:maintidx
 func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	if e.CommonConfig.EngineName != Name {

--- a/internal/pkg/util/fs/files/action_scripts.go
+++ b/internal/pkg/util/fs/files/action_scripts.go
@@ -12,9 +12,11 @@ package files
 import _ "embed"
 
 // ActionScript is the action script content.
+//
 //go:embed action_script.sh
 var ActionScript string
 
 // RuntimeVars is the runtime variables script.
+//
 //go:embed runtime_vars.sh
 var RuntimeVars string

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -142,7 +142,7 @@ type Image struct {
 }
 
 // ReInit fills in the File object if needed.  This function should be
-//   called after passing an image object between processes using JSON
+// called after passing an image object between processes using JSON
 func (i *Image) ReInit() {
 	if i.File == nil && i.Path != "" {
 		i.File = os.NewFile(i.Fd, i.Path)


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#987

The original PR description was:
> Bump `golangci-lint` to v1.49. Replace deprecated `deadcode` linter with `unused`. Address various lint.