### PR TITLE
Check for existence of runtime execPrefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   variables are defined. Fixes a regression introduced in 1.1.4.
 - Print a warning if extra arguments are given to a shell action, and
   show in the run action usage that arguments may be passed.
+- Check for the existence of the runtime executable prefix, to avoid
+  issues when running under Slurm's srun. If it doesn't exist, fall
+  back to the compile-time prefix.
 
 ## v1.1.5 - \[2023-01-10\]
 

--- a/internal/pkg/buildcfg/confgen/gen.go
+++ b/internal/pkg/buildcfg/confgen/gen.go
@@ -96,6 +96,14 @@ func getPrefix() (string) {
 			return
 		}
 
+		_, err = os.Stat(executablePath)
+		if err != nil {
+			// Due to mount namespace issues, os.Executable may return a non-existing
+			// location
+			installPrefix = "{{.Prefix}}"
+			return
+		}
+
 		bin := filepath.Dir(executablePath)
 		base := filepath.Base(executablePath)
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Check for the existence of the runtime executable prefix, to avoid issues when running under Slurm's srun. If it doesn't exist, fall back to the compile-time prefix.

### This fixes or addresses the following GitHub issues:

 - Fixes #1061 (with some caveats, but this check doesn't hurt).


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
