### PR TITLE
Warn instead of fail with non-writable overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   non-standard location the way conda does.
 - Fix the creation of missing bind points when using image binding with
   underlay.
+- Change the error when an overlay image is not writable into a warning
+  that suggests adding `:ro` to make it read only or using `--fakeroot`.
 
 ### Bug fixes
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -45,6 +45,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/namespaces"
 	"github.com/apptainer/apptainer/pkg/util/slice"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
@@ -263,7 +264,7 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 
 	sylog.Debugf("Mount all")
 	if err := system.MountAll(); err != nil {
-		return err
+		return errors.Wrap(err, "mount hook function failure")
 	}
 
 	if engine.EngineConfig.GetSessionLayer() == apptainer.UnderlayLayer {


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

Improve the error messages when --overlay with ext3 format image file fails due to permission denied. 


### This fixes or addresses the following GitHub issues:

 - Fixes #757 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
