### PR TITLE
Properly clean up after a failed unsquashfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,23 +18,21 @@ For older changes see the [archived Singularity change log](https://github.com/a
   point-in-time usage.
 - Support for `DOCKER_HOST` parsing when using `docker-daemon://`
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
-- `--rocm` flag in combination with `-c` / `-C` fixed by forwarding all
-  `/dri/render*` devices into the container.
 
 ### Bug fixes
 
+- Fix the `--rocm` flag in combination with `-c` / `-C` by forwarding all
+  `/dri/render*` devices into the container.
 - Prefer the `fakeroot-sysv` command over the `fakeroot` command because
   the latter can be linked to either `fakeroot-sysv` or `fakeroot-tcp`,
   but `fakeroot-sysv` is much faster.
 - Fix the locating of shared libraries when running `unsquashfs` from a
   non-standard location the way conda does.
+- Properly clean up temporary files if `unsquashfs` fails.
 - Fix the creation of missing bind points when using image binding with
   underlay.
 - Change the error when an overlay image is not writable into a warning
   that suggests adding `:ro` to make it read only or using `--fakeroot`.
-
-### Bug fixes
-
 - Updated the included `squashfuse_ll` to have `-o uid=N` and `-o gid=N`
   options and changed the corresponding image driver to use them when
   available.  This makes files inside sif files appear to be owned by the


### PR DESCRIPTION
This fixes cleaning up after a failed call to unsquashfs.  There was code attempting to do it, but it was broken.

- Fixes #768
- Replaces #808