### PR TITLE
Turn overlay permission denied into a fatal error with info instead of a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Bug fixes
 
+- Change the warning when an overlay image is not writable, introduced
+  in v1.1.3, back into a (more informative) fatal error because it doesn't
+  actually enter the container environment.
 - Set the `--net` flag if `--network` or `--network-args` is set rather
   than silently ignoring them if `--net` was not set.
 


### PR DESCRIPTION
This reverts some of #810 except includes an INFO message instead of a Warning.

- Fixes #838