### PR TITLE
Change non-writable overlay warning into info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Properly clean up temporary files if `unsquashfs` fails.
 - Fix the creation of missing bind points when using image binding with
   underlay.
-- Change the error when an overlay image is not writable into a warning
-  that suggests adding `:ro` to make it read only or using `--fakeroot`.
+- Change the error when an overlay image is not writable into an info
+  message that suggests adding `:ro` to make it read only or using
+  `--fakeroot`.
 - Avoid permission denied errors during unprivileged builds without
   `/etc/subuid`-based fakeroot when `/var/lib/containers/sigstore` is
   readable only by root.

--- a/internal/app/starter/master_linux.go
+++ b/internal/app/starter/master_linux.go
@@ -50,7 +50,7 @@ func createContainer(ctx context.Context, rpcSocket int, containerPid int, e *en
 
 		// continue with warnings rather than fatal errors
 		if strings.Contains(err.Error(), "mount hook function failure") && strings.Contains(err.Error(), "permission denied") {
-			sylog.Warningf("%s, try adding ':ro' after your overlay.img or adding '--fakeroot'", err)
+			sylog.Infof("%s, try adding ':ro' after your overlay.img or adding '--fakeroot'", err)
 			return
 		}
 


### PR DESCRIPTION
It just occurred to me this should have been an info, not a warning.