### PR TITLE
Add a test for nested apptainer

### DIFF
--- a/scripts/ci-docker-run
+++ b/scripts/ci-docker-run
@@ -16,7 +16,7 @@
 DOCKER_HUB_URI="$OS_TYPE:$OS_VERSION"
 docker pull "$DOCKER_HUB_URI"
 
-DOCKER_CONTAINER_NAME="test_${OS_TYPE#*/}_${OS_VERSION}"
+DOCKER_CONTAINER_NAME="test_${OS_TYPE##*/}_${OS_VERSION}"
 PKGTYPE=rpm
 if [ "$OS_TYPE" = "debian" ] || [ "$OS_TYPE" = "ubuntu" ]; then
     PKGTYPE=deb

--- a/scripts/ci-unpriv-test
+++ b/scripts/ci-unpriv-test
@@ -29,5 +29,6 @@ su testuser -c '
   truncate -s 1G overlay.img
   mkfs.ext3 -F -O ^has_journal overlay.img
   ins/bin/apptainer exec --overlay overlay.img -f image.sif touch /bin/newfile
+  ins/bin/apptainer exec -B $PWD -f image.sif ins/bin/apptainer exec --overlay overlay.img image.sif cat /bin/newfile
   ins/bin/apptainer exec --unsquash image.sif true
 '


### PR DESCRIPTION
This adds a test for nested apptainer commands in the ci-unpriv-test that we now run on multiple operating system versions.  That's a lot simpler than adding an e2e test because all the dependencies are already conveniently installed by install-unprivileged.sh.  This tests all 4 unprivileged dependencies at once: squashfuse, fuse2fs, fuse-overlayfs, and fakeroot.

- Fixes #524