### PR TITLE
Remove pacstrap obsolete -d option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Do not hang on pull from http(s) source that doesn't provide a content-length.
 - Avoid hang on fakeroot cleanup under high load seen on some
   distributions / kernels.
+- Remove obsolete pacstrap `-d` in Arch packer
 
 ## v1.1.3 - \[2022-10-25\]
 

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -150,7 +150,7 @@ func (cp *ArchConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 		}
 	}
 
-	args := []string{"-C", pacConf, "-c", "-d", "-G", "-M", cp.b.RootfsPath, "haveged"}
+	args := []string{"-C", pacConf, "-c", "-G", "-M", cp.b.RootfsPath, "haveged"}
 	args = append(args, instList...)
 
 	pacCmd := exec.Command(pacstrapPath, args...)


### PR DESCRIPTION
Signed-off-by: vejnar <charles.vejnar@gmail.com>

Same as https://github.com/apptainer/apptainer/pull/890 for release-1.1 branch.