### PR TITLE
Support additional Linux capabilities, from sylabs 1072 & 1080

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   point-in-time usage.
 - Support for `DOCKER_HOST` parsing when using `docker-daemon://`
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
+- Add new Linux capabilities: `CAP_PERFMON`, `CAP_BPF`, `CAP_CHECKPOINT_RESTORE`.
 
 ## v1.1.3 - \[2022-10-25\]
 

--- a/cmd/starter/c/include/capability.h
+++ b/cmd/starter/c/include/capability.h
@@ -20,8 +20,8 @@
 
 /* 2.6.32 kernel is the minimal kernel version supported where latest cap is 33 */
 #define CAPSET_MIN  33
-/* 37 is the latest cap since many kernel versions */
-#define CAPSET_MAX  37
+/* 40 is the latest cap since kernel 5.9 */
+#define CAPSET_MAX  40
 
 /* Support only 64 bits sets, since kernel 2.6.26 */
 #ifdef _LINUX_CAPABILITY_VERSION_3

--- a/pkg/util/capabilities/capabilities.go
+++ b/pkg/util/capabilities/capabilities.go
@@ -386,48 +386,76 @@ var (
 		Description: `CAP_AUDIT_READ (since Linux 3.16)
 	Allow reading the audit log via a multicast netlink socket.`,
 	}
+
+	capPerfmon = &capability{
+		Name:  "CAP_PERFMON",
+		Value: 38,
+		Description: `CAP_PERFMON (since Linux 5.8)
+	Employ various performance-monitoring mechanisms, including:
+	* call perf_event_open(2);
+	* employ various BPF operations that have performance implications.`,
+	}
+
+	capBPF = &capability{
+		Name:  "CAP_BPF",
+		Value: 39,
+		Description: `CAP_BPF (since Linux 5.8)
+	Employ privileged BPF operations; see bpf(2) and bpf-helpers(7).`,
+	}
+
+	capCheckpointRestore = &capability{
+		Name:  "CAP_CHECKPOINT_RESTORE",
+		Value: 40,
+		Description: `CAP_CHECKPOINT_RESTORE (since Linux 5.9)
+	* Update /proc/sys/kernel/ns_last_pid (see pid_namespaces(7));
+	* employ the set_tid feature of clone3(2);
+	* read the contents of the symbolic links in /proc/[pid]/map_files for other processes.`,
+	}
 )
 
 // Map maps each capability name to a struct with details about the capability.
 var Map = map[string]*capability{
-	"CAP_CHOWN":            capChown,
-	"CAP_DAC_OVERRIDE":     capDacOverride,
-	"CAP_DAC_READ_SEARCH":  capDacReadSearch,
-	"CAP_FOWNER":           capFowner,
-	"CAP_FSETID":           capFsetid,
-	"CAP_KILL":             capKill,
-	"CAP_SETGID":           capSetgid,
-	"CAP_SETUID":           capSetuid,
-	"CAP_SETPCAP":          capSetpcap,
-	"CAP_LINUX_IMMUTABLE":  capLinuxImmutable,
-	"CAP_NET_BIND_SERVICE": capNetBindService,
-	"CAP_NET_BROADCAST":    capNetBroadcast,
-	"CAP_NET_ADMIN":        capNetAdmin,
-	"CAP_NET_RAW":          capNetRaw,
-	"CAP_IPC_LOCK":         capIpcLock,
-	"CAP_IPC_OWNER":        capIpcOwner,
-	"CAP_SYS_MODULE":       capSysModule,
-	"CAP_SYS_RAWIO":        capSysRawio,
-	"CAP_SYS_CHROOT":       capSysChroot,
-	"CAP_SYS_PTRACE":       capSysPtrace,
-	"CAP_SYS_PACCT":        capSysPacct,
-	"CAP_SYS_ADMIN":        capSysAdmin,
-	"CAP_SYS_BOOT":         capSysBoot,
-	"CAP_SYS_NICE":         capSysNice,
-	"CAP_SYS_RESOURCE":     capSysResource,
-	"CAP_SYS_TIME":         capSysTime,
-	"CAP_SYS_TTY_CONFIG":   capSysTtyConfig,
-	"CAP_MKNOD":            capMknod,
-	"CAP_LEASE":            capLease,
-	"CAP_AUDIT_WRITE":      capAuditWrite,
-	"CAP_AUDIT_CONTROL":    capAuditControl,
-	"CAP_SETFCAP":          capSetfcap,
-	"CAP_MAC_OVERRIDE":     capMacOverride,
-	"CAP_MAC_ADMIN":        capMacAdmin,
-	"CAP_SYSLOG":           capSyslog,
-	"CAP_WAKE_ALARM":       capWakeAlarm,
-	"CAP_BLOCK_SUSPEND":    capBlockSuspend,
-	"CAP_AUDIT_READ":       capAuditRead,
+	"CAP_CHOWN":              capChown,
+	"CAP_DAC_OVERRIDE":       capDacOverride,
+	"CAP_DAC_READ_SEARCH":    capDacReadSearch,
+	"CAP_FOWNER":             capFowner,
+	"CAP_FSETID":             capFsetid,
+	"CAP_KILL":               capKill,
+	"CAP_SETGID":             capSetgid,
+	"CAP_SETUID":             capSetuid,
+	"CAP_SETPCAP":            capSetpcap,
+	"CAP_LINUX_IMMUTABLE":    capLinuxImmutable,
+	"CAP_NET_BIND_SERVICE":   capNetBindService,
+	"CAP_NET_BROADCAST":      capNetBroadcast,
+	"CAP_NET_ADMIN":          capNetAdmin,
+	"CAP_NET_RAW":            capNetRaw,
+	"CAP_IPC_LOCK":           capIpcLock,
+	"CAP_IPC_OWNER":          capIpcOwner,
+	"CAP_SYS_MODULE":         capSysModule,
+	"CAP_SYS_RAWIO":          capSysRawio,
+	"CAP_SYS_CHROOT":         capSysChroot,
+	"CAP_SYS_PTRACE":         capSysPtrace,
+	"CAP_SYS_PACCT":          capSysPacct,
+	"CAP_SYS_ADMIN":          capSysAdmin,
+	"CAP_SYS_BOOT":           capSysBoot,
+	"CAP_SYS_NICE":           capSysNice,
+	"CAP_SYS_RESOURCE":       capSysResource,
+	"CAP_SYS_TIME":           capSysTime,
+	"CAP_SYS_TTY_CONFIG":     capSysTtyConfig,
+	"CAP_MKNOD":              capMknod,
+	"CAP_LEASE":              capLease,
+	"CAP_AUDIT_WRITE":        capAuditWrite,
+	"CAP_AUDIT_CONTROL":      capAuditControl,
+	"CAP_SETFCAP":            capSetfcap,
+	"CAP_MAC_OVERRIDE":       capMacOverride,
+	"CAP_MAC_ADMIN":          capMacAdmin,
+	"CAP_SYSLOG":             capSyslog,
+	"CAP_WAKE_ALARM":         capWakeAlarm,
+	"CAP_BLOCK_SUSPEND":      capBlockSuspend,
+	"CAP_AUDIT_READ":         capAuditRead,
+	"CAP_PERFMON":            capPerfmon,
+	"CAP_BPF":                capBPF,
+	"CAP_CHECKPOINT_RESTORE": capCheckpointRestore,
 }
 
 // Normalize takes a slice of capabilities, normalizes and unwraps CAP_ALL.


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity#1072
- sylabs/singularity#1080
 which fixed
- sylabs/singularity#1071
- sylabs/singularity#1079

The original PR descriptions were:
> Add support for:
> 
>  * CAP_PERFMON (Linux 5.8)
>  * CAP_BPF (Linux 5.8)
>  * CAP_CHECKPOINT_RESTORE (Linux 5.9)

> In sylabs/singularity#1072, additional capabilities were added in Go code. The C starter code uses a loop up to CAPSET_MAX when reconciling capabilities vs supported on the machine. Because CAPSET_MAX was still 37, not 40, it failed to trim the 3 upper capabilities that are unsupported on older kernels.
> 
> Correct CAPSET_MAX to fix the issue on older kernels.