### PR TITLE
Fix GOCACHE settings for golang build on PPA build environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `--contain` is in use. This makes `/dev/dri/render` devices available,
   required for later ROCm versions.
 
+### Bug fixes
+
+- Fix `GOCACHE` settings for golang build on PPA build environment.
+
 ## v1.1.6 - \[2023-02-14\]
 
 ### Security fix

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -85,7 +85,7 @@ override_dh_auto_configure:
 	    cd $(GOROOT)/..; \
 	    tar -xf $$HERE/debian/go$(MINGO_VERSION).src.tar.gz; \
 	    cd go/src; \
-	    ./make.bash; \
+	    GOCACHE=$(GOCACHE) ./make.bash; \
 	  fi
 ifneq ($(NEW_VERSION),)
 	$(warning "Setting new version in debian changelog: $(NEW_VERSION)")
@@ -98,7 +98,6 @@ endif
 		--mandir=/usr/share/man
 
 override_dh_auto_build:
-	@mkdir -p $(GOCACHE)
 	@PATH=$(GOROOT)/bin:$$PATH GOCACHE=$(GOCACHE) dh_auto_build -Smakefile --parallel --max-parallel=$(MAKEPARALLEL) -D$(DEB_SC_BUILDDIR)
 
 override_dh_auto_install:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix GOCACHE settings for golang build on PPA build environment.
Add GOCACHE environment variable to golang build procedures on `dist/debian/rules`
Add entry to CHANGELOG

### This fixes or addresses the following GitHub issues:

 - Fixes #1106


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
