### PR TITLE
Minimize e2e library / docker pulls, from sylabs 1099

### DIFF
--- a/e2e/docker/regressions.go
+++ b/e2e/docker/regressions.go
@@ -75,7 +75,7 @@ func (c ctx) issue4943(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs("--force", "/dev/null", image),
+		e2e.WithArgs("--disable-cache", "--force", "/dev/null", image),
 		e2e.ExpectExit(0),
 	)
 }
@@ -89,7 +89,7 @@ func (c ctx) issue5172(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs("--sandbox", imagePath, regImage),
+		e2e.WithArgs("--disable-cache", "--sandbox", imagePath, regImage),
 		e2e.PostRun(func(t *testing.T) {
 			if !t.Failed() {
 				os.RemoveAll(imagePath)
@@ -102,7 +102,7 @@ func (c ctx) issue5172(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("pull"),
-		e2e.WithArgs(imagePath, regImage),
+		e2e.WithArgs("--disable-cache", imagePath, regImage),
 		e2e.PostRun(func(t *testing.T) {
 			if !t.Failed() {
 				os.RemoveAll(imagePath)
@@ -144,12 +144,13 @@ From: continuumio/miniconda3:latest
 		t.Fatalf("Unable to create test definition file: %v", err)
 	}
 
+	// Run build with cache disabled, so we can be a parallel test (we are slooow!)
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("build"),
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs(imagePath, defFile),
+		e2e.WithArgs("--disable-cache", imagePath, defFile),
 		e2e.ExpectExit(0),
 	)
 	// An exec of `conda info` in the container should show environment active, no errors.

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -12,6 +12,7 @@ package ecl
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -20,11 +21,15 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/syecl"
 )
 
-// KeyMap contains test keys.
-var KeyMap = map[string]string{
-	"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
-	"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",
-}
+var (
+	// KeyMap contains test keys.
+	KeyMap = map[string]string{
+		"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
+		"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",
+	}
+
+	busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
+)
 
 type ctx struct {
 	env e2e.TestEnv
@@ -100,7 +105,7 @@ func (c *ctx) eclConfig(t *testing.T) {
 			name:    "build signed image",
 			command: "build",
 			profile: e2e.UserProfile,
-			args:    []string{signed, "oras://ghcr.io/apptainer/busybox:1.31.1"},
+			args:    []string{signed, busyboxSIF},
 			exit:    0,
 		},
 		{

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -12,7 +12,6 @@ package ecl
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -21,15 +20,11 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/syecl"
 )
 
-var (
-	// KeyMap contains test keys.
-	KeyMap = map[string]string{
-		"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
-		"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",
-	}
-
-	busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
-)
+// KeyMap contains test keys.
+var KeyMap = map[string]string{
+	"key1": "0C5B8C9A5FFC44E2A0AC79851CD6FA281D476DD1",
+	"key2": "78F8AD36B0DCB84B707F23853D608DAE21C8CA10",
+}
 
 type ctx struct {
 	env e2e.TestEnv
@@ -105,7 +100,7 @@ func (c *ctx) eclConfig(t *testing.T) {
 			name:    "build signed image",
 			command: "build",
 			profile: e2e.UserProfile,
-			args:    []string{signed, busyboxSIF},
+			args:    []string{signed, e2e.BusyboxSIF(t)},
 			exit:    0,
 		},
 		{

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -15,7 +15,6 @@ package apptainerenv
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -36,7 +35,7 @@ const (
 func (c ctx) apptainerEnv(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 	// Apptainer defines a path by default. See apptainerware/apptainer/etc/init.
-	defaultImage := "testdata/busybox_" + runtime.GOARCH + ".sif"
+	defaultImage := e2e.BusyboxSIF(t)
 	// This image sets a custom path.
 	// See e2e/testdata/Apptainer
 	customImage := c.env.ImagePath
@@ -131,7 +130,7 @@ func (c ctx) apptainerEnv(t *testing.T) {
 func (c ctx) apptainerEnvOption(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 	// Apptainer defines a path by default. See apptainerware/apptainer/etc/init.
-	defaultImage := "testdata/busybox_" + runtime.GOARCH + ".sif"
+	defaultImage := e2e.BusyboxSIF(t)
 	// This image sets a custom path.
 	// See e2e/testdata/Apptainer
 	customImage := c.env.ImagePath

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -28,11 +29,12 @@ func (c ctx) issue5426(t *testing.T) {
 	defer cleanup(t)
 
 	// Build a current sandbox
+	busyboxSIF := "testdata/busybox_" + runtime.GOARCH + ".sif"
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs("--force", "--sandbox", sandboxDir, "oras://ghcr.io/apptainer/alpine:3.15.0"),
+		e2e.WithArgs("--force", "--sandbox", sandboxDir, busyboxSIF),
 		e2e.ExpectExit(0),
 	)
 

--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -29,12 +28,11 @@ func (c ctx) issue5426(t *testing.T) {
 	defer cleanup(t)
 
 	// Build a current sandbox
-	busyboxSIF := "testdata/busybox_" + runtime.GOARCH + ".sif"
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs("--force", "--sandbox", sandboxDir, busyboxSIF),
+		e2e.WithArgs("--force", "--sandbox", sandboxDir, e2e.BusyboxSIF(t)),
 		e2e.ExpectExit(0),
 	)
 

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -27,7 +27,10 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 )
 
-var testFileContent = "Test file content\n"
+var (
+	testFileContent = "Test file content\n"
+	busyboxSIF      = "testdata/busybox_" + runtime.GOARCH + ".sif"
+)
 
 type imgBuildTests struct {
 	env e2e.TestEnv
@@ -88,6 +91,10 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 		// 	name:       "ShubDefFile",
 		// 	buildSpec:  "../examples/shub/Apptainer",
 		// },
+		{
+			name:      "LibraryURI",
+			buildSpec: "oras://ghcr.io/apptainer/alpine:latest",
+		},
 		{
 			name:      "LibraryDefFile",
 			buildSpec: "../examples/library/Apptainer",
@@ -178,11 +185,11 @@ func (c imgBuildTests) nonRootBuild(t *testing.T) {
 	}{
 		{
 			name:      "local sif",
-			buildSpec: "testdata/busybox_" + runtime.GOARCH + ".sif",
+			buildSpec: busyboxSIF,
 		},
 		{
 			name:      "local sif to sandbox",
-			buildSpec: "testdata/busybox_" + runtime.GOARCH + ".sif",
+			buildSpec: busyboxSIF,
 			args:      []string{"--sandbox"},
 		},
 		{
@@ -341,8 +348,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			name: "FileCopySimple",
 			dfd: []e2e.DefFileDetails{
 				{
-					Bootstrap: "oras",
-					From:      "ghcr.io/apptainer/alpine:latest",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					Stage:     "one",
 					Files: []e2e.FilePair{
 						{
@@ -356,8 +363,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "oras",
-					From:      "ghcr.io/apptainer/alpine:latest",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					FilesFrom: []e2e.FileSection{
 						{
 							Stage: "one",
@@ -393,8 +400,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 			name: "FileCopyComplex",
 			dfd: []e2e.DefFileDetails{
 				{
-					Bootstrap: "oras",
-					From:      "ghcr.io/apptainer/alpine:latest",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					Stage:     "one",
 					Files: []e2e.FilePair{
 						{
@@ -408,8 +415,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "oras",
-					From:      "ghcr.io/apptainer/alpine:latest",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					Stage:     "two",
 					Files: []e2e.FilePair{
 						{
@@ -423,8 +430,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "oras",
-					From:      "ghcr.io/apptainer/alpine:latest",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					Stage:     "three",
 					FilesFrom: []e2e.FileSection{
 						{
@@ -456,8 +463,8 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 					},
 				},
 				{
-					Bootstrap: "oras",
-					From:      "ghcr.io/apptainer/alpine:latest",
+					Bootstrap: "localimage",
+					From:      busyboxSIF,
 					FilesFrom: []e2e.FileSection{
 						{
 							Stage: "three",
@@ -542,12 +549,12 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 
 	tt := map[string]e2e.DefFileDetails{
 		"Empty": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 		},
 		"Help": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Help: []string{
 				"help info line 1",
 				"help info line 2",
@@ -555,8 +562,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Files": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Files: []e2e.FilePair{
 				{
 					Src: tmpfile,
@@ -569,8 +576,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Test": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Test: []string{
 				"echo testscript line 1",
 				"echo testscript line 2",
@@ -578,8 +585,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Startscript": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			StartScript: []string{
 				"echo startscript line 1",
 				"echo startscript line 2",
@@ -587,8 +594,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Runscript": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			RunScript: []string{
 				"echo runscript line 1",
 				"echo runscript line 2",
@@ -596,8 +603,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Env": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Env: []string{
 				"testvar1=one",
 				"testvar2=two",
@@ -605,8 +612,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Labels": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Labels: map[string]string{
 				"customLabel1": "one",
 				"customLabel2": "two",
@@ -614,29 +621,29 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"Pre": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Pre: []string{
 				filepath.Join(c.env.TestDir, "PreFile1"),
 			},
 		},
 		"Setup": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Setup: []string{
 				filepath.Join(c.env.TestDir, "SetupFile1"),
 			},
 		},
 		"Post": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Post: []string{
 				"PostFile1",
 			},
 		},
 		"AppHelp": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -657,8 +664,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppEnv": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -679,8 +686,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppLabels": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -701,8 +708,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppFiles": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -733,8 +740,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppInstall": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -751,8 +758,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppRun": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -773,8 +780,8 @@ func (c imgBuildTests) buildDefinition(t *testing.T) {
 			},
 		},
 		"AppTest": {
-			Bootstrap: "oras",
-			From:      "ghcr.io/apptainer/alpine:latest",
+			Bootstrap: "localimage",
+			From:      busyboxSIF,
 			Apps: []e2e.AppDetail{
 				{
 					Name: "foo",
@@ -870,7 +877,7 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 
 	// First with the command line argument
 	imgPath1 := filepath.Join(dn, "encrypted_cmdline_option.sif")
-	cmdArgs := []string{"--encrypt", "--pem-path", pemFile, imgPath1, "oras://ghcr.io/apptainer/alpine:latest"}
+	cmdArgs := []string{"--encrypt", "--pem-path", pemFile, imgPath1, busyboxSIF}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -889,7 +896,7 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 	// Second with the environment variable
 	pemEnvVar := fmt.Sprintf("%s=%s", "APPTAINER_ENCRYPTION_PEM_PATH", pemFile)
 	imgPath2 := filepath.Join(dn, "encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", imgPath2, "oras://ghcr.io/apptainer/alpine:latest"}
+	cmdArgs = []string{"--encrypt", imgPath2, busyboxSIF}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -934,7 +941,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	}
 	cmdlineTestImgPath := filepath.Join(dn, "encrypted_cmdline_option.sif")
 	// The image is deleted during cleanup of the temporary directory
-	cmdArgs := []string{"--passphrase", cmdlineTestImgPath, "oras://ghcr.io/apptainer/alpine:latest"}
+	cmdArgs := []string{"--passphrase", cmdlineTestImgPath, busyboxSIF}
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("passphrase flag"),
@@ -954,7 +961,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 
 	// With the command line argument, using --encrypt and --passphrase
 	cmdlineTest2ImgPath := filepath.Join(dn, "encrypted_cmdline2_option.sif")
-	cmdArgs = []string{"--encrypt", "--passphrase", cmdlineTest2ImgPath, "oras://ghcr.io/apptainer/alpine:latest"}
+	cmdArgs = []string{"--encrypt", "--passphrase", cmdlineTest2ImgPath, busyboxSIF}
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("encrypt and passphrase flags"),
@@ -975,7 +982,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 	// With the environment variable
 	passphraseEnvVar := fmt.Sprintf("%s=%s", "APPTAINER_ENCRYPTION_PASSPHRASE", e2e.Passphrase)
 	envvarImgPath := filepath.Join(dn, "encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", envvarImgPath, "oras://ghcr.io/apptainer/alpine:latest"}
+	cmdArgs = []string{"--encrypt", envvarImgPath, busyboxSIF}
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("passphrase env var"),
@@ -995,7 +1002,7 @@ func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
 
 	// Finally a test that must fail: try to specify the passphrase on the command line
 	dummyImgPath := filepath.Join(dn, "dummy_encrypted_env_var.sif")
-	cmdArgs = []string{"--encrypt", "--passphrase", e2e.Passphrase, dummyImgPath, "oras://ghcr.io/apptainer/alpine:latest"}
+	cmdArgs = []string{"--encrypt", "--passphrase", e2e.Passphrase, dummyImgPath, busyboxSIF}
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("passphrase on cmdline"),
@@ -1104,7 +1111,7 @@ func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 		{
 			name:    "build single signed source image",
 			command: "build",
-			args:    []string{singleSigned, "oras://ghcr.io/apptainer/busybox:1.31.1"},
+			args:    []string{singleSigned, busyboxSIF},
 		},
 		{
 			name:    "build double signed source image",

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -16,7 +16,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -27,10 +26,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 )
 
-var (
-	testFileContent = "Test file content\n"
-	busyboxSIF      = "testdata/busybox_" + runtime.GOARCH + ".sif"
-)
+var testFileContent = "Test file content\n"
 
 type imgBuildTests struct {
 	env e2e.TestEnv
@@ -177,6 +173,7 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 }
 
 func (c imgBuildTests) nonRootBuild(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
 	tt := []struct {
 		name        string
 		buildSpec   string
@@ -332,6 +329,7 @@ func (c imgBuildTests) badPath(t *testing.T) {
 }
 
 func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
 	tmpfile, err := e2e.WriteTempFile(c.env.TestDir, "testFile-", testFileContent)
 	if err != nil {
 		log.Fatal(err)
@@ -541,6 +539,7 @@ func (c imgBuildTests) buildMultiStageDefinition(t *testing.T) {
 
 //nolint:maintidx
 func (c imgBuildTests) buildDefinition(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
 	tmpfile, err := e2e.WriteTempFile(c.env.TestDir, "testFile-", testFileContent)
 	if err != nil {
 		log.Fatal(err)
@@ -852,6 +851,8 @@ func (c *imgBuildTests) ensureImageIsEncrypted(t *testing.T, imgPath string) {
 }
 
 func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
+
 	// Expected results for a successful command execution
 	expectedExitCode := 0
 	expectedStderr := ""
@@ -918,6 +919,8 @@ func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 // while using a passphrase. Note that it covers both the normal case and when the
 // version of cryptsetup available is not compliant.
 func (c imgBuildTests) buildEncryptPassphrase(t *testing.T) {
+	busyboxSIF := e2e.BusyboxSIF(t)
+
 	// Expected results for a successful command execution
 	expectedExitCode := 0
 	expectedStderr := ""
@@ -1111,7 +1114,7 @@ func (c imgBuildTests) buildWithFingerprint(t *testing.T) {
 		{
 			name:    "build single signed source image",
 			command: "build",
-			args:    []string{singleSigned, busyboxSIF},
+			args:    []string{singleSigned, e2e.BusyboxSIF(t)},
 		},
 		{
 			name:    "build double signed source image",

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -411,7 +411,7 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 		From string
 		File string
 	}{
-		From: busyboxSIF,
+		From: e2e.BusyboxSIF(t),
 		File: tmpfile,
 	}
 

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -408,13 +408,15 @@ func (c *imgBuildTests) issue3848(t *testing.T) {
 	defer os.Remove(tmpfile) // clean up
 
 	d := struct {
+		From string
 		File string
 	}{
+		From: busyboxSIF,
 		File: tmpfile,
 	}
 
-	defTmpl := `Bootstrap: oras
-From: ghcr.io/apptainer/alpine:latest
+	defTmpl := `Bootstrap: localimage
+From: {{ .From }}
 
 %files
 	{{ .File }}

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -177,4 +177,17 @@ func CopyImage(t *testing.T, source, dest string, insecureSource, insecureDest b
 	if err != nil {
 		t.Fatalf("failed to copy %s to %s: %s", source, dest, err)
 	}
+}
+
+// BusyboxImage will provide the path to a local busybox SIF image for the current architecture
+func BusyboxSIF(t *testing.T) string {
+	busyboxSIF := "testdata/busybox_" + runtime.GOARCH + ".sif"
+	_, err := os.Stat(busyboxSIF)
+	if os.IsNotExist(err) {
+		t.Fatalf("busybox image not found for %s", runtime.GOARCH)
+	}
+	if err != nil {
+		t.Error(err)
+	}
+	return busyboxSIF
 }

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
@@ -20,6 +21,8 @@ import (
 type ctx struct {
 	env e2e.TestEnv
 }
+
+var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
 
 func (c ctx) testOverlayCreate(t *testing.T) {
 	require.Filesystem(t, "overlay")
@@ -43,7 +46,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs(sifSignedImage, "oras://ghcr.io/apptainer/busybox:1.31.1"),
+		e2e.WithArgs(sifSignedImage, busyboxSIF),
 		e2e.ExpectExit(0),
 	)
 
@@ -70,7 +73,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 		t,
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
-		e2e.WithArgs(sifImage, "oras://ghcr.io/apptainer/busybox:1.31.1"),
+		e2e.WithArgs(sifImage, busyboxSIF),
 		e2e.ExpectExit(0),
 	)
 
@@ -166,7 +169,7 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 			t,
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
-			e2e.WithArgs("--encrypt", sifEncryptedImage, "oras://ghcr.io/apptainer/busybox:1.31.1"),
+			e2e.WithArgs("--encrypt", sifEncryptedImage, busyboxSIF),
 			e2e.WithEnv(append(os.Environ(), passphraseEnvVar)),
 			e2e.ExpectExit(0),
 		)

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
@@ -22,12 +21,11 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
-var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
-
 func (c ctx) testOverlayCreate(t *testing.T) {
 	require.Filesystem(t, "overlay")
 	require.MkfsExt3(t)
 	e2e.EnsureImage(t, c.env)
+	busyboxSIF := e2e.BusyboxSIF(t)
 
 	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "overlay", "")
 	defer cleanup(t)

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -15,6 +15,8 @@ package pull
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -543,6 +545,11 @@ func (c ctx) testPullDisableCacheCmd(t *testing.T) {
 // testPullUmask will run some pull tests with different umasks, and
 // ensure the output file has the correct permissions.
 func (c ctx) testPullUmask(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, c.env.ImagePath)
+	}))
+	defer srv.Close()
+
 	umask22Image := "0022-umask-pull"
 	umask77Image := "0077-umask-pull"
 	umask27Image := "0027-umask-pull"
@@ -617,7 +624,7 @@ func (c ctx) testPullUmask(t *testing.T) {
 		if tc.force {
 			cmdArgs = append(cmdArgs, "--force")
 		}
-		cmdArgs = append(cmdArgs, tc.imagePath, "oras://ghcr.io/apptainer/alpine:latest")
+		cmdArgs = append(cmdArgs, tc.imagePath, srv.URL)
 
 		c.env.RunApptainer(
 			t,

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -24,6 +25,8 @@ import (
 type ctx struct {
 	env e2e.TestEnv
 }
+
+var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
 
 // testRun555Cache tests the specific case where the cache directory is
 // 0555 for access rights, and we try to run an Apptainer run command
@@ -71,7 +74,7 @@ func (c ctx) testRunPEMEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_pem-path.sif")
-	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, "oras://ghcr.io/apptainer/alpine:3.15.0"}
+	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, busyboxSIF}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -121,7 +124,7 @@ func (c ctx) testRunPassphraseEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_passphrase.sif")
-	cmdArgs := []string{"--encrypt", imgPath, "oras://ghcr.io/apptainer/alpine:3.15.0"}
+	cmdArgs := []string{"--encrypt", imgPath, busyboxSIF}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -25,8 +24,6 @@ import (
 type ctx struct {
 	env e2e.TestEnv
 }
-
-var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
 
 // testRun555Cache tests the specific case where the cache directory is
 // 0555 for access rights, and we try to run an Apptainer run command
@@ -74,7 +71,7 @@ func (c ctx) testRunPEMEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_pem-path.sif")
-	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, busyboxSIF}
+	cmdArgs := []string{"--encrypt", "--pem-path", pemPubFile, imgPath, e2e.BusyboxSIF(t)}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),
@@ -124,7 +121,7 @@ func (c ctx) testRunPassphraseEncrypted(t *testing.T) {
 	defer cleanup(t)
 
 	imgPath := filepath.Join(tempDir, "encrypted_cmdline_passphrase.sif")
-	cmdArgs := []string{"--encrypt", imgPath, busyboxSIF}
+	cmdArgs := []string{"--encrypt", imgPath, e2e.BusyboxSIF(t)}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.RootProfile),

--- a/e2e/sign/sign.go
+++ b/e2e/sign/sign.go
@@ -12,7 +12,6 @@ package sign
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -27,8 +26,6 @@ type ctx struct {
 }
 
 const imgName = "testImage.sif"
-
-var busyboxSIF = "testdata/busybox_" + runtime.GOARCH + ".sif"
 
 func (c ctx) apptainerSignHelpOption(t *testing.T) {
 	c.env.KeyringDir = c.keyringDir
@@ -52,7 +49,7 @@ func (c *ctx) prepareImage(t *testing.T) (string, func(*testing.T)) {
 	}
 	imgPath := filepath.Join(tempDir, imgName)
 
-	err = fs.CopyFile(busyboxSIF, imgPath, 0o755)
+	err = fs.CopyFile(e2e.BusyboxSIF(t), imgPath, 0o755)
 	if err != nil {
 		t.Fatalf("failed to copy temporary image: %s", err)
 	}


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1099
 which fixed
- sylabs/singularity#913

The original PR description was:
> As much as easily possible, replace use of a library pull with a local busybox or built alpine test image.
> 
> Remove redundant docker pulls, that aren't really testing anything additional.
> 
> Move docker tests that are very slow, or pulling from local registries, to be parallel again. Modify these tests so that they use `--disable-cache` to avoid docker cache concurrency issues. The other ordered tests are checking the path pulling through the cache.
> 
> With these changes, e2e parallelism is better, so it is sensible to use a `resource_class: large` VM for e2e only.