### PR TITLE
Set EUID during %environment if not set

### DIFF
--- a/internal/pkg/build/sources/01-base.sh
+++ b/internal/pkg/build/sources/01-base.sh
@@ -22,3 +22,6 @@
 # to reproduce, distribute copies to the public, prepare derivative works, and
 # perform publicly and display publicly, and to permit other to do so.
 #
+if [ -z "$EUID" ]; then
+    EUID="$UID"
+fi


### PR DESCRIPTION
EUID is not defined by mvdan/sh, but some lmod expects it to be set during profile initialization. This sets EUID, when it is missing, before the user-defined %environment section is sourced.

Closes #837

Signed-off-by: Jonathon Anderson <janderson@ciq.co>