### PR TITLE
feat: reproducible build (SOURCEDIR / BUILDDIR), from sylabs 1196

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - When the kernel supports unprivileged overlay mounts in a user
   namespace, the container will be constructed using an overlay
   instead of underlay layout.
+- A new `--reproducible` flag for `./mconfig` will configure Apptainer so that
+  its binaries do not contain non-reproducible paths. This disables plugin
+  functionality.
 
 ### New features / functionalities
 

--- a/internal/app/apptainer/plugin_compile_linux.go
+++ b/internal/app/apptainer/plugin_compile_linux.go
@@ -45,6 +45,10 @@ type buildToolchain struct {
 
 // getApptainerSrcDir returns the source directory for apptainer.
 func getApptainerSrcDir() (string, error) {
+	if buildcfg.IsReproducibleBuild() {
+		return "", fmt.Errorf("plugin functionality is not available in --reproducible builds of apptainer")
+	}
+
 	dir := buildcfg.SOURCEDIR
 	canary := filepath.Join(dir, canaryFile)
 	sylog.Debugf("Searching source file %s", canary)

--- a/internal/pkg/buildcfg/confgen/gen.go
+++ b/internal/pkg/buildcfg/confgen/gen.go
@@ -193,6 +193,10 @@ func relocatePath(original string) string {
 {{ range $i, $d := .Defines }}
 {{$d.WriteLine -}}
 {{end}}
+
+func IsReproducibleBuild() bool {
+	return SOURCEDIR == "REPRODUCIBLE_BUILD"
+}
 `))
 
 func main() {

--- a/internal/pkg/plugin/create.go
+++ b/internal/pkg/plugin/create.go
@@ -59,6 +59,10 @@ const gitIgnore = `apptainer_source
 // Create creates a skeleton plugin directory structure
 // to start development of a new plugin.
 func Create(path, name string) error {
+	if buildcfg.IsReproducibleBuild() {
+		return fmt.Errorf("plugin functionality is not available in --reproducible builds of apptainer")
+	}
+
 	dir, err := filepath.Abs(path)
 	if err != nil {
 		return fmt.Errorf("could not determine absolute path for %s: %s", path, err)

--- a/internal/pkg/plugin/module.go
+++ b/internal/pkg/plugin/module.go
@@ -153,6 +153,10 @@ func GetModules(dir string) (*GoMod, error) {
 func PrepareGoModules(pluginDir string, disableMinorCheck bool) ([]byte, error) {
 	var goMod bytes.Buffer
 
+	if buildcfg.IsReproducibleBuild() {
+		return nil, fmt.Errorf("plugin functionality is not available in --reproducible builds of apptainer")
+	}
+
 	singModules, err := GetModules(buildcfg.SOURCEDIR)
 	if err != nil {
 		return nil, fmt.Errorf("while getting Apptainer Go modules: %s", err)

--- a/mconfig
+++ b/mconfig
@@ -88,6 +88,7 @@ libdir=
 localedir=
 mandir=
 
+reproducible=0
 
 usage () {
 	echo "${0##*/}: could not complete configuration"
@@ -145,6 +146,11 @@ usage_args () {
 	echo "     --libdir         install libraries in \`libdir'"
 	echo "     --localedir      install locale dependent data in \`localedir'"
 	echo "     --mandir         install man documentation in \`mandir'"
+  echo
+  echo "  Reproducible builds:"
+  echo "     --reproducible   set reproducible SOURCEDIR & BUILDDIR values in binaries."
+  echo "                      This will disable plugin build functionality."
+
 	echo
 }
 
@@ -377,6 +383,8 @@ while [ $# -ne 0 ]; do
    with_seccomp_check=0; shift;;
   --only-rpm)
    do_go_version_check=0; shift;;
+  --reproducible)
+   reproducible=1; shift;;
   -V)
    if ! echo "$2" | awk '/^-.*/ || /^$/ { exit 2 }'; then
      echo "error: option requires an argument: $1"

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -16,8 +16,14 @@ config_add_def PACKAGE_VERSION \"$package_version\"
 config_add_def PACKAGE_STRING \"apptainer $package_version\"
 config_add_def PACKAGE_URL \"\"
 
-config_add_def BUILDDIR \"$builddir\"
-config_add_def SOURCEDIR \"$sourcedir\"
+if [ "$reproducible" == "1" ]; then
+   config_add_def BUILDDIR \"REPRODUCIBLE_BUILD\"
+   config_add_def SOURCEDIR \"REPRODUCIBLE_BUILD\"
+else
+   config_add_def SOURCEDIR \"$sourcedir\"
+   config_add_def BUILDDIR \"$builddir\"
+fi
+
 config_add_def PREFIX \"$prefix\"
 config_add_def EXECPREFIX \"$exec_prefix\"
 config_add_def BINDIR \"$bindir\"


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity#1196
 which fixed
- sylabs/singularity#1173

The original PR description was:
> Add a `--reproducible` flag for mconfig. This will set BUILDDIR and SOURCEDIR in the buildcfg package to a literal `REPRODUCIBLE_BUILD`, so that binaries do not contain the paths to the source.
> 
> Disables pluign functionality, which needs the source path for in-tree plugin builds.