### PR TITLE
Do underlay processing at the same point as overlay, after image binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   but `fakeroot-sysv` is much faster.
 - Fix the locating of shared libraries when running `unsquashfs` from a
   non-standard location the way conda does.
+- Fix the creation of missing bind points when using image binding with
+  underlay.
 
 ## v1.1.2 - \[2022-10-06\]
 

--- a/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
+++ b/internal/pkg/util/fs/layout/layer/underlay/underlay_linux.go
@@ -45,7 +45,7 @@ func (u *Underlay) Add(session *layout.Session, system *mount.System) error {
 	if err := u.session.AddDir(underlayDir); err != nil {
 		return err
 	}
-	return system.RunBeforeTag(mount.PreLayerTag, u.createUnderlay)
+	return system.RunBeforeTag(mount.LayerTag, u.createUnderlay)
 }
 
 // Dir returns absolute underlay directory within session
@@ -194,7 +194,7 @@ func (u *Underlay) duplicateDir(dir string, system *mount.System, existingPath s
 				return fmt.Errorf("can't add directory %s to underlay: %s", dst, err)
 			}
 			dst, _ = u.session.GetPath(dst)
-			if err := system.Points.AddBind(mount.PreLayerTag, src, dst, syscall.MS_BIND); err != nil {
+			if err := system.Points.AddBind(mount.LayerTag, src, dst, syscall.MS_BIND); err != nil {
 				return fmt.Errorf("can't add bind mount point: %s", err)
 			}
 			binds++
@@ -211,7 +211,7 @@ func (u *Underlay) duplicateDir(dir string, system *mount.System, existingPath s
 				return fmt.Errorf("can't add directory %s to underlay: %s", dst, err)
 			}
 			dst, _ = u.session.GetPath(dst)
-			if err := system.Points.AddBind(mount.PreLayerTag, src, dst, syscall.MS_BIND); err != nil {
+			if err := system.Points.AddBind(mount.LayerTag, src, dst, syscall.MS_BIND); err != nil {
 				return fmt.Errorf("can't add bind mount point: %s", err)
 			}
 			binds++

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -91,7 +91,7 @@ const (
 	RootfsTag = "rootfs"
 	// PreLayerTag defines tag to prepare overlay/underlay layer
 	PreLayerTag = "prelayer"
-	// LayerTag defines tag for overlay/underlay final mount point
+	// LayerTag defines tag for overlay/underlay mount point(s)
 	LayerTag = "layer"
 	// SharedTag defines tag for shared mount point between master
 	// and container processes
@@ -129,7 +129,7 @@ var authorizedTags = map[AuthorizedTag]struct {
 	SessionTag:   {false, 0},
 	RootfsTag:    {false, 1},
 	PreLayerTag:  {true, 2},
-	LayerTag:     {false, 3},
+	LayerTag:     {true, 3},
 	SharedTag:    {true, 4},
 	DevTag:       {true, 5},
 	HostfsTag:    {true, 6},


### PR DESCRIPTION
This fixes creation of missing bind points when using image binds with underlay, by doing underlay processing at the same point as overlay processing, after image binds.

- Fixes #728