### PR TITLE
fix mount of faked without -sysv suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
 - Add new Linux capabilities: `CAP_PERFMON`, `CAP_BPF`, `CAP_CHECKPOINT_RESTORE`.
 
+### Bug fixes
+
+- Fix the use of `fakeroot`, `faked`, and `libfakeroot.so` if they are not
+  suffixed by `-sysv`, as is for instance the case on Gentoo Linux.
+
 ## v1.1.4 - \[2022-12-12\]
 
 - Added tools/install-unprivileged.sh to download and install apptainer

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@
 - Ángel Bejarano <abejarano@ontropos.com>
 - Apuã Paquola <apuapaquola@gmail.com>
 - Aron Öfjörð Jóhannesson <aron1991@gmail.com>
+- Bart Oldeman <bart.oldeman@calculquebec.ca>
 - Bernard Li <bernardli@lbl.gov>
 - Brian Bockelman <bbockelm@cse.unl.edu>
 - Brian Clemens <brian@resf.org>, <brian@tiuxo.com>

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -155,9 +155,9 @@ func GetFakeBinds(fakerootPath string) ([]string, error) {
 	if len(splits) > 1 {
 		// add the faked that corresponds to the preload library
 		src += "-" + splits[1]
-		if _, err = os.Stat(src); err == nil {
-			binds[1] = src + ":" + point
-		}
+	}
+	if _, err = os.Stat(src); err == nil {
+		binds[1] = src + ":" + point
 	}
 	point = binds[2]
 	splits = strings.Split(libraryPath, ":")


### PR DESCRIPTION
On e.g. Gentoo, fakeroot is compiled without any special options so the relevant files are called fakeroot, faked, and libfakeroot.so (symbolic link to libfakeroot-0.so).

Apptainer insisted that the LD_PRELOADed lib inside fakeroot environments (libfakeroot.so) has a `-` in it (e.g. libfakeroot-sysv.so), then append the `-sysv` to faked and check for its existence. Without `-` no mapping was done.

So to work with plain faked, simply check for faked if there is no `-` in the LD_PRELOAD lib.

Fixes #951

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #951 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
