### PR TITLE
Prevent force overridden of PS1 if already set

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -92,6 +92,7 @@
 - Westley Kurtzer <westley@sylabs.io>, <westleyk@nym.hush.com>
 - Yannick Cote <y@sylabs.io>, <yhcote@gmail.com>
 - Yaroslav Halchenko <debian@onerussian.com>
+- Yoshiaki Senda <yoshiaki@live.it>
 - Onur Yılmaz <csonuryilmaz@gmail.com>
 - Pranathi Locula <locula@deshaw.com>
 - Pedro Alves Batista <pedro.pesquisapb@gmail.com>

--- a/internal/pkg/build/sources/99-base.sh
+++ b/internal/pkg/build/sources/99-base.sh
@@ -29,5 +29,7 @@ else
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/.singularity.d/libs"
 fi
 
-PS1="Apptainer> "
+if test -z "${PS1:-}"; then
+        export PS1="Apptainer> "
+fi
 export LD_LIBRARY_PATH PS1

--- a/internal/pkg/build/sources/99-base.sh
+++ b/internal/pkg/build/sources/99-base.sh
@@ -30,6 +30,6 @@ else
 fi
 
 if test -z "${PS1:-}"; then
-        export PS1="Apptainer> "
+    PS1="Apptainer> "
 fi
 export LD_LIBRARY_PATH PS1


### PR DESCRIPTION
## Description of the Pull Request (PR):

When users explicitly set PS1 value in environment section, 99-base.sh force overridden of that PS1 value. This PR prevents force overridden of PS1.
This make allow users to set their preferable PS1 value for their image.


### This fixes or addresses the following GitHub issues:

 - Fixes #925 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
