### PR TITLE
Remove pacstrap obsolete -d option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   When moving the binaries to a new location, the `/usr` at the top of some
   of the paths needs to be removed.  Relocation is disallowed when the
   `starter-suid` is present, for security reasons.
+- Remove obsolete pacstrap `-d` in Arch packer
 
 ## v1.1.3 - \[2022-10-25\]
 

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -148,7 +148,7 @@ func (cp *ArchConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 		}
 	}
 
-	args := []string{"-C", pacConf, "-c", "-d", "-G", "-M", cp.b.RootfsPath, "haveged"}
+	args := []string{"-C", pacConf, "-c", "-G", "-M", cp.b.RootfsPath, "haveged"}
 	args = append(args, instList...)
 
 	pacCmd := exec.Command(pacstrapPath, args...)


### PR DESCRIPTION
Pacstrap `-d` option has been obsolete for many years and not doing anything. It was remove recently:
https://github.com/archlinux/arch-install-scripts/commit/91562aa99cd8237a2dec1aff5101949e40bf7d75

Using `apptainer build` with up-to-date pacstrap to build an Archlinux image now fails with error:
```
==> ERROR: pacstrap: invalid option -- 'd'
```
This PR removes `-d` option.