### PR TITLE
Preserve argument 0 of the starter with unprivileged install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
 - Add new Linux capabilities: `CAP_PERFMON`, `CAP_BPF`, `CAP_CHECKPOINT_RESTORE`.
 
+### Bug fixes
+
+- Restored the ability for running instances to be tracked when apptainer
+  is installed with tools/install-unprivileged.sh.  Instance tracking
+  depends on argument 0 of the starter, which was not getting preserved.
+
 ## v1.1.5 - \[2023-01-10\]
 
 - Update the rpm packaging to (a) move the Obsoletes of singularity to

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/apptainer/apptainer/pkg/syfs"
+	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
 const (
@@ -198,6 +199,7 @@ func (i *File) Delete() error {
 	if dir == "." {
 		dir = ""
 	}
+	sylog.Debugf("Deleting %v", dir)
 	return os.RemoveAll(dir)
 }
 
@@ -239,6 +241,7 @@ func (i *File) Update() error {
 		return err
 	}
 
+	sylog.Debugf("Storing instance data to %s", i.Path)
 	path := filepath.Dir(i.Path)
 
 	oldumask := syscall.Umask(0)

--- a/internal/pkg/util/starter/starter.go
+++ b/internal/pkg/util/starter/starter.go
@@ -108,7 +108,11 @@ func Run(name string, config *config.Common, ops ...CommandOp) error {
 
 	cmd := exec.Command(c.path)
 	cmd.Args = []string{name}
-	cmd.Env = c.env
+	// Add this variable in case there's a relocating wrapper script,
+	// because arg0 cannot get passed through a #!/bin/bash shebang
+	arg0 := "_WRAPPER_ARG0=" + name
+	sylog.Debugf("Adding to env: %s", arg0)
+	cmd.Env = append(c.env, arg0)
 	cmd.Stdin = c.stdin
 	cmd.Stdout = c.stdout
 	cmd.Stderr = c.stderr

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -347,7 +347,7 @@ mv tmp/usr/bin/fuse-overlayfs tmp/usr/*bin/fuse2fs tmp/usr/*bin/*squashfs utils/
 mv tmp/usr/bin/fake*sysv utils/bin
 cat >utils/bin/.wrapper <<'!EOF!'
 #!/bin/bash
-ME=${0##*/}
+BASEME=${0##*/}
 HERE="${0%/*}"
 if [ "$HERE" = "." ]; then
 	HERE="$PWD"
@@ -355,8 +355,10 @@ elif [[ "$HERE" != /* ]]; then
 	HERE="$PWD/$HERE"
 fi
 PARENT="${HERE%/*}"
-#_WRAPPER_EXEC_CMD is sometimes used by apptainer
-LD_LIBRARY_PATH=$PARENT/lib ${_WRAPPER_EXEC_CMD:-exec} $PARENT/libexec/$ME "$@"
+#_WRAPPER_EXEC_CMD and _WRAPPER_ARG0 are sometimes used by apptainer
+REALME=$PARENT/libexec/$BASEME
+ARG0="${_WRAPPER_ARG0:-$REALME}"
+LD_LIBRARY_PATH=$PARENT/lib ${_WRAPPER_EXEC_CMD:-exec -a "$ARG0"} $REALME "$@"
 !EOF!
 chmod +x utils/bin/.wrapper
 for TOOL in utils/libexec/*; do
@@ -368,7 +370,7 @@ rm -rf tmp
 mkdir libexec/apptainer/libexec
 cat >libexec/apptainer/bin/.wrapper <<'!EOF!'
 #!/bin/bash
-ME=${0##*/}
+BASEME=${0##*/}
 HERE="${0%/*}"
 if [ "$HERE" = "." ]; then
 	HERE="$PWD"
@@ -377,7 +379,9 @@ elif [[ "$HERE" != /* ]]; then
 fi
 PARENT="${HERE%/*}"
 GGPARENT="${PARENT%/*/*}"
-LD_LIBRARY_PATH=$GGPARENT/utils/lib ${_WRAPPER_EXEC_CMD:-exec} $PARENT/libexec/$ME "$@"
+REALME=$PARENT/libexec/$BASEME
+ARG0="${_WRAPPER_ARG0:-$REALME}"
+LD_LIBRARY_PATH=$GGPARENT/utils/lib ${_WRAPPER_EXEC_CMD:-exec -a "$ARG0"} $REALME "$@"
 !EOF!
 chmod +x libexec/apptainer/bin/.wrapper
 for TOOL in libexec/apptainer/bin/*; do


### PR DESCRIPTION
This makes sure that argument 0 gets preserved for the starter when apptainer is installed with tools/unprivileged.sh.  It's not trivial because the `#!/bin/bash` shebang loses the original argument 0.  Argument 0 is needed because it is used as part of the instance list mechanism, plus it's just helpful when doing a `ps`.

- Fixes #1002 