### PR TITLE
set --net if --network or --network-args is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Support for `DOCKER_HOST` parsing when using `docker-daemon://`
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
 
+### Bug fixes
+
+- Set the `--net` flag if `--network` or `--network-args` is set rather
+  than silently ignoring them if `--net` was not set.
+
 ## v1.1.3 - \[2022-10-25\]
 
 - Prefer the `fakeroot-sysv` command over the `fakeroot` command because

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,6 +44,7 @@
 - Jason Stover <jms@sylabs.io>, <jason.stover@gmail.com>
 - Jeff Kriske <jekriske@gmail.com>
 - Jia Li <jiali@sylabs.io>
+- Jim Phillips <jcphill@users.noreply.github.com>
 - Joana Chavez <joana@sylabs.io>, <j.chavezlavalle@gmail.com>
 - Jonathon Anderson <janderson@ciq.co>
 - Josef Hrabal <josef.hrabal@vsb.cz>

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -226,7 +226,7 @@ var actionHostnameFlag = cmdline.Flag{
 var actionNetworkFlag = cmdline.Flag{
 	ID:           "actionNetworkFlag",
 	Value:        &Network,
-	DefaultValue: "bridge",
+	DefaultValue: "",
 	Name:         "network",
 	Usage:        "specify desired network type separated by commas, each network will bring up a dedicated interface inside container",
 	EnvKeys:      []string{"NETWORK"},

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -687,7 +687,19 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 		procname = "Apptainer runtime parent"
 	}
 
+	if !NetNamespace && Network != "" {
+		sylog.Infof("Setting --net (required by --network)")
+		NetNamespace = true
+	}
+	if !NetNamespace && len(NetworkArgs) != 0 {
+		sylog.Infof("Setting --net (required by --network-args)")
+		NetNamespace = true
+	}
 	if NetNamespace {
+		if Network == "" {
+			Network = "bridge"
+			engineConfig.SetNetwork(Network)
+		}
 		if IsFakeroot && Network != "none" {
 			engineConfig.SetNetwork("fakeroot")
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Set the `--net` flag if `--network` or `--network-args` is set rather than silently ignoring them if `--net` was not set.


### This fixes or addresses the following GitHub issues:

 - Fixes https://github.com/apptainer/apptainer/issues/822


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
