### PR TITLE
Prefer fakeroot-sysv over fakeroot (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes Since Last Release
+
+- Prefer the `fakeroot-sysv` command over the `fakeroot` command because
+  the latter can be linked to either `fakeroot-sysv` or `fakeroot-tcp`,
+  but `fakeroot-sysv` is much faster.
+
 ## v1.1.2 - \[2022-10-06\]
 
 - [CVE-2022-39237](https://github.com/sylabs/sif/security/advisories/GHSA-m5m3-46gj-wch8):

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -55,16 +55,21 @@ func UnshareRootMapped(args []string) error {
 	return nil
 }
 
-// This just adds debug messages around bin.FindBin("fakeroot")
+// Look for fakeroot-sysv first and then fakeroot, since fakeroot-sysv
+// is much faster than fakeroot-tcp.
 func FindFake() (string, error) {
-	sylog.Debugf("looking for the fakeroot command")
-	fakerootPath, err := bin.FindBin("fakeroot")
-	if err != nil {
-		sylog.Debugf("failure finding fakeroot: %v", err)
-		return "", err
+	var err error
+	for _, cmd := range []string{"fakeroot-sysv", "fakeroot"} {
+		sylog.Debugf("looking for the %v command", cmd)
+		var fakerootPath string
+		fakerootPath, err = bin.FindBin(cmd)
+		if err == nil {
+			sylog.Debugf("%v found at %v", cmd, fakerootPath)
+			return fakerootPath, nil
+		}
+		sylog.Debugf("failure finding %v: %v", cmd, err)
 	}
-	sylog.Debugf("fakeroot found at %v", fakerootPath)
-	return fakerootPath, nil
+	return "", err
 }
 
 // Get the args needed to execute the fakeroot mapped into the container

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -51,6 +51,7 @@ func FindBin(name string) (path string, err error) {
 		"debootstrap",
 		"dnf",
 		"fakeroot",
+		"fakeroot-sysv",
 		"fuse-overlayfs",
 		"fuse2fs",
 		"go",


### PR DESCRIPTION
This cherry-picks #763 into the release-1.1 branch.