### PR TITLE
Remove reference to cryptsetup in mconfig

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -922,10 +922,6 @@ if [ "$verbose" = 1 ]; then
 else
 	echo "    - verbose: no"
 fi
-if test "${host}" = "unix" ; then
-	echo "      ---"
-	echo "    - cryptsetup: ${cryptsetup_path}"
-fi
 echo "      ---"
 echo "    - version: $package_version"
 


### PR DESCRIPTION
Remove reference to cryptsetup in mconfig, because it is searched for at runtime since #552.

- Fixes #950