### PR TITLE
Unprivileged install for openSUSE/SUSE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,15 +170,15 @@ jobs:
 
       - name: Install and test unprivileged for openSUSE leap
         env:
-          OS_TYPE: opensuse
-          OS_VERSION: leap
+          OS_TYPE: opensuse/leap
+          OS_VERSION: latest
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 
       - name: Install and test unprivileged for openSUSE tumbleweed
         env:
-          OS_TYPE: opensuse
-          OS_VERSION: tumbleweed
+          OS_TYPE: opensuse/tumbleweed
+          OS_VERSION: latest
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,20 @@ jobs:
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 
+      - name: Install and test unprivileged for openSUSE leap
+        env:
+          OS_TYPE: opensuse
+          OS_VERSION: leap
+          TEST_TYPE: unpriv
+        run: ./scripts/ci-docker-run
+
+      - name: Install and test unprivileged for openSUSE tumbleweed
+        env:
+          OS_TYPE: opensuse
+          OS_VERSION: tumbleweed
+          TEST_TYPE: unpriv
+        run: ./scripts/ci-docker-run
+
   rpmbuild-rocky9:
     runs-on: ubuntu-22.04
     name: rpmbuild-rocky9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,13 +175,6 @@ jobs:
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 
-      - name: Install and test unprivileged for openSUSE tumbleweed
-        env:
-          OS_TYPE: opensuse/tumbleweed
-          OS_VERSION: latest
-          TEST_TYPE: unpriv
-        run: ./scripts/ci-docker-run
-
   rpmbuild-rocky9:
     runs-on: ubuntu-22.04
     name: rpmbuild-rocky9

--- a/scripts/ci-unpriv-test
+++ b/scripts/ci-unpriv-test
@@ -10,6 +10,8 @@
 if [ "$OS_TYPE" = debian ] || [ "$OS_TYPE" = ubuntu ]; then
   apt-get update
   apt-get install -y curl rpm2cpio cpio e2fsprogs tzdata
+elif [ "$OS_TYPE" = "opensuse/leap" ] || [ "$OS_TYPE" = "opensuse/tumbleweed" ]; then
+  zypper install -y e2fsprogs cpio util-linux
 else
   yum install -y e2fsprogs cpio
 fi
@@ -20,6 +22,7 @@ rm -f /etc/subuid /etc/subgid
 
 # Be careful not to use unescaped single quotes in these commands
 su testuser -c '
+  export PATH=$PATH:/usr/sbin
   set -x
   set -e
   rm -rf ins image.sif overlay.img

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -276,7 +276,7 @@ OSUTILS=""
 EXTRASUTILS="fuse-overlayfs"
 EPELUTILS="fakeroot"
 if [ "$DIST" == el7 ]; then
-	OSUTILS="$OSUTILS lzo squashfs-tools libseccomp fuse-libs"
+	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs"
 	EPELUTILS="$EPELUTILS libzstd fuse2fs fuse3-libs fakeroot-libs"
 elif [ "$DIST" == el8 ]; then
 	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs libzstd e2fsprogs-libs e2fsprogs fuse3-libs"
@@ -290,7 +290,7 @@ elif [ "$DIST" == "suse15" ]; then
 	EXTRASUTILS="$EXTRASUTILS fuse2fs"
 	EPELUTILS=""
 else
-	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools libzstd e2fsprogs-libs e2fsprogs"
+	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs libzstd e2fsprogs-libs e2fsprogs"
 	EXTRASUTILS="$EXTRASUTILS fuse3-libs"
 	EPELUTILS="$EPELUTILS fakeroot-libs"
 fi

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -23,6 +23,8 @@ usage()
 	echo "   e.g. el9 or fc37, default based on the current system."
 	echo "   As a convenience, active debian and ubuntu versions (not counting 18.04)"
 	echo "   get translated into a compatible el version for downloads."
+	echo "   Also openSUSE based distributions are mapped to EL/FC or native openSUSE"
+	echo "   binaries can be used via the -o switch."
 	echo " arch can be any architecture supported by EPEL or Fedora,"
 	echo "   default based on the current system."
 	echo " version selects a specific apptainer version, default latest release,"

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -208,7 +208,7 @@ latesturl()
 	typeset LATEST="$(echo "$LASTPKGS"|sed -e 's/.*href="//;s/".*//' -e 's/\.mirrorlist//' -e 's/\-32bit//' -e 's@^\.\/@@' |grep "^$2-[0-9].*$ARCH"|tail -1)"
 	if [ -n "$LATEST" ]; then
 		echo "$URL/$LATEST"
-	elif [ "$4" = true ]; then
+	elif [ "$4" == true ]; then
 		URL="${URL/\/updates\///releases/}"
 		URL="${URL/\/Packages\///os/Packages/}"
 		latesturl "$URL" "$2" false false
@@ -220,7 +220,6 @@ latesturl()
 }
 
 LOCALAPPTAINER=false
-#if test -z "$VERSION" || ! test -z $OBSURL ; then
 if test -z "$VERSION" || [[ "$KOJI" == "false" ]]; then
 	# shellcheck disable=SC2310,SC2311
 	if ! APPTAINERURL="$(latesturl "$EPELREPOURL" apptainer $KOJI false)"; then
@@ -276,17 +275,17 @@ APPTAINERURL="https://kojipkgs.fedoraproject.org/packages/apptainer/"
 OSUTILS=""
 EXTRASUTILS="fuse-overlayfs"
 EPELUTILS="fakeroot"
-if [ "$DIST" = el7 ]; then
+if [ "$DIST" == el7 ]; then
 	OSUTILS="$OSUTILS lzo squashfs-tools libseccomp fuse-libs"
 	EPELUTILS="$EPELUTILS libzstd fuse2fs fuse3-libs fakeroot-libs"
-elif [ "$DIST" = el8 ]; then
+elif [ "$DIST" == el8 ]; then
 	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs libzstd e2fsprogs-libs e2fsprogs fuse3-libs"
 	EPELUTILS="$EPELUTILS fakeroot-libs"
-elif [ "$DIST" = "opensuse-tumbleweed" ]; then
+elif [ "$DIST" == "opensuse-tumbleweed" ]; then
 	OSUTILS="$OSUTILS libseccomp2 squashfs liblzo2-2 libzstd1 e2fsprogs fuse3 libfuse3-3 fakeroot fuse2fs $EXTRASUTILS $EPELUTILS"
 	EXTRASUTILS=""
 	EPELUTILS=""
-elif [ "$DIST" = "suse15" ]; then
+elif [ "$DIST" == "suse15" ]; then
 	OSUTILS="$OSUTILS libseccomp2 squashfs liblzo2-2 libzstd1 e2fsprogs fuse3 libfuse3-3 fakeroot $EPELUTILS"
 	EXTRASUTILS="$EXTRASUTILS fuse2fs"
 	EPELUTILS=""

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -220,7 +220,7 @@ latesturl()
 }
 
 LOCALAPPTAINER=false
-if test -z "$VERSION" || [[ "$KOJI" == "false" ]]; then
+if test -z "$VERSION" || test "$KOJI" == "false" ; then
 	# shellcheck disable=SC2310,SC2311
 	if ! APPTAINERURL="$(latesturl "$EPELREPOURL" apptainer $KOJI false)"; then
 		fatal "Could not find apptainer version from $APPTAINERURL"


### PR DESCRIPTION
Adds openSUSE/SUSE distros to `tools/install-unprivileged.sh`.
Installation can be done via KOJI rpms or the rpms from the openBuild service.
