### PR TITLE
Add noacl option to fuse-overlayfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Avoid permission denied errors during unprivileged builds without
   `/etc/subuid`-based fakeroot when `/var/lib/containers/sigstore` is
   readable only by root.
+- Avoid failures with `--writable-tmpfs` in non-setuid mode when using
+  fuse-overlayfs versions 1.8 or greater by adding the fuse-overlayfs
+  `noacl` mount option to disable support for posix Access Control Lists.
 
 ## v1.1.2 - \[2022-10-06\]
 

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -151,6 +151,10 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 	case "overlay":
 		f = &d.overlayFeature
 		optsStr := strings.Join(params.FSOptions, ",")
+		// noacl is needed to avoid failures when the upper layer
+		// filesystem type (for example tmpfs) does not support it,
+		// when the fuse-overlayfs version is 1.8 or greater.
+		optsStr += ",noacl"
 		cmdArgs = append(cmdArgs, f.cmdPath, "-f", "-o", optsStr, params.Target)
 		cmd = exec.Command(cmdArgs[0], cmdArgs[1:]...)
 


### PR DESCRIPTION
This adds the `noacl` option to the invocation of fuse-overlayfs, to avoid errors with using tmpfs as an upper layer.

- Fixes #796