### PR TITLE
Print warning if args to shell command, add args in run command help (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   for each bundled golang module.
 - Hide messages about SINGULARITY variables if corresponding APPTAINER
   variables are defined. Fixes a regression introduced in 1.1.4.
+- Print a warning if extra arguments are given to a shell action, and
+  show in the run action usage that arguments may be passed.
 
 ## v1.1.5 - \[2023-01-10\]
 

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -207,6 +207,10 @@ var ShellCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	PreRun:                actionPreRun,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 1 {
+			sylog.Warningf("Parameters to shell command are ignored")
+		}
+
 		a := []string{"/.singularity.d/actions/shell"}
 		setVM(cmd)
 		if VM {

--- a/docs/content.go
+++ b/docs/content.go
@@ -676,7 +676,7 @@ Enterprise Performance Computing (EPC)`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// run
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	RunUse   string = `run [run options...] <container>`
+	RunUse   string = `run [run options...] <container> [args...]`
 	RunShort string = `Run the user-defined default command within a container`
 	RunLong  string = `
   This command will launch an Apptainer container and execute a runscript


### PR DESCRIPTION
This cherry-picks #1079 to the release-1.1 branch.