### PR TITLE
App instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Support for online verification checks of x509 certificates using OCSP protocol.
   (introduced flag: `verify --ocsp-verify`)
 - Support for unprivileged encryption of SIF files using gocryptfs.
+- The `instance start` command now accepts an optional `--app <name>` argument which
+  invokes start script within the `%appstart <name>` section in the definition file.
+  The `instance stop` command still only requires the instance name.
 
 ### Other changes
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -105,4 +105,5 @@
 - Pablo Caderno <kaderno@gmail.com>
 - Xu Yang <jasonyangshadow@gmail.com>
 - Charles Vejnar <charles.vejnar@gmail.com>
+- Carmelo Piccione <carmelo.piccione@gmail.com>
 ```

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -870,7 +870,7 @@ func init() {
 
 		cmdManager.RegisterFlagForCmd(&actionAddCapsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionAllowSetuidFlag, actionsInstanceCmd...)
-		cmdManager.RegisterFlagForCmd(&actionAppFlag, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionAppFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionApplyCgroupsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionBindFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionCleanEnvFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -312,7 +312,11 @@ func (c *command) setAttribute(section, value, file string) error {
 			c.metadata.Data.Attributes.Runscript = value
 		}
 	case "startscript":
-		c.metadata.Data.Attributes.Startscript = value
+		if app != "" {
+			c.metadata.Data.Attributes.Apps[app].Startscript = value
+		} else {
+			c.metadata.Data.Attributes.Startscript = value
+		}
 	case "environment":
 		if app != "" {
 			c.metadata.Data.Attributes.Apps[app].Environment[file] = value
@@ -461,7 +465,12 @@ func (c *command) addStartscriptCommand() {
 		return
 	}
 
-	if c.appName == "" {
+	if c.appName != "" {
+		if c.sifMetadata.Attributes.Apps[c.appName] != nil {
+			c.metadata.AddApp(c.appName)
+			c.metadata.Attributes.Apps[c.appName].Startscript = c.sifMetadata.Attributes.Apps[c.appName].Startscript
+		}
+	} else {
 		c.metadata.Attributes.Startscript = c.sifMetadata.Attributes.Startscript
 	}
 }
@@ -669,10 +678,8 @@ var InspectCmd = &cobra.Command{
 		}
 
 		if startscript || allData {
-			if appName == "" {
-				sylog.Debugf("Inspection of startscript selected.")
-				inspectCmd.addStartscriptCommand()
-			}
+			sylog.Debugf("Inspection of startscript selected.")
+			inspectCmd.addStartscriptCommand()
 		}
 
 		if testfile || allData {
@@ -724,6 +731,8 @@ var InspectCmd = &cobra.Command{
 			}
 			if inspectData.Data.Attributes.Startscript != "" {
 				fmt.Printf("%s\n", inspectData.Data.Attributes.Startscript)
+			} else if appAttr != nil && appAttr.Startscript != "" {
+				fmt.Printf("%s\n", appAttr.Startscript)
 			}
 			if inspectData.Data.Attributes.Test != "" {
 				fmt.Printf("%s\n", inspectData.Data.Attributes.Test)

--- a/docs/content.go
+++ b/docs/content.go
@@ -849,6 +849,7 @@ Enterprise Performance Computing (EPC)`
       SCIF_APPBIN        is the bin folder for the app, which is automatically added to the $PATH when the app is active
       SCIF_APPLIB        is the application's library folder that is added to the LD_LIBRARY_PATH
       SCIF_APPRUN        is the runscript
+      SCIF_APPSTART      is the startscript
       SCIF_APPHELP       is the help file for the runscript
       SCIF_APPTEST       is the testing script (test.sh) associated with the application
       SCIF_APPNAME       the name for the active application

--- a/e2e/internal/e2e/imagebuild.go
+++ b/e2e/internal/e2e/imagebuild.go
@@ -58,6 +58,7 @@ type AppDetail struct {
 	Files   []FilePair
 	Install []string
 	Run     []string
+	Start   []string
 	Test    []string
 }
 

--- a/e2e/internal/e2e/imageverify.go
+++ b/e2e/internal/e2e/imageverify.go
@@ -176,7 +176,11 @@ func DefinitionImageVerify(t *testing.T, cmdPath, imagePath string, dfd DefFileD
 	}
 
 	// Verify any apps
-	for _, app := range dfd.Apps {
+	appDetailImageVerify(t, cmdPath, imagePath, dfd.Apps)
+}
+
+func appDetailImageVerify(t *testing.T, cmdPath, imagePath string, apps []AppDetail) {
+	for _, app := range apps {
 		// %apphelp
 		if app.Help != nil {
 			helpPath := filepath.Join(imagePath, `/scif/apps/`, app.Name, `/scif/runscript.help`)
@@ -229,6 +233,18 @@ func DefinitionImageVerify(t *testing.T, cmdPath, imagePath string, dfd DefFileD
 			}
 
 			if err := verifyScript(t, scriptPath, app.Run); err != nil {
+				t.Fatalf("unexpected failure in app %v: runscript: %v", app.Name, err)
+			}
+		}
+
+		// %appStart
+		if app.Start != nil {
+			scriptPath := filepath.Join(imagePath, "/scif/apps/", app.Name, "scif/startscript")
+			if !fs.IsFile(scriptPath) {
+				t.Fatalf("unexpected failure in app %v: Script %v does not exist in app", app.Name, scriptPath)
+			}
+
+			if err := verifyScript(t, scriptPath, app.Start); err != nil {
 				t.Fatalf("unexpected failure in app %v: runscript: %v", app.Name, err)
 			}
 		}

--- a/e2e/testdata/Apptainer
+++ b/e2e/testdata/Apptainer
@@ -57,6 +57,10 @@ export HELLOTHISIS
 %apprun foo
     echo "RUNNING FOO"
 
+%appstart foo
+    echo "STARTING FOO"
+    exec nc -l -k -p $1 -e /bin/cat
+
 %startscript
     exec nc -l -k -p $1 -e /bin/cat
 

--- a/e2e/testdata/deffile.tmpl
+++ b/e2e/testdata/deffile.tmpl
@@ -146,6 +146,13 @@ Stage: {{.Stage}}
     {{$l}}
 {{- end}}
 
+{{- if $app.Start}}
+%apprun {{$app.Name}}
+{{- end}}
+{{- range $l := $app.Start}}
+    {{$l}}
+{{- end}}
+
 {{- if $app.Test}}
 %apptest {{$app.Name}}
 {{- end}}

--- a/e2e/testdata/inspector_container.def
+++ b/e2e/testdata/inspector_container.def
@@ -37,6 +37,9 @@ exec "$@"
 %apprun hello
 echo "hello"
 
+%appstart hello
+exec "$@"
+
 %apphelp hello
 This is the help for hello!
 

--- a/examples/instances/Apptainer
+++ b/examples/instances/Apptainer
@@ -3,3 +3,7 @@ From: ghcr.io/apptainer/busybox:1.31.1
 
 %startscript
     exec nc -ll -p $1 -e /bin/cat 2>/dev/null
+
+%appstart foo
+    echo "STARTING FOO"
+    exec nc -ll -p $1 -e /bin/cat 2>/dev/null

--- a/internal/pkg/util/fs/files/action_script.sh
+++ b/internal/pkg/util/fs/files/action_script.sh
@@ -208,7 +208,15 @@ test)
     sylog info "No test script found in container, exiting"
     exit 0 ;;
 start)
-    if test -x "/.singularity.d/startscript"; then
+    if test -n "${SINGULARITY_APPNAME:-}"; then
+        if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/startscript"; then
+            exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/startscript" "$@"
+		elif test -x "/scif/apps/singularity/scif/test"; then
+            exec "/scif/apps/singularity/scif/test" "$@"
+        fi
+        sylog error "No startscript for contained app: ${SINGULARITY_APPNAME:-}"
+        exit 1
+    elif test -x "/.singularity.d/startscript"; then
         exec "/.singularity.d/startscript" "$@"
     fi
 

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -567,6 +567,7 @@ var appSections = map[string]bool{
 	"apptest":    true,
 	"apphelp":    true,
 	"apprun":     true,
+	"appstart":   true,
 }
 
 // validHeaders just contains a list of all the valid headers a definition file

--- a/pkg/inspect/metadata.go
+++ b/pkg/inspect/metadata.go
@@ -17,6 +17,7 @@ type AppAttributes struct {
 	Environment map[string]string `json:"environment,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Runscript   string            `json:"runscript,omitempty"`
+	Startscript string            `json:"startscript,omitempty"`
 	Test        string            `json:"test,omitempty"`
 	Helpfile    string            `json:"helpfile,omitempty"`
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Introduces an optional `--app` argument to the `apptainer instance start` command which will leverage
the `%appstart` section if it exists in the definition file to instantiate a particular app as a service. Eg.


````Console
apptainer instance start --app tail tailer.sif tailer
````

with definition file `tailer.def` containing:

```Yaml
%appstart tail
    tail -f /dev/null
```
will create a service called `tailer` which invokes the app `tail` that simply tails `/dev/null` until terminated.

Stopping the instance is the exact same as stopping any other apptainer instance. The app name is no longer necessary- only the instance name is required. For the above the invocation is

```Console
apptainer instance stop tailer
```
In addition to extending the e2e test, also updated the examples where appropriate to indicate the new functionality.

### This fixes or addresses the following GitHub issues:

 - Fixes #1118 

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
  - [x] e2e imageverify test extended to test `%appstart`
- [x] Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
