### PR TITLE
Change sylabs.io to sycloud.io in tests

### DIFF
--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -96,12 +96,12 @@ func (c *ctx) apptainerKeySearch(t *testing.T) {
 		},
 		{
 			name:   "key search 0x<key fingerprint>",
-			args:   []string{"search", "-u", "https://keys.sylabs.io", "0x7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
+			args:   []string{"search", "-u", "https://keys.production.sycloud.io", "0x7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
 			stdout: "^Showing 1 results",
 		},
 		{
 			name:   "key search <key fingerprint>",
-			args:   []string{"search", "-u", "https://keys.sylabs.io", "7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
+			args:   []string{"search", "-u", "https://keys.production.sycloud.io", "7605BC2716168DF057D6C600ACEEC62C8BD91BEE"},
 			stdout: "^Showing 1 results",
 		},
 		{

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -320,13 +320,13 @@ func (c ctx) testPullCmd(t *testing.T) {
 		{
 			desc:             "bad library URI",
 			srcURI:           "oras://ghcr.io/apptainer/bad/busybox:1.31.1",
-			library:          "https://bad-library.sylabs.io",
+			library:          "https://bad-library.production.sycloud.io",
 			expectedExitCode: 255,
 		},
 		{
 			desc:             "default library URI",
 			srcURI:           "oras://ghcr.io/apptainer/busybox:1.31.1",
-			library:          "https://library.sylabs.io",
+			library:          "https://library.production.sycloud.io",
 			force:            true,
 			expectedExitCode: 0,
 		},

--- a/e2e/pull/regressions.go
+++ b/e2e/pull/regressions.go
@@ -17,11 +17,11 @@ import (
 )
 
 // If a remote is set to a different endpoint we should be able to pull
-// with `--library https://library.sylabs.io` from the default Sylabs cloud library.
+// with `--library https://library.production.sycloud.io` from the default Sylabs cloud library.
 func (c ctx) issue5808(t *testing.T) {
 	testEndpoint := "issue5808"
-	testEndpointURI := "https://cloud.staging.sylabs.io"
-	defaultLibraryURI := "https://library.sylabs.io"
+	testEndpointURI := "https://cloud.staging.sycloud.io"
+	defaultLibraryURI := "https://library.production.sycloud.io"
 	testImage := "library://sylabs/tests/signed:1.0.0"
 
 	pullDir, cleanup := e2e.MakeTempDir(t, "", "issue5808", "")

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -41,8 +41,8 @@ func (c ctx) remoteAdd(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"AddCloud", "cloud", "cloud.sylabs.io"},
-		{"AddOtherCloud", "other", "cloud.sylabs.io"},
+		{"AddCloud", "cloud", "cloud.sycloud.io"},
+		{"AddOtherCloud", "other", "cloud.sycloud.io"},
 	}
 
 	for _, tt := range testPass {
@@ -62,7 +62,7 @@ func (c ctx) remoteAdd(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"AddExistingRemote", "cloud", "cloud.sylabs.io"},
+		{"AddExistingRemote", "cloud", "cloud.sycloud.io"},
 		{"AddExistingRemoteInvalidURI", "other", "anythingcangohere"},
 	}
 
@@ -97,8 +97,8 @@ func (c ctx) remoteRemove(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"addCloud", "cloud", "cloud.sylabs.io"},
-		{"addOther", "other", "cloud.sylabs.io"},
+		{"addCloud", "cloud", "cloud.sycloud.io"},
+		{"addOther", "other", "cloud.sycloud.io"},
 	}
 
 	for _, tt := range add {
@@ -189,8 +189,8 @@ func (c ctx) remoteUse(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"addCloud", "cloud", "cloud.sylabs.io"},
-		{"addOther", "other", "cloud.sylabs.io"},
+		{"addCloud", "cloud", "cloud.sycloud.io"},
+		{"addOther", "other", "cloud.sycloud.io"},
 	}
 
 	for _, tt := range add {
@@ -244,7 +244,7 @@ func (c ctx) remoteStatus(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"addCloud", "cloud", "cloud.sylabs.io"},
+		{"addCloud", "cloud", "cloud.sycloud.io"},
 		{"addInvalidRemote", "invalid", "notarealendpoint"},
 	}
 
@@ -333,8 +333,8 @@ func (c ctx) remoteList(t *testing.T) {
 		remote string
 		uri    string
 	}{
-		{"addCloud", "cloud", "cloud.sylabs.io"},
-		{"addRemote", "remote", "cloud.sylabs.io"},
+		{"addCloud", "cloud", "cloud.sycloud.io"},
+		{"addRemote", "remote", "cloud.sycloud.io"},
 	}
 
 	for _, tt := range add {

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -297,7 +297,7 @@ func (c ctx) checkURLOption(t *testing.T) {
 		t.Fatalf("image file (%s) does not exist", c.successImage)
 	}
 
-	cmdArgs := []string{"--legacy-insecure", "--url", "https://keys.sylabs.io", c.successImage}
+	cmdArgs := []string{"--legacy-insecure", "--url", "https://keys.production.sycloud.io", c.successImage}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),

--- a/examples/library/Apptainer
+++ b/examples/library/Apptainer
@@ -1,5 +1,5 @@
 Bootstrap: library
-Library: https://library.sylabs.io
+Library: https://library.production.sycloud.io
 From: alpine:3.11.5
 
 %runscript

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	libraryURL = "https://library.sylabs.io/"
+	libraryURL = "https://library.production.sycloud.io/"
 	libraryURI = "library://alpine:latest"
 )
 

--- a/internal/pkg/remote/endpoint/client_test.go
+++ b/internal/pkg/remote/endpoint/client_test.go
@@ -20,9 +20,9 @@ func init() {
 }
 
 const (
-	testCloudURI     = "cloud.sylabs.io"
-	testLibraryURI   = "https://library.sylabs.io"
-	testKeyserverURI = "https://keys.sylabs.io"
+	testCloudURI     = "cloud.sycloud.io"
+	testLibraryURI   = "https://library.production.sycloud.io"
+	testKeyserverURI = "https://keys.production.sycloud.io"
 )
 
 func TestKeyserverClientOpts(t *testing.T) {

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -68,7 +68,7 @@ func TestWriteToReadFrom(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -148,7 +148,7 @@ func TestSyncFrom(t *testing.T) {
 			usr: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -156,7 +156,7 @@ func TestSyncFrom(t *testing.T) {
 			res: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -166,7 +166,7 @@ func TestSyncFrom(t *testing.T) {
 			sys: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -174,7 +174,7 @@ func TestSyncFrom(t *testing.T) {
 			usr: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -182,11 +182,11 @@ func TestSyncFrom(t *testing.T) {
 			res: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -196,7 +196,7 @@ func TestSyncFrom(t *testing.T) {
 			sys: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -204,11 +204,11 @@ func TestSyncFrom(t *testing.T) {
 			usr: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -216,11 +216,11 @@ func TestSyncFrom(t *testing.T) {
 			res: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -230,7 +230,7 @@ func TestSyncFrom(t *testing.T) {
 			sys: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -242,7 +242,7 @@ func TestSyncFrom(t *testing.T) {
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -250,11 +250,11 @@ func TestSyncFrom(t *testing.T) {
 			res: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -265,7 +265,7 @@ func TestSyncFrom(t *testing.T) {
 				DefaultRemote: "sylabs-global",
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -277,7 +277,7 @@ func TestSyncFrom(t *testing.T) {
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -286,11 +286,11 @@ func TestSyncFrom(t *testing.T) {
 				DefaultRemote: "sylabs-global",
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -301,7 +301,7 @@ func TestSyncFrom(t *testing.T) {
 				DefaultRemote: "sylabs-global",
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token", // should be ignored by SyncFrom
 					},
 				},
@@ -314,7 +314,7 @@ func TestSyncFrom(t *testing.T) {
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -323,11 +323,11 @@ func TestSyncFrom(t *testing.T) {
 				DefaultRemote: "sylabs",
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:    "cloud.sylabs.io",
+						URI:    "cloud.sycloud.io",
 						System: true,
 					},
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -353,7 +353,7 @@ func TestSyncFrom(t *testing.T) {
 			sys: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs-global": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 				},
@@ -361,11 +361,11 @@ func TestSyncFrom(t *testing.T) {
 			usr: Config{
 				Remotes: map[string]*endpoint.Config{
 					"sylabs": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: "fake-token",
 					},
 					"sylabs-global": {
-						URI: "cloud.sylabs.io",
+						URI: "cloud.sycloud.io",
 					},
 				},
 			},
@@ -401,14 +401,14 @@ func TestAddRemote(t *testing.T) {
 				DefaultRemote: "",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
 			},
 			id: "cloud",
 			ep: &endpoint.Config{
-				URI:   "cloud.sylabs.io",
+				URI:   "cloud.sycloud.io",
 				Token: testToken,
 			},
 		},
@@ -431,14 +431,14 @@ func TestAddRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
 			},
 			id: "cloud",
 			ep: &endpoint.Config{
-				URI:   "cloud.sylabs.io",
+				URI:   "cloud.sycloud.io",
 				Token: testToken,
 			},
 		},
@@ -462,14 +462,14 @@ func TestAddRemote(t *testing.T) {
 			DefaultRemote: "",
 			Remotes: map[string]*endpoint.Config{
 				"cloud": {
-					URI:   "cloud.sylabs.io",
+					URI:   "cloud.sycloud.io",
 					Token: testToken,
 				},
 			},
 		},
 		id: "cloud",
 		ep: &endpoint.Config{
-			URI:   "cloud.sylabs.io",
+			URI:   "cloud.sycloud.io",
 			Token: testToken,
 		},
 	}
@@ -489,7 +489,7 @@ func TestRemoveRemote(t *testing.T) {
 				DefaultRemote: "",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -509,7 +509,7 @@ func TestRemoveRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -535,7 +535,7 @@ func TestRemoveRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -589,7 +589,7 @@ func TestRenameRemote(t *testing.T) {
 				DefaultRemote: "",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -598,7 +598,7 @@ func TestRenameRemote(t *testing.T) {
 				DefaultRemote: "",
 				Remotes: map[string]*endpoint.Config{
 					"newCloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -616,7 +616,7 @@ func TestRenameRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -629,7 +629,7 @@ func TestRenameRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"newCloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -682,7 +682,7 @@ func TestRenameRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -712,14 +712,14 @@ func TestGetRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
 			},
 			id: "cloud",
 			ep: &endpoint.Config{
-				URI:   "cloud.sylabs.io",
+				URI:   "cloud.sycloud.io",
 				Token: testToken,
 			},
 		},
@@ -746,7 +746,7 @@ func TestGetRemote(t *testing.T) {
 				DefaultRemote: "cloud",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -775,13 +775,13 @@ func TestGetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
 			},
 			ep: &endpoint.Config{
-				URI:   "cloud.sylabs.io",
+				URI:   "cloud.sycloud.io",
 				Token: testToken,
 			},
 		},
@@ -812,7 +812,7 @@ func TestGetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -824,7 +824,7 @@ func TestGetDefaultRemote(t *testing.T) {
 				DefaultRemote: "notaremote",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -852,7 +852,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -865,7 +865,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -893,7 +893,7 @@ func TestSetDefaultRemote(t *testing.T) {
 				DefaultRemote: "cloud",
 				Remotes: map[string]*endpoint.Config{
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -921,7 +921,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -936,7 +936,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token:     testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -967,7 +967,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -994,7 +994,7 @@ func TestSetDefaultRemote(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:       "cloud.sylabs.io",
+						URI:       "cloud.sycloud.io",
 						Exclusive: true,
 						Token:     testToken,
 					},
@@ -1077,7 +1077,7 @@ func TestGetServiceURI(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},
@@ -1111,7 +1111,7 @@ func TestGetServiceURI(t *testing.T) {
 						Token: testToken,
 					},
 					"cloud": {
-						URI:   "cloud.sylabs.io",
+						URI:   "cloud.sycloud.io",
 						Token: testToken,
 					},
 				},


### PR DESCRIPTION
The sylabs.io domain isn't working and sycloud.io has been set up instead.