### PR TITLE
Include fix for cve-2022-23538

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
 - Add new Linux capabilities: `CAP_PERFMON`, `CAP_BPF`, `CAP_CHECKPOINT_RESTORE`.
 
+### Security fix
+
+- Included a fix for [CVE-2022-23538](https://github.com/sylabs/scs-library-client/security/advisories/GHSA-7p8m-22h4-9pj7)
+  which potentially leaked user credentials to a third-party S3 storage
+  service when using the `library://` protocol.  See the link for details.
+
 ### Bug fixes
 
 - Restored the ability for running instances to be tracked when apptainer

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60
 	github.com/apex/log v1.9.0
 	github.com/apptainer/container-key-client v0.8.0
-	github.com/apptainer/container-library-client v1.4.1
+	github.com/apptainer/container-library-client v1.4.2
 	github.com/apptainer/sif/v2 v2.9.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/buger/goterm v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/apptainer/container-key-client v0.8.0 h1:K181Zrejb53mR2YQZwCathSj8YReCen+Wi2YuBxGH60=
 github.com/apptainer/container-key-client v0.8.0/go.mod h1:wMeJdiMXlPRiwJfUyae2WRHsZlHG9Af6iPQ9TZcBnS8=
-github.com/apptainer/container-library-client v1.4.1 h1:pBfmTiEN9kKWZrq1pGNfxf3zKtPCdyO6diIiearQAyI=
-github.com/apptainer/container-library-client v1.4.1/go.mod h1:EA5bDsL/dxzAxFh3zBszSdVpB25wIwv/66M1qLOzrNU=
+github.com/apptainer/container-library-client v1.4.2 h1:VXSvOQKMPviIIj8zvXBOlLU91f1PDv1KRRzgnLIdnQs=
+github.com/apptainer/container-library-client v1.4.2/go.mod h1:EA5bDsL/dxzAxFh3zBszSdVpB25wIwv/66M1qLOzrNU=
 github.com/apptainer/sif/v2 v2.9.0 h1:sWajVeb/PQIn99wi9rno9vKL/kAV84+0QrKhZMUfVQA=
 github.com/apptainer/sif/v2 v2.9.0/go.mod h1:tlSjSpxEVX3vUMhV4oc637Tvku/vubsTdkkIlH26rRo=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=


### PR DESCRIPTION
This updates to container-library-client v1.4.2.

- Fixes #1052 