### PR TITLE
rocm: fixups, from sylabs 1181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Added `Provides: bundled(golang())` statements to the rpm packaging
   for each bundled golang module.
 - Define EUID in %environment alongside UID.
+- In `--rocm` mode, the whole of `/dev/dri` is now bound into the container when
+  `--contain` is in use. This makes `/dev/dri/render` devices available,
+  required for later ROCm versions.
 
 ## v1.1.5 - \[2023-01-10\]
 

--- a/etc/rocmliblist.conf
+++ b/etc/rocmliblist.conf
@@ -26,6 +26,8 @@ libmcwamp_cpu.so
 libmcwamp_hsa.so
 libmiopengemm.so
 libMIOpen.so
+libdrm.so
+libdrm_amdgpu.so
 libnuma.so
 libpci.so
 librccl.so

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -1509,7 +1509,7 @@ func (c *container) addDevMount(system *mount.System) error {
 		}
 
 		if c.engine.EngineConfig.GetRocm() {
-			devs, err := gpu.RocmDevices(true)
+			devs, err := gpu.RocmDevices()
 			if err != nil {
 				return fmt.Errorf("failed to get rocm devices: %v", err)
 			}


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity#1181
 which fixed
- sylabs/singularity#1034

The original PR description was:
> A selection of ROCm fixes and addition of --oci support. Am including all in a single PR to minimize amount of work needed testing on a ROCm enabled system.
> 
> * In `--oci` mode ensure user and group entries written to container passwd / group files. Required to proceed with ROCm stuff. 
> * When binding ROCm devices with --contain in effect, we were only taking /dev/dri/cardxxx and /dev/kfd. At least some circumstances also require /dev/dri. Bind the whole of /dev/dri, just like the AMD ROCm container documentation for Docker does.
> * Under --oci mode, allow --rocm, which will bind ROCm devices, libraries, and binaries into the container.
> * e2e: minimal --rocm --oci test
> * fix: rocm: update rocmliblist and fix e2e tests -`rocminfo` now needs `lsmod` and libdrm libdrm_amdgpu. Bind the former in tests, the libraries from rocmliblist.conf. We can now use Ubuntu 22.04 for ROCm tests.
> 
> 
> You may need to trust me that this works :-) Here's the output on a Fedora 37 machine with a ROCm supported GPU:
> 
> ```
> $ make -C builddir e2e-test E2E_GROUPS=GPU
> ...
> --- PASS: TestE2E (28.26s)
>     --- PASS: TestE2E/PAR (0.00s)
>         --- PASS: TestE2E/PAR/GPU (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/build_nvidia (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/build_nvccli (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/nvccli (0.00s)
>             --- SKIP: TestE2E/PAR/GPU/nvidia (0.00s)
>             --- PASS: TestE2E/PAR/GPU/rocm (17.42s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/User (0.20s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/UserContain (0.18s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/UserNamespace (1.56s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/Fakeroot (0.55s)
>                 --- PASS: TestE2E/PAR/GPU/rocm/Root (0.18s)
>             --- PASS: TestE2E/PAR/GPU/build_rocm (21.48s)
>                 --- PASS: TestE2E/PAR/GPU/build_rocm/WithRocmRoot (1.31s)
>                 --- PASS: TestE2E/PAR/GPU/build_rocm/WithRocmFakeroot (1.71s)
>                 --- PASS: TestE2E/PAR/GPU/build_rocm/WithoutRocmRoot (1.14s)
>                 --- PASS: TestE2E/PAR/GPU/build_rocm/WithoutRocmFakeroot (2.19s)
>             --- PASS: TestE2E/PAR/GPU/oci_rocm (25.08s)
>                 --- PASS: TestE2E/PAR/GPU/oci_rocm/OCIUser (13.37s)
>                 --- PASS: TestE2E/PAR/GPU/oci_rocm/OCIFakeroot (3.84s)
>                 --- PASS: TestE2E/PAR/GPU/oci_rocm/OCIRoot (7.84s)
> ```