### PR TITLE
Avoid permission denied on /var/lib/containers/sigstore with fake fakeroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
   underlay.
 - Change the error when an overlay image is not writable into a warning
   that suggests adding `:ro` to make it read only or using `--fakeroot`.
-- Updated the included `squashfuse_ll` to have `-o uid=N` and `-o gid=N`
+- Update the included `squashfuse_ll` to have `-o uid=N` and `-o gid=N`
   options and changed the corresponding image driver to use them when
   available.  This makes files inside sif files appear to be owned by the
   user instead of by the nobody id 65534 when running in non-setuid mode.
+- Avoid permission denied errors during unprivileged builds without
+  `/etc/subuid`-based fakeroot when `/var/lib/containers/sigstore` is
+  readable only by root.
 
 ## v1.1.2 - \[2022-10-06\]
 


### PR DESCRIPTION
This makes the containers/image library behave better with the fake fakeroot, avoiding errors on unreadable /var/lib/containers/sigstore, by just moving the workaround that was used for real fakeroot to a place where it applies to both.

- Fixes #758

The original workaround was put in place in apptainer/singularity#5712.