### PR TITLE
Update basechecks.chk

### DIFF
--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -79,6 +79,9 @@ if [ $do_go_version_check = 0 ]; then
 	fi
 elif [ "$hstgo" = "" ]; then
 	printf " checking: host Go compiler (at least version $hstgo_version)... "
+	if [ "$hstgo_opts" = "" ]; then
+		echo "\$hstgo_opts is undefined! Cannot check host Go compiler."
+	fi
 	for go in $hstgo_opts; do
 		if $makeit_scriptsdir/check-min-go-version $go $hstgo_version >/dev/null 2>&1; then
 			hstgo=`command -v $go`

--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -92,12 +92,17 @@ elif [ "$hstgo" = "" ]; then
 	if [ "$hstgo" != "" ]; then
 		echo $hstgo
 	else
-		echo "not found!"
+        # check-min-go-version has failed for each of $hstgo_opts
+        for go in $hstgo_opts; do
+            # print error message
+            echo "$($makeit_scriptsdir/check-min-go-version $go $hstgo_version)"
+        done
 		usage
 		exit 1
 	fi
 else
 	printf " checking: host Go compiler (at least version $hstgo_version)... "
+    go_check_result=$($makeit_scriptsdir/check-min-go-version $go $hstgo_version)
 	if $makeit_scriptsdir/check-min-go-version $go $hstgo_version >/dev/null 2>&1; then
 		hstgo=`command -v $hstgo`
 		echo $hstgo

--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -81,6 +81,7 @@ elif [ "$hstgo" = "" ]; then
 	printf " checking: host Go compiler (at least version $hstgo_version)... "
 	if [ "$hstgo_opts" = "" ]; then
 		echo "\$hstgo_opts is undefined! Cannot check host Go compiler."
+		exit 1
 	fi
 	for go in $hstgo_opts; do
 		if $makeit_scriptsdir/check-min-go-version $go $hstgo_version >/dev/null 2>&1; then

--- a/mlocal/scripts/check-min-go-version
+++ b/mlocal/scripts/check-min-go-version
@@ -4,10 +4,13 @@ if [ $# != 2 ]; then
     echo "  min_go_version can be either of form x.y or x.y.z" >&2
     exit 1
 fi
-
-GOVERSION="$($1 version)"
+GOVERSION="$($1 version 2> /dev/null)"
 GOVERSION="${GOVERSION//go version go/}"
 GOVERSION="${GOVERSION// *}"
+if [ -z "$GOVERSION" ]; then
+    echo "$1 not found!"
+    exit 1
+fi
 # GOVERSION can also be either form x.y or x.y.z
 GOMAJOR="${GOVERSION/.*}"
 GOMINOR="${GOVERSION#*.}"
@@ -34,12 +37,14 @@ else
 fi
 
 if [ "$GOMAJOR" -lt "$MINMAJOR" ]; then
+    echo "found go $GOVERSION does not meet minimum requirement $MINVERSION!"
     exit 1
 fi
 if [ "$GOMAJOR" -gt "$MINMAJOR" ]; then
     exit 0
 fi
 if [ "$GOMINOR" -lt "$MINMINOR" ]; then
+    echo "found go $GOVERSION does not meet minimum requirement $MINVERSION!"
     exit 1
 fi
 if [ "$GOMINOR" -gt "$MINMINOR" ]; then
@@ -49,9 +54,11 @@ if [ -z "$MINPATCH" ]; then
     exit 0
 fi
 if [ -z "$GOPATCH" ]; then
+    echo "found go $GOVERSION does not meet minimum requirement $MINVERSION!"
     exit 1
 fi
 if [ "$GOPATCH" -lt "$MINPATCH" ]; then
+    echo "found go $GOVERSION does not meet minimum requirement $MINVERSION!"
     exit 1
 fi
 exit 0


### PR DESCRIPTION
## Description of the Pull Request (PR):

`echo "not found!"` assumes that `command -v $go` came up empty. But if `$hstgo_opts` is undefined, `command -v $go` was never run, and no check has actually been conducted.

I think someone with more understanding should come up with a more descriptive error message. I've never used the go compiler, and I'm not experienced with autotools, but I'm confused by a couple things here:
* what's the difference between the 
* why `hstgo_opts` would ever be anything other than `"go"`
* why there should be a list of names that invoke the go compiler
* why a list of names that invoke the go compiler should be called `hstgo_opts`.
