### PR TITLE
Show info message instead of fatal error for name collision between global and individual remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Increase the timeout on image driver (that is, FUSE) mounts from 2
   seconds to 10 seconds.  Instead, print an INFO message if it takes
   more than 2 seconds.
+- If a `remote` is defined both globally (i.e. system-wide) and
+  individually, change `apptainer remote` commands to print an info message
+  instead of exiting with a fatal error and to give precedence to the
+  individual configuration.
 
 ## v1.1.5 - \[2023-01-10\]
 

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -104,13 +104,12 @@ func (c *Config) WriteTo(w io.Writer) (int64, error) {
 
 // SyncFrom updates c with the remotes specified in sys. Typically, this is used
 // to sync a globally-configured remote.Config into a user-specific remote.Config.
-// Currently, SyncFrom will return a name-collision error if there is an EndPoint
-// name which exists in both c & sys, and the EndPoint in c has System == false.
 func (c *Config) SyncFrom(sys *Config) error {
 	for name, eSys := range sys.Remotes {
 		eUsr, err := c.GetRemote(name)
 		if err == nil && !eUsr.System { // usr & sys name collision
-			return fmt.Errorf("name collision while syncing: %s", name)
+			sylog.Infof("%s defined both globally and individually, using individual", name)
+			continue
 		} else if err == nil {
 			eUsr.URI = eSys.URI // update URI just in case
 			eUsr.Exclusive = eSys.Exclusive

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -346,39 +346,6 @@ func TestSyncFrom(t *testing.T) {
 			}
 		})
 	}
-
-	testsFail := []syncTest{
-		{
-			name: "sys endpoint collision",
-			sys: Config{
-				Remotes: map[string]*endpoint.Config{
-					"sylabs-global": {
-						URI:   "cloud.sycloud.io",
-						Token: "fake-token",
-					},
-				},
-			},
-			usr: Config{
-				Remotes: map[string]*endpoint.Config{
-					"sylabs": {
-						URI:   "cloud.sycloud.io",
-						Token: "fake-token",
-					},
-					"sylabs-global": {
-						URI: "cloud.sycloud.io",
-					},
-				},
-			},
-		},
-	}
-
-	for _, test := range testsFail {
-		t.Run(test.name, func(t *testing.T) {
-			if err := test.usr.SyncFrom(&test.sys); err == nil {
-				t.Error("unexpected success calling SyncFrom")
-			}
-		})
-	}
 }
 
 type remoteTest struct {


### PR DESCRIPTION
When the same remote name is defined both globally and individually, show an info message instead of causing a fatal error.

- Fixes #1018