### PR TITLE
Remove reference to cryptsetup in mconfig (release-1.1)

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -922,10 +922,6 @@ if [ "$verbose" = 1 ]; then
 else
 	echo "    - verbose: no"
 fi
-if test "${host}" = "unix" ; then
-	echo "      ---"
-	echo "    - cryptsetup: ${cryptsetup_path}"
-fi
 echo "      ---"
 echo "    - version: $package_version"
 


### PR DESCRIPTION
This cherry-picks #971 to the release-1.1 branch.