### PR TITLE
feat: Set APPTAINER_INSTANCE equal to instance name, from sylabs 1182

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Support for `DOCKER_HOST` parsing when using `docker-daemon://`
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
 - Add new Linux capabilities: `CAP_PERFMON`, `CAP_BPF`, `CAP_CHECKPOINT_RESTORE`.
+- Instance name is available inside an instance via the new
+  `APPTAINER_INSTANCE` environment variable.
 
 ### Bug fixes
 

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -148,6 +148,12 @@ func (c *ctx) testBasicOptions(t *testing.T) {
 				t.Errorf("Hostname is %s, but expected %s", stdout, testHostname)
 			}
 
+			// Verify that the APPTAINER_INSTANCE has been set correctly.
+			stdout, _, success = c.execInstance(t, instanceName, "sh", "-c", "echo $APPTAINER_INSTANCE")
+			if success && !bytes.Equal([]byte(instanceName+"\n"), []byte(stdout)) {
+				t.Errorf("APPTAINER_INSTANCE is %s, but expected %s", stdout, instanceName)
+			}
+
 			// Stop the instance.
 			c.stopInstance(t, instanceName)
 		}),

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -333,6 +333,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 
 	// Setup instance specific configuration if required.
 	if instanceName != "" {
+		l.generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "INSTANCE", instanceName)
 		l.cfg.Namespaces.PID = true
 		l.engineConfig.SetInstance(true)
 		l.engineConfig.SetBootInstance(l.cfg.Boot)
@@ -486,6 +487,7 @@ func (l *Launcher) setImageOrInstance(image string, name string) error {
 		l.cfg.Namespaces.User = file.UserNs
 		l.generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "CONTAINER", file.Image)
 		l.generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "NAME", filepath.Base(file.Image))
+		l.generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "INSTANCE", instanceName)
 		l.engineConfig.SetImage(image)
 		l.engineConfig.SetInstanceJoin(true)
 

--- a/internal/pkg/util/fs/files/action_script.sh
+++ b/internal/pkg/util/fs/files/action_script.sh
@@ -42,7 +42,7 @@ clear_env() {
         case "${key}" in
         PWD|HOME|OPTIND|UID|GID|SINGULARITY_APPNAME|SINGULARITY_SHELL)
             ;;
-        APPTAINER_NAME|APPTAINER_CONTAINER)
+        APPTAINER_NAME|APPTAINER_CONTAINER|APPTAINER_INSTANCE)
             readonly "${key}"
             ;;
         *)


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1182
 which fixed
- sylabs/singularity#1132

The original PR description was:
> Inside an instance, expose the instance name as the environment variable `SINGULARITY_INSTANCE`.