### PR TITLE
fix: avoid readonly warnings with --env-file, from sylabs 1278

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Fix non-root instance join with unprivileged systemd managed cgroups, when
   join is from outside a user-owned cgroup.
+- Avoid UID / GID / EUID readonly var warnings with `--env-file`.
 
 ### Bug fixes
 

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -644,5 +644,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5057":               c.issue5057, // https://github.com/apptainer/singularity/issues/5057
 		"issue 5426":               c.issue5426, // https://github.com/apptainer/singularity/issues/5426
 		"issue 43":                 c.issue43,   // https://github.com/sylabs/singularity/issues/43
+		"issue 1263":               c.issue1263, // https://github.com/sylabs/singularity/issues/1263
 	}
 }

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -956,6 +956,11 @@ func (l *Launcher) setEnvVars(ctx context.Context, args []string) error {
 			e := strings.SplitN(envar, "=", 2)
 			if len(e) != 2 {
 				sylog.Warningf("Ignore environment variable %q: '=' is missing", envar)
+				continue
+			}
+			// Don't attempt to overwrite bash builtin readonly vars
+			// https://github.com/sylabs/singularity/issues/1263
+			if e[0] == "UID" || e[0] == "GID" || e[0] == "EUID" {
 				continue
 			}
 			// Ensure we don't overwrite --env variables with environment file


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1278
 which fixed
- sylabs/singularity#1263

The original PR description was:
> Ensure UID and GID values returned by running shell interpreter on the env-file are not used for container. They are read-only built-ins, and attempting to set them displays a confusing warning.