### PR TITLE
add more helpful error message when no library endpoint found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - When the kernel supports unprivileged overlay mounts in a user
   namespace, the container will be constructed using an overlay
   instead of underlay layout.
-- Add helpful error message for build `--remote` option.
 
 ### New features / functionalities
 
@@ -34,6 +33,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Fix the use of `fakeroot`, `faked`, and `libfakeroot.so` if they are not
   suffixed by `-sysv`, as is for instance the case on Gentoo Linux.
+- Add helpful error message for build `--remote` option.
+- Add more helpful error message when no library endpoint found.
 
 ## v1.1.4 - \[2022-12-12\]
 

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -845,7 +845,7 @@ func getLibraryClientConfig(uri string) (*libClient.Config, error) {
 		if endpoint.DefaultLibraryURI != "" {
 			sylog.Warningf("no default remote in use, falling back to default library: %s", endpoint.DefaultLibraryURI)
 		} else {
-			return nil, fmt.Errorf("no default remote with library client in use")
+			return nil, fmt.Errorf("no default remote with library client in use (see https://apptainer.org/docs/user/latest/endpoint.html#no-default-remote)")
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: jason yang <jasonyangshadow@gmail.com>

## Description of the Pull Request (PR):

Add more helpful error message when no library endpoint found.


### This fixes or addresses the following GitHub issues:

 - Fixes #955 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
