### PR TITLE
Prevent macro expansion in rpm spec comments

### DIFF
--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -94,9 +94,9 @@ Requires: fuse-overlayfs
 Requires: e2fsprogs
 # Uncomment this for the epel build, but we don't want it for the Apptainer
 #  release build because there the same rpm is shared across OS versions
-#%if 0%{?el7}
+#%%if 0%{?el7}
 #Requires: fuse2fs
-#%endif
+#%%endif
 
 %description
 Apptainer provides functionality to make portable
@@ -111,7 +111,7 @@ Provides the optional setuid-root portion of Apptainer.
 
 %prep
 %if "%{?squashfuse_version}" != ""
-# the default directory for other steps is where the %prep section ends
+# the default directory for other steps is where the %%prep section ends
 # so do main package last
 %setup -b 10 -n squashfuse-%{squashfuse_version}
 %patch -P 10 -p1


### PR DESCRIPTION
Change % in rpm macro comments to %% to avoid warnings abound expansion as shown in #913.