### PR TITLE
Fix `GOCACHE` environment variable settings when building debian source  package on PPA build environment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes Since Last Release
 
-### Changed defaults / behaviours
+### Bug fixes
 
 - Fix `GOCACHE` environment variable settings when building debian source
   package on PPA build environment.
 - Make `PS1` environment variable changeable via `%environment` section on
   definition file that used to be only changeable via `APPTAINERENV_PS1`
   outside of container. This makes container's prompt customizable.
+
+### Changed defaults / behaviours
+
 - When the kernel supports unprivileged overlay mounts in a user
   namespace, the container will be constructed using an overlay
   instead of underlay layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Changed defaults / behaviours
 
+- Fix `GOCACHE` environment variable settings when building debian source
+  package on PPA build environment.
 - Make `PS1` environment variable changeable via `%environment` section on
   definition file that used to be only changeable via `APPTAINERENV_PS1`
   outside of container. This makes container's prompt customizable.

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -23,12 +23,7 @@ endif
 # For locally compiled go
 MINGO_VERSION = $(shell scripts/get-min-go-version)
 GOROOT = $${TMPDIR:-/tmp}/appdebgo/go
-
-ifdef TMPDIR
-export GOCACHE=$(TMPDIR)/appdebgo/cache
-else
-export GOCACHE=/tmp/appdebgo/cache
-endif
+GOCACHE = $${TMPDIR:-/tmp}/appdebgo/cache
 
 # get version via script
 SC_VERSION = $(shell scripts/get-version )
@@ -97,8 +92,8 @@ endif
 		--mandir=/usr/share/man
 
 override_dh_auto_build:
-	mkdir -p $(GOCACHE)
-	@PATH=$(GOROOT)/bin:$$PATH dh_auto_build -Smakefile --parallel --max-parallel=$(MAKEPARALLEL) -D$(DEB_SC_BUILDDIR)
+	@mkdir -p $(GOCACHE)
+	@PATH=$(GOROOT)/bin:$$PATH GOCACHE=$(GOCACHE) dh_auto_build -Smakefile --parallel --max-parallel=$(MAKEPARALLEL) -D$(DEB_SC_BUILDDIR)
 
 override_dh_auto_install:
 	@dh_auto_install -Smakefile -D$(DEB_SC_BUILDDIR)

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -91,6 +91,7 @@ endif
 		--mandir=/usr/share/man
 
 override_dh_auto_build:
+	mkdir -p /tmp/.cache/go-build ; export GOCACHE=/tmp/.cache/go-build
 	@PATH=$(GOROOT)/bin:$$PATH dh_auto_build -Smakefile --parallel --max-parallel=$(MAKEPARALLEL) -D$(DEB_SC_BUILDDIR)
 
 override_dh_auto_install:

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -24,6 +24,12 @@ endif
 MINGO_VERSION = $(shell scripts/get-min-go-version)
 GOROOT = $${TMPDIR:-/tmp}/appdebgo/go
 
+ifdef TMPDIR
+export GOCACHE=$(TMPDIR)/appdebgo/cache
+else
+export GOCACHE=/tmp/appdebgo/cache
+endif
+
 # get version via script
 SC_VERSION = $(shell scripts/get-version )
 NEW_VERSION = $(shell dpkg --compare-versions $(SC_VERSION) gt $(pkgver) && echo $(SC_VERSION) )
@@ -91,7 +97,7 @@ endif
 		--mandir=/usr/share/man
 
 override_dh_auto_build:
-	mkdir -p /tmp/.cache/go-build ; export GOCACHE=/tmp/.cache/go-build
+	mkdir -p $(GOCACHE)
 	@PATH=$(GOROOT)/bin:$$PATH dh_auto_build -Smakefile --parallel --max-parallel=$(MAKEPARALLEL) -D$(DEB_SC_BUILDDIR)
 
 override_dh_auto_install:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Set GOCACHE environment variable to prevent build error on PPA build environment

This Fix #1009
This creates `GOCACHE` directory on `/tmp` and export `GOCACHE` variable.

Signed-off-by: Yoshiaki Senda <yoshiaki@live.it>

### This fixes or addresses the following GitHub issues:

 - Fixes #1009 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
