### PR TITLE
Allow --security uid and gid in non-suid mode (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   distributions / kernels.
 - Remove obsolete pacstrap `-d` in Arch packer.
 - Adjust warning message for deprecated environment variables usage.
+- Enable the `--security uid:N` and `--security gid:N` options to work
+  when run in non-suid mode.  In non-suid mode they work with any user,
+  not just root.  Unlike with root and suid mode, however, only one gid
+  may be set in non-suid mode.
 
 ## v1.1.3 - \[2022-10-25\]
 

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -316,9 +316,11 @@ static void apply_privileges(struct privileges *privileges, struct capabilities 
                 fatalf("Failed to set GID %d: %s\n", targetGID, strerror(errno));
             }
 
-            debugf("Set %d additional group IDs\n", privileges->numGID);
-            if ( setgroups(privileges->numGID, privileges->targetGID) < 0 ) {
-                fatalf("Failed to set additional groups: %s\n", strerror(errno));
+            if ( privileges->numGID > 1 ) {
+                debugf("Set %d additional group IDs\n", privileges->numGID);
+                if ( setgroups(privileges->numGID, privileges->targetGID) < 0 ) {
+                    fatalf("Failed to set additional groups: %s\n", strerror(errno));
+                }
             }
         }
     }


### PR DESCRIPTION
This cherry-picks #915 to the release-1.1 branch.