### PR TITLE
Missing ` in code multiline block and missing newline before code block (release-1.1)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -186,9 +186,10 @@ First, make sure that additional required packages are installed.  On Debian:
 
 ```sh
 apt-get install -y autoconf automake libtool pkg-config libfuse-dev zlib1g-dev
-``
+```
 
 On CentOS/RHEL:
+
 ```sh
 yum install -y autoconf automake libtool pkgconfig fuse3-devel zlib-devel
 ```


### PR DESCRIPTION
This cherry-picks https://github.com/apptainer/apptainer/pull/788 into the release-1.1 branch.