### PR TITLE
Use -o uid=N,gid=N with patched squashfuse_ll (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
   the latter can be linked to either `fakeroot-sysv` or `fakeroot-tcp`,
   but `fakeroot-sysv` is much faster.
 
+### Bug fixes
+
+- Updated the included `squashfuse_ll` to have `-o uid=N` and `-o gid=N`
+  options and changed the corresponding image driver to use them when
+  available.  This makes files inside sif files appear to be owned by the
+  user instead of by the nobody id 65534 when running in non-setuid mode.
+
 ## v1.1.2 - \[2022-10-06\]
 
 - [CVE-2022-39237](https://github.com/sylabs/sif/security/advisories/GHSA-m5m3-46gj-wch8):

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -178,6 +178,9 @@ performance version of `squashfuse_ll`.
 As of this writing there is a patch pending to the squashfuse project to
 add multithreading support that significantly improves performance for
 applications that access a lot of small files from many cores at once.
+There's also another `squashfuse_ll` patch for supporting options to make
+files appear to be owned by the user
+(the same options that exist in `squashfuse`).
 
 First, make sure that additional required packages are installed.  On Debian:
 
@@ -194,9 +197,11 @@ To download the source code do this:
 
 ```sh
 SQUASHFUSEVERSION=0.1.105
-SQUASHFUSEPR=70
+SQUASHFUSEPRS="70 77"
 curl -L -O https://github.com/vasi/squashfuse/archive/$SQUASHFUSEVERSION/squashfuse-$SQUASHFUSEVERSION.tar.gz
-curl -L -O https://github.com/vasi/squashfuse/pull/$SQUASHFUSEPR.patch
+for PR in $SQUASHFUSEPRS; do
+    curl -L -O https://github.com/vasi/squashfuse/pull/$PR.patch
+done
 ```
 
 Then to compile and install do this:
@@ -204,7 +209,9 @@ Then to compile and install do this:
 ```sh
 tar xzf squashfuse-$SQUASHFUSEVERSION.tar.gz
 cd squashfuse-$SQUASHFUSEVERSION
-patch -p1 <../$SQUASHFUSEPR.patch
+for PR in $SQUASHFUSEPRS; do
+    patch -p1 <../$PR.patch
+done
 ./autogen.sh
 FLAGS=-std=c99 ./configure --enable-multithreading
 make squashfuse_ll

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -51,6 +51,7 @@ Source: https://github.com/%{name}/%{name}/releases/download/v%{package_version}
 %if "%{?squashfuse_version}" != ""
 Source10: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squashfuse-%{squashfuse_version}.tar.gz
 Patch10: https://github.com/vasi/squashfuse/pull/70.patch
+Patch11: https://github.com/vasi/squashfuse/pull/77.patch
 %endif
 # The singularity package was renamed to apptainer after version 3.8.x.
 # The apptainer package reset numbering at 1.0.0, and some singularity
@@ -113,6 +114,7 @@ Provides the optional setuid-root portion of Apptainer.
 # so do main package last
 %setup -b 10 -n squashfuse-%{squashfuse_version}
 %patch -P 10 -p1
+%patch -P 11 -p1
 %setup -n %{name}-%{package_version}
 %else
 %autosetup -n %{name}-%{package_version}

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -9,6 +9,7 @@
 package driver
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io/ioutil"
@@ -47,6 +48,7 @@ type fuseappsDriver struct {
 	ext3Feature    fuseappsFeature
 	overlayFeature fuseappsFeature
 	cmdPrefix      []string
+	squashSetUID   bool
 }
 
 func (f *fuseappsFeature) init(binNames string, purpose string, desired image.DriverFeature) {
@@ -89,11 +91,42 @@ func InitImageDrivers(register bool, unprivileged bool, fileconf *apptainerconf.
 	ext3Feature.init("fuse2fs", "mount EXT3 filesystems", desiredFeatures&image.ImageFeature)
 	overlayFeature.init("fuse-overlayfs", "use overlay", desiredFeatures&image.OverlayFeature)
 
+	// squashfuse generally supports the -o uid and -o gid options, except
+	// on Debian 18.04, but it doesn't show in the help output so we just
+	// assume that it does support it.  squashfuse_ll doesn't generally
+	// support them, but when it does they are in the help output so we
+	// scan for that.
+	// See https://github.com/apptainer/apptainer/issues/736
+	squashSetUID := true
+	if squashFeature.binName == "squashfuse_ll" {
+		squashSetUID = false
+		cmd := exec.Command(squashFeature.cmdPath)
+		output, err := cmd.StdoutPipe()
+		if err != nil {
+			return fmt.Errorf("error making squashfuse_ll output pipe: %v", err)
+		}
+		cmd.Stderr = cmd.Stdout
+		err = cmd.Start()
+		if err != nil {
+			return fmt.Errorf("error starting squashfuse_ll: %v", err)
+		}
+		scanner := bufio.NewScanner(output)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, "-o uid=") {
+				squashSetUID = true
+				sylog.Debugf("squashfuse_ll supports -o uid")
+				break
+			}
+		}
+		_ = cmd.Wait()
+	}
+
 	if squashFeature.cmdPath != "" || ext3Feature.cmdPath != "" || overlayFeature.cmdPath != "" {
 		sylog.Debugf("Setting ImageDriver to %v", driverName)
 		fileconf.ImageDriver = driverName
 		if register {
-			return image.RegisterDriver(driverName, &fuseappsDriver{squashFeature, ext3Feature, overlayFeature, []string{}})
+			return image.RegisterDriver(driverName, &fuseappsDriver{squashFeature, ext3Feature, overlayFeature, []string{}, squashSetUID})
 		}
 	}
 	return nil
@@ -125,11 +158,7 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 	case "squashfs":
 		f = &d.squashFeature
 		optsStr := ""
-		// squashfuse_ll does not currently support setting the
-		//   uid/gid options, so need to skip those with that.
-		// It only affects the way the ownership of files look
-		//   without fakeroot, it's not very significant.
-		if f.binName == "squashfuse" {
+		if d.squashSetUID {
 			optsStr = fmt.Sprintf("uid=%v,gid=%v", os.Getuid(), os.Getgid())
 		}
 		if params.Offset > 0 {


### PR DESCRIPTION
This cherry-picks #759 into the release-1.1 branch.