### PR TITLE
Advertise the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+If you suspect you have found a vulnerability in Apptainer we want
+to work with you so that it can be investigated, fixed, and disclosed in
+a responsible manner. Please follow the steps in our published `Security
+Policy <https://apptainer.org/security-policy/>`__, which begins with
+contacting us privately via security@apptainer.org
+
+We disclose vulnerabilities found in Apptainer through public
+CVE reports, and notifications on our community channels. We encourage
+all users to monitor new releases of Apptainer for security
+information. Security patches are applied to the latest open-source
+release.


### PR DESCRIPTION
GitHub will prominently link to this information in multiple locations
