### PR TITLE
add helpful error message for build remote option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Changed defaults / behaviours
 
-- Make `PS1` envrionment variable changeable via `%environment` section on
+- Make `PS1` environment variable changeable via `%environment` section on
   definition file that used to be only changeable via `APPTAINERENV_PS1`
   outside of container. This makes container's prompt customizable.
 - When the kernel supports unprivileged overlay mounts in a user
   namespace, the container will be constructed using an overlay
   instead of underlay layout.
+- Add helpful error message for build `--remote` option.
 
 ### New features / functionalities
 

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -11,6 +11,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -49,6 +50,7 @@ var buildArgs struct {
 	ignoreSubuid      bool // Ignore /etc/subuid entries (hidden)
 	ignoreFakerootCmd bool // Ignore fakeroot command (hidden)
 	ignoreUserns      bool // Ignore user namespace(hidden)
+	remote            bool // Remote flag(hidden, only for helpful error message)
 }
 
 // -s|--sandbox
@@ -273,6 +275,16 @@ var buildIgnoreUsernsFlag = cmdline.Flag{
 	Hidden:       true,
 }
 
+var buildRemoteFlag = cmdline.Flag{
+	ID:           "remoteFlag",
+	Value:        &buildArgs.remote,
+	DefaultValue: false,
+	Name:         "remote",
+	Usage:        "--remote is no longer supported, try building locally without it",
+	EnvKeys:      []string{},
+	Hidden:       true,
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(buildCmd)
@@ -311,6 +323,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&buildIgnoreSubuidFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildIgnoreFakerootCommand, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildIgnoreUsernsFlag, buildCmd)
+		cmdManager.RegisterFlagForCmd(&buildRemoteFlag, buildCmd)
 	})
 }
 
@@ -338,6 +351,11 @@ func preRun(cmd *cobra.Command, args []string) {
 			sylog.Verbosef("Implying --fakeroot because building from Deffile file unprivileged")
 			fakerootExec(isDeffile)
 		}
+	}
+
+	if buildArgs.remote {
+		err := errors.New("--remote is no longer supported, try building locally without it")
+		cobra.CheckErr(err)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

Add helpful error message for build `--remote` option


### This fixes or addresses the following GitHub issues:

 - Fixes #947 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
