### PR TITLE
Enable unprivileged apptainer command to work in a symlinked path

### DIFF
--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -338,12 +338,7 @@ echo "Creating bin/apptainer and bin/singularity"
 mkdir -p bin
 cat >bin/apptainer <<'!EOF!'
 #!/bin/bash
-HERE="${0%/*}"
-if [ "$HERE" = "." ]; then
-	HERE="$PWD"
-elif [[ "$HERE" != /* ]]; then
-	HERE="$PWD/$HERE"
-fi
+HERE="$(cd "${0%/*}" && /bin/pwd)"
 BASEPATH="${HERE%/*}"
 ARCH="$(uname -m)"
 if [ -z "$ARCH" ]; then


### PR DESCRIPTION
This changes the way the apptainer script installed by install-unprivileged.sh locates its own path, so it can work if the path includes symlinks.

- Fixes #960