### PR TITLE
Turn overlay permission denied into a fatal error with info instead of a warning (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes Since Last Release
 
+- Change the warning when an overlay image is not writable, introduced
+  in v1.1.3, back into a (more informative) fatal error because it doesn't
+  actually enter the container environment.
 - Set the `--net` flag if `--network` or `--network-args` is set rather
   than silently ignoring them if `--net` was not set.
 


### PR DESCRIPTION
This cherry-picks #840 into the release-1.1 branch.