### PR TITLE
Fix strange variable name APPTAINERENV_SING_USER_DEFINED_PREPEND_PATH in deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   of the paths needs to be removed.  Relocation is disallowed when the
   `starter-suid` is present, for security reasons.
 - Remove obsolete pacstrap `-d` in Arch packer
+- Adjust warning message for deprecated environment variables usage
 
 ## v1.1.3 - \[2022-10-25\]
 

--- a/internal/pkg/util/env/create_test.go
+++ b/internal/pkg/util/env/create_test.go
@@ -425,7 +425,7 @@ func TestSetContainerEnv(t *testing.T) {
 				"PRECEDENCE": "second",
 			},
 			outputNeeded: []string{
-				"DEPRECATED USAGE: Forwarding SINGULARITYENV_PRECEDENCE as environment variable will not be supported in the future, use APPTAINERENV_PRECEDENCE instead",
+				"DEPRECATED USAGE: Environment variable SINGULARITYENV_PRECEDENCE will not be supported in the future, use APPTAINERENV_PRECEDENCE instead",
 				"Forwarding SINGULARITYENV_PRECEDENCE as PRECEDENCE environment variable",
 				"Environment variable PRECEDENCE already has value [second], will not forward new value [fifth] from parent process environment",
 			},
@@ -515,7 +515,7 @@ func TestSetContainerEnv(t *testing.T) {
 				"PRECEDENCE": "precedence",
 			},
 			outputNeeded: []string{
-				"DEPRECATED USAGE: Forwarding SINGULARITYENV_PRECEDENCE as environment variable will not be supported in the future, use APPTAINERENV_PRECEDENCE instead",
+				"DEPRECATED USAGE: Environment variable SINGULARITYENV_PRECEDENCE will not be supported in the future, use APPTAINERENV_PRECEDENCE instead",
 				"Forwarding SINGULARITYENV_PRECEDENCE as PRECEDENCE environment variable",
 				"Environment variable PRECEDENCE already has duplicate value [precedence], will not forward from parent process environment",
 			},
@@ -595,7 +595,7 @@ func TestSetContainerEnv(t *testing.T) {
 				"PRECEDENCE": "second",
 			},
 			outputNeeded: []string{
-				"DEPRECATED USAGE: Forwarding SINGULARITYENV_PRECEDENCE as environment variable will not be supported in the future, use APPTAINERENV_PRECEDENCE instead",
+				"DEPRECATED USAGE: Environment variable SINGULARITYENV_PRECEDENCE will not be supported in the future, use APPTAINERENV_PRECEDENCE instead",
 				"Forwarding SINGULARITYENV_PRECEDENCE as PRECEDENCE environment variable",
 			},
 		},
@@ -682,6 +682,7 @@ func TestSetContainerEnv(t *testing.T) {
 			}()
 			for _, requiredOutput := range tc.outputNeeded {
 				if !strings.Contains(output.String(), requiredOutput) {
+					t.Errorf(" --------------- %s", output.String())
 					t.Errorf("Did not find required output: [%s]", requiredOutput)
 				}
 			}

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -31,14 +31,20 @@ const (
 
 	// defaultLocalKeyDirName represents the default local key storage folder name
 	defaultLocalKeyDirName = "keys"
+
+	// Legacy singularity prefix
+	LegacySingularityPrefix = "SINGULARITY_"
+
+	// Legacy singularity env prefix
+	LegacySingularityEnvPrefix = "SINGULARITYENV_"
 )
 
 // ApptainerPrefixes the following prefixes are for settings looked at by Apptainer command
-var ApptainerPrefixes = []string{ApptainerPrefix, "SINGULARITY_"}
+var ApptainerPrefixes = []string{ApptainerPrefix, LegacySingularityPrefix}
 
 // ApptainerEnvPrefixes defines the environment variable prefixes for passthru
 // to container
-var ApptainerEnvPrefixes = []string{ApptainerEnvPrefix, "SINGULARITYENV_"}
+var ApptainerEnvPrefixes = []string{ApptainerEnvPrefix, LegacySingularityEnvPrefix}
 
 // SetFromList sets environment variables from environ argument list.
 func SetFromList(environ []string) error {


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

Adjust warning message for deprecated environment variables usage


### This fixes or addresses the following GitHub issues:

 - Fixes #870 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
