### PR TITLE
fix: Wait directly in fakeroot MonitorContainer, from sylabs 1116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Set the `--net` flag if `--network` or `--network-args` is set rather
   than silently ignoring them if `--net` was not set.
 - Do not hang on pull from http(s) source that doesn't provide a content-length.
+- Avoid hang on fakeroot cleanup under high load seen on some
+  distributions / kernels.
 
 ## v1.1.3 - \[2022-10-25\]
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1116
 which fixed
- sylabs/singularity#1109

The original PR description was:
> When the user's container exits, fakeroot cleanup runs `rm` though the fakeroot engine to remove a temporary container directory, extracted from a SIF image, where necessary.
> 
> Under high load / parallelism, on some distros / kernels, execution of fakeroot tempdir cleanup can become stuck. See sylabs/singularity#1109 for discussion of a reproducer.
> 
> The fakeroot engine MonitorContainer code sits in a loop waiting for signals. It requires a SIGCHLD to be received before it will wait4 on the child process, to confirm it has exited.
> 
> Debug logging showed that sometimes a SIGCHLD was not received by this code. It is not clear why, as `signal.Notify` is set early, and the signals channel buffer is not being filled. The behavior varies between distributions / kernels. It is sometimes easy to trigger, and sometimes impossible.
> 
> As a workaround, re-structure the MonitorContainer function so that it performs a blocking `wait4` in a go routine, separate from signal handling. This ensures that receiving a `SIGCHLD` is not necessary to identify that the child process has exited.
> 
> This fix has been verified in the CircleCI ssh environment. A reproducer script that previously will freeze within a few iterations does not freeze at all with this change.