### PR TITLE
chore: bump Go to 1.19.2, from sylabs 1011

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   check_go_mod:
     name: check_go_mod
     runs-on: ubuntu-20.04
-    container: golang:1.19.1
+    container: golang:1.19.2
     steps:
       - uses: actions/checkout@v2
 
@@ -51,7 +51,7 @@ jobs:
   alpine:
     name: alpine
     runs-on: ubuntu-20.04
-    container: golang:1.19.1-alpine
+    container: golang:1.19.2-alpine
     steps:
       - name: Fetch deps
         run: apk add -q --no-cache git bash alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
@@ -84,7 +84,7 @@ jobs:
   check_license_dependencies:
     name: check_license_dependencies
     runs-on: ubuntu-20.04
-    container: golang:1.19.1
+    container: golang:1.19.2
     steps:
       - uses: actions/checkout@v2
 
@@ -166,7 +166,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup
@@ -196,7 +196,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup
@@ -240,7 +240,7 @@ jobs:
         if: env.run_tests
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Fetch deps
         if: env.run_tests
@@ -277,7 +277,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Check pkg/... doesn't depend on buildcfg
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,7 @@ _**NOTE:** if you are updating Go from a older version, make sure you remove
 `/usr/local/go` before reinstalling it._
 
 ```sh
-export GOVERSION=1.19.1 OS=linux ARCH=amd64  # change this as you need
+export GOVERSION=1.19.2 OS=linux ARCH=amd64  # change this as you need
 
 wget -O /tmp/go${GOVERSION}.${OS}-${ARCH}.tar.gz \
   https://dl.google.com/go/go${GOVERSION}.${OS}-${ARCH}.tar.gz


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1011

The original PR description was:
> Bump Go to 1.19.2.