### PR TITLE
Increase image driver mount timeout from 2 to 10 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Check for the existence of the runtime executable prefix, to avoid
   issues when running under Slurm's srun. If it doesn't exist, fall
   back to the compile-time prefix.
+- Increase the timeout on image driver (that is, FUSE) mounts from 2
+  seconds to 10 seconds.  Instead, print an INFO message if it takes
+  more than 2 seconds.
 
 ## v1.1.5 - \[2023-01-10\]
 

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -295,7 +295,8 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 	}
 
 	f.instances = append(f.instances, fuseappsInstance{cmd, params})
-	maxTime := 2 * time.Second
+	maxTime := 10 * time.Second
+	infoTime := 2 * time.Second
 	totTime := 0 * time.Second
 	for totTime < maxTime {
 		sleepTime := 25 * time.Millisecond
@@ -331,7 +332,11 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 				// Haven't seen this happen, but just in case
 				sylog.Infof("%v", msg)
 			}
-			sylog.Debugf("%v mounted in %v", params.Target, totTime)
+			if totTime > infoTime {
+				sylog.Infof("%v mount took an unexpectedly long time: %v", f.binName, totTime)
+			} else {
+				sylog.Debugf("%v mounted in %v", params.Target, totTime)
+			}
 			if params.Filesystem == "overlay" && os.Getuid() == 0 {
 				// Look for unexpectedly readonly overlay
 				hasUpper := false
@@ -362,7 +367,11 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 		}
 	}
 	f.stop(params.Target, true)
-	return fmt.Errorf("%v failed to mount %v in %v: %v", f.binName, params.Target, maxTime, stderr.String())
+	errmsg := stderr.String()
+	if errmsg != "" {
+		errmsg = ": " + errmsg
+	}
+	return fmt.Errorf("%v failed to mount %v in %v%v", f.binName, params.Target, maxTime, errmsg)
 }
 
 func (d *fuseappsDriver) Start(params *image.DriverParams, containerPid int) error {


### PR DESCRIPTION
This increases the maximum time allowed to mount an image driver fuse filesystem from 2 to 10 seconds, but prints a message if it goes over 2 seconds.

- Fixes #1033 