### PR TITLE
Improvements for install-unprivileged.sh

### DIFF
--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -336,7 +336,7 @@ done
 cd ..
 echo "Creating bin/apptainer and bin/singularity"
 mkdir -p bin
-cat >>bin/apptainer <<'!EOF!'
+cat >bin/apptainer <<'!EOF!'
 #!/bin/bash
 HERE="${0%/*}"
 if [ "$HERE" = "." ]; then

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -293,7 +293,9 @@ cat >utils/bin/.wrapper <<'!EOF!'
 #!/bin/bash
 ME=${0##*/}
 HERE="${0%/*}"
-if [[ "$HERE" != /* ]]; then
+if [ "$HERE" = "." ]; then
+	HERE="$PWD"
+elif [[ "$HERE" != /* ]]; then
 	HERE="$PWD/$HERE"
 fi
 PARENT="${HERE%/*}"
@@ -312,7 +314,9 @@ cat >libexec/apptainer/bin/.wrapper <<'!EOF!'
 #!/bin/bash
 ME=${0##*/}
 HERE="${0%/*}"
-if [[ "$HERE" != /* ]]; then
+if [ "$HERE" = "." ]; then
+	HERE="$PWD"
+elif [[ "$HERE" != /* ]]; then
 	HERE="$PWD/$HERE"
 fi
 PARENT="${HERE%/*}"
@@ -331,7 +335,9 @@ mkdir -p bin
 cat >>bin/apptainer <<'!EOF!'
 #!/bin/bash
 HERE="${0%/*}"
-if [[ "$HERE" != /* ]]; then
+if [ "$HERE" = "." ]; then
+	HERE="$PWD"
+elif [[ "$HERE" != /* ]]; then
 	HERE="$PWD/$HERE"
 fi
 BASEPATH="${HERE%/*}"

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -284,6 +284,10 @@ cd ..
 
 set -e
 
+# remove .build-id files seen on el8 or later
+rm -rf lib/.build-id
+rmdir lib 2>/dev/null || true
+
 # move everything needed out of tmp to utils
 mkdir -p utils/bin utils/lib utils/libexec
 mv tmp/usr/lib*/* utils/lib


### PR DESCRIPTION
This fixes a few small issues found in the tools/install-unprivileged.sh script:
1. It wasn't working when invoked by `./apptainer` from the bin directory.
2. It was including unneeded .build-id files.
3. When used multiple times on the same destination directory, it was appending to the main bin/apptainer script so it would get multiple copies of the script code.  The last line is an "exec" so the extra lines had no effect, but they shouldn't be there.