### PR TITLE
remove /rootfs-* like directory when error occurs

### DIFF
--- a/internal/pkg/image/unpacker/squashfs.go
+++ b/internal/pkg/image/unpacker/squashfs.go
@@ -175,12 +175,6 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 	sylog.Debugf("*** END WRAPPED UNSQUASHFS OUTPUT ***")
 
 	if err != nil {
-		// here we will remove all $TMPDIR/rootfs-*/tmp-rootfs-* like folders if error occurs
-		matches, _ := filepath.Glob(fmt.Sprintf("%s/tmp-rootfs-*", filepath.Dir(dest)))
-		for _, match := range matches {
-			sylog.Debugf("extract command failed and %s folder will be removed", match)
-			os.RemoveAll(match)
-		}
 		return fmt.Errorf("extract command failed: %s: %s", string(o), err)
 	}
 

--- a/internal/pkg/image/unpacker/squashfs.go
+++ b/internal/pkg/image/unpacker/squashfs.go
@@ -175,6 +175,12 @@ func (s *Squashfs) extract(files []string, reader io.Reader, dest string) (err e
 	sylog.Debugf("*** END WRAPPED UNSQUASHFS OUTPUT ***")
 
 	if err != nil {
+		// here we will remove all $TMPDIR/rootfs-*/tmp-rootfs-* like folders if error occurs
+		matches, _ := filepath.Glob(fmt.Sprintf("%s/tmp-rootfs-*", filepath.Dir(dest)))
+		for _, match := range matches {
+			sylog.Debugf("extract command failed and %s folder will be removed", match)
+			os.RemoveAll(match)
+		}
 		return fmt.Errorf("extract command failed: %s: %s", string(o), err)
 	}
 


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

We need to clean up the $TMPDIR/rootfs-*/tmp-rootfs-* when error occurs


### This fixes or addresses the following GitHub issues:

 - Fixes #768 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
