### PR TITLE
Allow apptainer command itself to be a symlink, not just parent

### DIFF
--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -390,7 +390,8 @@ echo "Creating bin/apptainer and bin/singularity"
 mkdir -p bin
 cat >bin/apptainer <<'!EOF!'
 #!/bin/bash
-HERE="$(cd "${0%/*}" && /bin/pwd)"
+ME="$(/usr/bin/realpath $0)"
+HERE="${ME%/*}"
 BASEPATH="${HERE%/*}"
 ARCH="$(uname -m)"
 if [ -z "$ARCH" ]; then


### PR DESCRIPTION
This allows the apptainer command created by tools/install-unprivileged to be a symlink, not just one of its parent directories.

- Fixes #1004