### PR TITLE
feat: Allow kernel supported unpriv overlay, from sylabs 1077 & 1081

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes Since Last Release
 
+### Changed defaults / behaviours
+
+- When the kernel supports unprivileged overlay mounts in a user
+  namespace, the container will be constructed using an overlay
+  instead of underlay layout.
+
 ### New features / functionalities
 
 - The `--no-mount` flag now accepts the value `bind-paths` to disable mounting

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -357,23 +357,6 @@ func (c configTests) configGlobal(t *testing.T) {
 			directiveValue: "no",
 			exit:           1,
 		},
-		// use user namespace profile to force underlay use
-		{
-			name:           "EnableUnderlayNo",
-			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
-			profile:        e2e.UserNamespaceProfile,
-			directive:      "enable underlay",
-			directiveValue: "no",
-			exit:           255,
-		},
-		{
-			name:           "EnableUnderlayYes",
-			argv:           []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
-			profile:        e2e.UserNamespaceProfile,
-			directive:      "enable underlay",
-			directiveValue: "yes",
-			exit:           0,
-		},
 		// test image is owned by root:root
 		{
 			name:           "LimitContainerOwnersUser",
@@ -727,6 +710,28 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 				"allow net users": u.Name,
 			},
 			exit: 255,
+		},
+		// disable overlay to force underlay
+		{
+			name:    "EnableUnderlayNo",
+			argv:    []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile: e2e.UserProfile,
+			directives: map[string]string{
+				"enable overlay":  "no",
+				"enable underlay": "no",
+			},
+
+			exit: 255,
+		},
+		{
+			name:    "EnableUnderlayYes",
+			argv:    []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			profile: e2e.UserProfile,
+			directives: map[string]string{
+				"enable overlay":  "no",
+				"enable underlay": "yes",
+			},
+			exit: 0,
 		},
 	}
 

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1080,7 +1080,7 @@ func (e *EngineOperations) setSessionLayer(img *image.Image) error {
 					e.EngineConfig.SetSessionLayer(apptainerConfig.OverlayLayer)
 					return nil
 				}
-				if err != nil && err != overlay.ErrNoRootlessOverlay {
+				if err != overlay.ErrNoRootlessOverlay {
 					sylog.Warningf("While checking for rootless overlay support: %s", err)
 				}
 			}

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -10,8 +10,15 @@
 package overlay
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
 
+	"github.com/apptainer/apptainer/internal/pkg/util/bin"
+	"github.com/apptainer/apptainer/pkg/sylog"
 	"golang.org/x/sys/unix"
 )
 
@@ -132,4 +139,72 @@ func IsIncompatible(err error) bool {
 		return true
 	}
 	return false
+}
+
+var ErrNoRootlessOverlay = errors.New("rootless overlay not supported by kernel")
+
+// CheckRootless checks whether the kernel overlay driver supports unprivileged use in a user namespace.
+func CheckRootless() error {
+	mountBin, err := bin.FindBin("mount")
+	if err != nil {
+		return fmt.Errorf("while looking for mount command: %s", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "check-overlay")
+	if err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	lowerDir := filepath.Join(tmpDir, "l")
+	if err := os.Mkdir(lowerDir, 0o777); err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+	upperDir := filepath.Join(tmpDir, "u")
+	if err := os.Mkdir(upperDir, 0o777); err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+	workDir := filepath.Join(tmpDir, "w")
+	if err := os.Mkdir(workDir, 0o777); err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+	mountDir := filepath.Join(tmpDir, "m")
+	if err := os.Mkdir(mountDir, 0o777); err != nil {
+		return fmt.Errorf("while creating temporary directories: %w", err)
+	}
+
+	args := []string{
+		"-t", "overlay",
+		"-o", fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,userxattr", lowerDir, upperDir, workDir),
+		"none",
+		mountDir,
+	}
+
+	cmd := exec.Command(mountBin, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	// Unshare user and mount namespace
+	cmd.SysProcAttr.Unshareflags = syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS
+	// Map to user to root inside the user namespace
+	cmd.SysProcAttr.UidMappings = []syscall.SysProcIDMap{
+		{
+			ContainerID: 0,
+			HostID:      os.Getuid(),
+			Size:        1,
+		},
+	}
+	cmd.SysProcAttr.GidMappings = []syscall.SysProcIDMap{
+		{
+			ContainerID: 0,
+			HostID:      os.Getgid(),
+			Size:        1,
+		},
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		sylog.Debugf("Rootless overlay not supported on this system: %s\n%s", err, out)
+		return ErrNoRootlessOverlay
+	}
+
+	sylog.Debugf("Rootless overlay appears supported on this system.")
+	return nil
 }


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity#1077
- sylabs/singularity#1081
 which fixed
- sylabs/singularity#818
- sylabs/singularity#1078

The original PR descriptions were:
> When we are running a container in a user namespace, check whether the kernel supports rootless overlay. If it does, use this instead of underlay.
> 
> At present, the visible effects of this are that:
> 
>  * When running under a user namespace, on a supported system, the overlay session layout is used. The rootfs in the container will appear as an overlay fs mount.
>  * When running under a user namespace, on a supported system, the `--writable-tmpfs` option can be used, with the same semantics as in set-uid mode.
> 
> 
> Note that this changeset does not allow unprivileged persistent overlays (singularity `--overlay` flag). It will be possible to enable unprivileged overlay directory mounts at a later point, and potentially other overlay mounts via FUSE drivers.
> 
> The principle benefit at this stage is to avoid the complex, and numerous, bind mounts used by the underlay layout.
> 
> ToDo: Refactor the underlay / overlay handling to a simpler, more linear flow.
> 
> **Testing note** - CircleCI is using an Ubuntu 22.04 image that supports unprivileged overlay. The non-unpriv overlay flow can be tested on e.g. CentOS 7.

> Kernel unprivileged overlay now means we can permit users to request a persistent overlay from a directory, when running in a non-setuid flow.
> 
> In setuid mode it still remains unsafe, as the mount occurs privileged.