### PR TITLE
Include squashfuse patch for modern C

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -198,7 +198,7 @@ To download the source code do this:
 
 ```sh
 SQUASHFUSEVERSION=0.1.105
-SQUASHFUSEPRS="70 77"
+SQUASHFUSEPRS="70 77 81"
 curl -L -O https://github.com/vasi/squashfuse/archive/$SQUASHFUSEVERSION/squashfuse-$SQUASHFUSEVERSION.tar.gz
 for PR in $SQUASHFUSEPRS; do
     curl -L -O https://github.com/vasi/squashfuse/pull/$PR.patch

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -52,6 +52,7 @@ Source: https://github.com/%{name}/%{name}/releases/download/v%{package_version}
 Source10: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squashfuse-%{squashfuse_version}.tar.gz
 Patch10: https://github.com/vasi/squashfuse/pull/70.patch
 Patch11: https://github.com/vasi/squashfuse/pull/77.patch
+Patch12: https://github.com/vasi/squashfuse/pull/81.patch
 %endif
 # The singularity package was renamed to apptainer after version 3.8.x.
 # The apptainer package reset numbering at 1.0.0, and some singularity
@@ -115,6 +116,7 @@ Provides the optional setuid-root portion of Apptainer.
 %setup -b 10 -n squashfuse-%{squashfuse_version}
 %patch -P 10 -p1
 %patch -P 11 -p1
+%patch -P 12 -p1
 %setup -n %{name}-%{package_version}
 %else
 %autosetup -n %{name}-%{package_version}


### PR DESCRIPTION
This cherry-picks #907 to the release-1.1 branch.