### PR TITLE
Support limit flags for instances, from sylabs 1195

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,8 +260,7 @@ jobs:
 
   e2e_tests:
     name: e2e_tests
-    # update to 22.04 causes fakeroot and cgroup test failures
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       # fetch tags as checkout@v2 doesn't do that by default
@@ -296,6 +295,14 @@ jobs:
         if: env.run_tests
         run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
 
+      # The fuse-overlayfs version from ubuntu-22.04, 1.7, is buggy,
+      # so update to version 1.9
+      # See https://github.com/apptainer/apptainer/issues/796
+      - name: Update fuse-overlayfs version
+        run: |
+          sudo sh -c "echo 'deb http://archive.ubuntu.com/ubuntu kinetic universe' >/etc/apt/sources.list.d/kinetic.list"
+          sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y fuse-overlayfs
+
       - name: Enable full cgroups v2 delegation
         run: |
           sudo mkdir -p /etc/systemd/system/user@.service.d
@@ -315,7 +322,12 @@ jobs:
         if: env.run_tests
         env:
           E2E_PARALLEL: 8
-        run: make -C ./builddir e2e-test
+        run: |
+          # Set up systemd for the rootless cgroups tests
+          systemctl --user daemon-reload
+          systemctl --user start dbus
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$UID/bus"
+          systemd-run --user --scope make -C ./builddir e2e-test
 
       - name: Upload artifacts
         if: env.run_tests

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -291,6 +291,10 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 	if err != nil {
 		return err
 	}
+	if cgJSON != "" && strings.HasPrefix(image, "instance://") {
+		cgJSON = ""
+		sylog.Warningf("Resource limits & cgroups configuration are only applied to instances at instance start.")
+	}
 
 	ki, err := getEncryptionMaterial(cmd)
 	if err != nil {

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -356,7 +356,7 @@ func (c *ctx) actionApplyRootless(t *testing.T) {
 	}
 }
 
-type actionFlagTest struct {
+type resourceFlagTest struct {
 	name            string
 	args            []string
 	expectErrorCode int
@@ -372,128 +372,129 @@ type actionFlagTest struct {
 	skipV2     bool
 }
 
+var resourceFlagTests = []resourceFlagTest{
+	{
+		name:            "blkio-weight",
+		args:            []string{"--blkio-weight", "50"},
+		expectErrorCode: 0,
+		controllerV1:    "blkio",
+		// This is the new path. Older kernels may have only `blkio.weight`
+		resourceV1:   "blkio.bfq.weight",
+		expectV1:     "50",
+		delegationV2: "io",
+		resourceV2:   "io.bfq.weight",
+		expectV2:     "default 50",
+	},
+	{
+		name:            "cpus",
+		args:            []string{"--cpus", "0.5"},
+		expectErrorCode: 0,
+		// 0.5 cpus = quota of 50000 with default period 100000
+		controllerV1: "cpu",
+		resourceV1:   "cpu.cfs_quota_us",
+		expectV1:     "50000",
+		delegationV2: "cpu",
+		resourceV2:   "cpu.max",
+		expectV2:     "50000 100000",
+	},
+	{
+		name:            "cpu-shares",
+		args:            []string{"--cpu-shares", "123"},
+		expectErrorCode: 0,
+		controllerV1:    "cpu",
+		resourceV1:      "cpu.shares",
+		expectV1:        "123",
+		// Cgroups v2 has a conversion from shares to weight
+		// weight = (1 + ((cpuShares-2)*9999)/262142)
+		delegationV2: "cpu",
+		resourceV2:   "cpu.weight",
+		expectV2:     "5",
+	},
+	{
+		name:            "cpuset-cpus",
+		args:            []string{"--cpuset-cpus", "0", "--cpuset-mems", "0"},
+		expectErrorCode: 0,
+		controllerV1:    "cpuset",
+		resourceV1:      "cpuset.cpus",
+		expectV1:        "0",
+		delegationV2:    "cpuset",
+		resourceV2:      "cpuset.cpus",
+		expectV2:        "0",
+	},
+	{
+		name:            "cpuset-mems",
+		args:            []string{"--cpuset-cpus", "0", "--cpuset-mems", "0"},
+		expectErrorCode: 0,
+		controllerV1:    "cpuset",
+		resourceV1:      "cpuset.mems",
+		expectV1:        "0",
+		delegationV2:    "cpuset",
+		resourceV2:      "cpuset.mems",
+		expectV2:        "0",
+	},
+	{
+		name:            "memory",
+		args:            []string{"--memory", "500M"},
+		expectErrorCode: 0,
+		controllerV1:    "memory",
+		resourceV1:      "memory.limit_in_bytes",
+		expectV1:        "524288000",
+		delegationV2:    "memory",
+		resourceV2:      "memory.max",
+		expectV2:        "524288000",
+	},
+	{
+		name:            "memory-reservation",
+		args:            []string{"--memory-reservation", "500M"},
+		expectErrorCode: 0,
+		controllerV1:    "memory",
+		resourceV1:      "memory.soft_limit_in_bytes",
+		expectV1:        "524288000",
+		delegationV2:    "memory",
+		resourceV2:      "memory.low",
+		expectV2:        "524288000",
+	},
+	{
+		// The CLI memory-swap value is v1 memory + swap... so this means 250M of swap
+		name:            "memory-swap",
+		args:            []string{"--memory-swap", "500M", "--memory", "250M"},
+		expectErrorCode: 0,
+		controllerV1:    "memory",
+		resourceV1:      "memory.memsw.limit_in_bytes",
+		// V1 shows the 500M combined
+		expectV1: "524288000",
+		// V2 treats the mem & swap separately... shows only 250M of swap (500M memory-swap - 250M memory)
+		delegationV2: "memory",
+		resourceV2:   "memory.swap.max",
+		expectV2:     "262144000",
+	},
+	{
+		name:            "oom-kill-disable",
+		args:            []string{"--oom-kill-disable"},
+		expectErrorCode: 0,
+		controllerV1:    "memory",
+		resourceV1:      "memory.oom_control",
+		expectV1:        "oom_kill_disable 1",
+		// v2 relies on oom_score_adj on /proc/pid instead
+		skipV2: true,
+	},
+	{
+		name:            "pids-limit",
+		args:            []string{"--pids-limit", "123"},
+		expectErrorCode: 0,
+		controllerV1:    "pids",
+		resourceV1:      "pids.max",
+		expectV1:        "123",
+		delegationV2:    "pids",
+		resourceV2:      "pids.max",
+		expectV2:        "123",
+	},
+}
+
 func (c *ctx) actionFlags(t *testing.T, profile e2e.Profile) {
 	e2e.EnsureImage(t, c.env)
-	tests := []actionFlagTest{
-		{
-			name:            "blkio-weight",
-			args:            []string{"--blkio-weight", "50"},
-			expectErrorCode: 0,
-			controllerV1:    "blkio",
-			// This is the new path. Older kernels may have only `blkio.weight`
-			resourceV1:   "blkio.bfq.weight",
-			expectV1:     "50",
-			delegationV2: "io",
-			resourceV2:   "io.bfq.weight",
-			expectV2:     "default 50",
-		},
-		{
-			name:            "cpus",
-			args:            []string{"--cpus", "0.5"},
-			expectErrorCode: 0,
-			// 0.5 cpus = quota of 50000 with default period 100000
-			controllerV1: "cpu",
-			resourceV1:   "cpu.cfs_quota_us",
-			expectV1:     "50000",
-			delegationV2: "cpu",
-			resourceV2:   "cpu.max",
-			expectV2:     "50000 100000",
-		},
-		{
-			name:            "cpu-shares",
-			args:            []string{"--cpu-shares", "123"},
-			expectErrorCode: 0,
-			controllerV1:    "cpu",
-			resourceV1:      "cpu.shares",
-			expectV1:        "123",
-			// Cgroups v2 has a conversion from shares to weight
-			// weight = (1 + ((cpuShares-2)*9999)/262142)
-			delegationV2: "cpu",
-			resourceV2:   "cpu.weight",
-			expectV2:     "5",
-		},
-		{
-			name:            "cpuset-cpus",
-			args:            []string{"--cpuset-cpus", "0", "--cpuset-mems", "0"},
-			expectErrorCode: 0,
-			controllerV1:    "cpuset",
-			resourceV1:      "cpuset.cpus",
-			expectV1:        "0",
-			delegationV2:    "cpuset",
-			resourceV2:      "cpuset.cpus",
-			expectV2:        "0",
-		},
-		{
-			name:            "cpuset-mems",
-			args:            []string{"--cpuset-cpus", "0", "--cpuset-mems", "0"},
-			expectErrorCode: 0,
-			controllerV1:    "cpuset",
-			resourceV1:      "cpuset.mems",
-			expectV1:        "0",
-			delegationV2:    "cpuset",
-			resourceV2:      "cpuset.mems",
-			expectV2:        "0",
-		},
-		{
-			name:            "memory",
-			args:            []string{"--memory", "500M"},
-			expectErrorCode: 0,
-			controllerV1:    "memory",
-			resourceV1:      "memory.limit_in_bytes",
-			expectV1:        "524288000",
-			delegationV2:    "memory",
-			resourceV2:      "memory.max",
-			expectV2:        "524288000",
-		},
-		{
-			name:            "memory-reservation",
-			args:            []string{"--memory-reservation", "500M"},
-			expectErrorCode: 0,
-			controllerV1:    "memory",
-			resourceV1:      "memory.soft_limit_in_bytes",
-			expectV1:        "524288000",
-			delegationV2:    "memory",
-			resourceV2:      "memory.low",
-			expectV2:        "524288000",
-		},
-		{
-			// The CLI memory-swap value is v1 memory + swap... so this means 250M of swap
-			name:            "memory-swap",
-			args:            []string{"--memory-swap", "500M", "--memory", "250M"},
-			expectErrorCode: 0,
-			controllerV1:    "memory",
-			resourceV1:      "memory.memsw.limit_in_bytes",
-			// V1 shows the 500M combined
-			expectV1: "524288000",
-			// V2 treats the mem & swap separately... shows only 250M of swap (500M memory-swap - 250M memory)
-			delegationV2: "memory",
-			resourceV2:   "memory.swap.max",
-			expectV2:     "262144000",
-		},
-		{
-			name:            "oom-kill-disable",
-			args:            []string{"--oom-kill-disable"},
-			expectErrorCode: 0,
-			controllerV1:    "memory",
-			resourceV1:      "memory.oom_control",
-			expectV1:        "oom_kill_disable 1",
-			// v2 relies on oom_score_adj on /proc/pid instead
-			skipV2: true,
-		},
-		{
-			name:            "pids-limit",
-			args:            []string{"--pids-limit", "123"},
-			expectErrorCode: 0,
-			controllerV1:    "pids",
-			resourceV1:      "pids.max",
-			expectV1:        "123",
-			delegationV2:    "pids",
-			resourceV2:      "pids.max",
-			expectV2:        "123",
-		},
-	}
 
-	for _, tt := range tests {
+	for _, tt := range resourceFlagTests {
 		t.Run(tt.name, func(t *testing.T) {
 			if cgroups.IsCgroup2UnifiedMode() {
 				c.actionFlagV2(t, tt, profile)
@@ -504,7 +505,7 @@ func (c *ctx) actionFlags(t *testing.T, profile e2e.Profile) {
 	}
 }
 
-func (c *ctx) actionFlagV1(t *testing.T, tt actionFlagTest, profile e2e.Profile) {
+func (c *ctx) actionFlagV1(t *testing.T, tt resourceFlagTest, profile e2e.Profile) {
 	// Don't try to test a resource that doesn't exist in our caller cgroup.
 	// E.g. some systems don't have memory.memswp, and might not have blkio.bfq
 	require.CgroupsResourceExists(t, tt.controllerV1, tt.resourceV1)
@@ -532,7 +533,7 @@ func (c *ctx) actionFlagV1(t *testing.T, tt actionFlagTest, profile e2e.Profile)
 	)
 }
 
-func (c *ctx) actionFlagV2(t *testing.T, tt actionFlagTest, profile e2e.Profile) {
+func (c *ctx) actionFlagV2(t *testing.T, tt resourceFlagTest, profile e2e.Profile) {
 	if tt.skipV2 {
 		t.Skip()
 	}
@@ -580,6 +581,136 @@ func (c *ctx) actionFlagsRootless(t *testing.T) {
 	}
 }
 
+func (c *ctx) instanceFlags(t *testing.T, profile e2e.Profile) {
+	e2e.EnsureImage(t, c.env)
+
+	for _, tt := range resourceFlagTests {
+		t.Run(tt.name, func(t *testing.T) {
+			if cgroups.IsCgroup2UnifiedMode() {
+				c.instanceFlagV2(t, tt, profile)
+				return
+			}
+			c.instanceFlagV1(t, tt, profile)
+		})
+	}
+}
+
+func (c *ctx) instanceFlagV1(t *testing.T, tt resourceFlagTest, profile e2e.Profile) {
+	// Don't try to test a resource that doesn't exist in our caller cgroup.
+	// E.g. some systems don't have memory.memswp, and might not have blkio.bfq
+	require.CgroupsResourceExists(t, tt.controllerV1, tt.resourceV1)
+
+	instanceName := randomName(t)
+	joinName := fmt.Sprintf("instance://%s", instanceName)
+	startArgs := append(tt.args, "-B", "/sys/fs/cgroup", c.env.ImagePath, instanceName)
+
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("start"),
+		e2e.WithProfile(profile),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs(startArgs...),
+		e2e.ExpectExit(0),
+	)
+
+	// Use shell in the container to find container cgroup and cat the value for the tested controller & resource.
+	// /proc/self/cgroup is : delimited
+	// controller is the 2nd field in `/proc/self/cgroup`
+	// cgroup path relative to root cgroup mount is the 3rd field in `/proc/self/cgroup`
+	shellCmd := fmt.Sprintf("cat /sys/fs/cgroup/%s$(cat /proc/self/cgroup | grep '[,:]%s[,:]' | cut -d ':' -f 3)/%s", tt.controllerV1, tt.controllerV1, tt.resourceV1)
+	exitFunc := []e2e.ApptainerCmdResultOp{}
+	if tt.expectV1 != "" {
+		exitFunc = []e2e.ApptainerCmdResultOp{e2e.ExpectOutput(e2e.ContainMatch, tt.expectV1)}
+	}
+
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("exec"),
+		e2e.WithProfile(profile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(joinName, "/bin/sh", "-c", shellCmd),
+		e2e.WithDir(profile.HostUser(t).Dir),
+		e2e.ExpectExit(tt.expectErrorCode, exitFunc...),
+	)
+
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("stop"),
+		e2e.WithProfile(profile),
+		e2e.WithCommand("instance stop"),
+		e2e.WithArgs(instanceName),
+		e2e.ExpectExit(0),
+	)
+}
+
+func (c *ctx) instanceFlagV2(t *testing.T, tt resourceFlagTest, profile e2e.Profile) {
+	if tt.skipV2 {
+		t.Skip()
+	}
+	// Don't try to test a resource that doesn't exist in our caller cgroup.
+	// E.g. some systems don't have io.bfq.*
+	require.CgroupsResourceExists(t, "", tt.resourceV2)
+
+	// In rootless mode, can only test subsystems that have been delegated
+	if !profile.Privileged() {
+		require.CgroupsV2Delegated(t, tt.delegationV2)
+	}
+
+	instanceName := randomName(t)
+	joinName := fmt.Sprintf("instance://%s", instanceName)
+	startArgs := append(tt.args, "-B", "/sys/fs/cgroup", c.env.ImagePath, instanceName)
+
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("start"),
+		e2e.WithProfile(profile),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs(startArgs...),
+		e2e.ExpectExit(0),
+	)
+
+	// Use shell in the container to find container cgroup and cat the value for the tested controller & resource.
+	// /proc/self/cgroup is : delimited
+	// For V2 the controller is null (field 2), at index 0 (field 1)
+	// cgroup path relative to root cgroup mount is the 3rd field in `/proc/self/cgroup`
+	shellCmd := fmt.Sprintf("cat /sys/fs/cgroup$(cat /proc/self/cgroup | grep '^0::' | cut -d ':' -f 3)/%s", tt.resourceV2)
+	exitFunc := []e2e.ApptainerCmdResultOp{}
+	if tt.expectV2 != "" {
+		exitFunc = []e2e.ApptainerCmdResultOp{e2e.ExpectOutput(e2e.ContainMatch, tt.expectV2)}
+	}
+
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("exec"),
+		e2e.WithProfile(profile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(joinName, "/bin/sh", "-c", shellCmd),
+		e2e.WithDir(profile.HostUser(t).Dir),
+		e2e.ExpectExit(tt.expectErrorCode, exitFunc...),
+	)
+
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("stop"),
+		e2e.WithProfile(profile),
+		e2e.WithCommand("instance stop"),
+		e2e.WithArgs(instanceName),
+		e2e.ExpectExit(0),
+	)
+}
+
+func (c *ctx) instanceFlagsRoot(t *testing.T) {
+	c.instanceFlags(t, e2e.RootProfile)
+}
+
+func (c *ctx) instanceFlagsRootless(t *testing.T) {
+	for _, profile := range []e2e.Profile{e2e.UserProfile, e2e.UserNamespaceProfile, e2e.FakerootProfile} {
+		t.Run(profile.String(), func(t *testing.T) {
+			c.instanceFlags(t, profile)
+		})
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := &ctx{
@@ -589,13 +720,15 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	np := testhelper.NoParallel
 
 	return testhelper.Tests{
-		"instance stats root":           np(env.WithRootManagers(c.instanceStatsRoot)),
-		"instance stats rootless":       np(env.WithRootlessManagers(c.instanceStatsRootless)),
-		"instance root cgroups":         np(env.WithRootManagers(c.instanceApplyRoot)),
-		"instance rootless cgroups":     np(env.WithRootlessManagers(c.instanceApplyRootless)),
-		"action root cgroups":           np(env.WithRootManagers(c.actionApplyRoot)),
-		"action rootless cgroups":       np(env.WithRootlessManagers(c.actionApplyRootless)),
-		"action flags root cgroups":     np(env.WithRootManagers(c.actionFlagsRoot)),
-		"action flags rootless cgroups": np(env.WithRootlessManagers(c.actionFlagsRootless)),
+		"instance stats root":             np(env.WithRootManagers(c.instanceStatsRoot)),
+		"instance stats rootless":         np(env.WithRootlessManagers(c.instanceStatsRootless)),
+		"instance root cgroups":           np(env.WithRootManagers(c.instanceApplyRoot)),
+		"instance rootless cgroups":       np(env.WithRootlessManagers(c.instanceApplyRootless)),
+		"instance flags root cgroups":     np(env.WithRootManagers(c.instanceFlagsRoot)),
+		"instance flags rootless cgroups": np(env.WithRootlessManagers(c.instanceFlagsRootless)),
+		"action root cgroups":             np(env.WithRootManagers(c.actionApplyRoot)),
+		"action rootless cgroups":         np(env.WithRootlessManagers(c.actionApplyRootless)),
+		"action flags root cgroups":       np(env.WithRootManagers(c.actionFlagsRoot)),
+		"action flags rootless cgroups":   np(env.WithRootlessManagers(c.actionFlagsRootless)),
 	}
 }

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -679,10 +679,14 @@ func (c *ctx) instanceFlagV2(t *testing.T, tt resourceFlagTest, profile e2e.Prof
 		exitFunc = []e2e.ApptainerCmdResultOp{e2e.ExpectOutput(e2e.ContainMatch, tt.expectV2)}
 	}
 
+	execProfile := profile
+	if profile.String() == e2e.FakerootProfile.String() {
+		execProfile = e2e.UserNamespaceProfile
+	}
 	c.env.RunApptainer(
 		t,
 		e2e.AsSubtest("exec"),
-		e2e.WithProfile(profile),
+		e2e.WithProfile(execProfile),
 		e2e.WithCommand("exec"),
 		e2e.WithArgs(joinName, "/bin/sh", "-c", shellCmd),
 		e2e.WithDir(profile.HostUser(t).Dir),

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -16,6 +16,7 @@ type TestEnv struct {
 	CmdPath              string // Path to the Apptainer binary to use for the execution of an Apptainer command
 	ImagePath            string // Path to the image that has to be used for the execution of an Apptainer command
 	SingularityImagePath string // Path to a Singularity image for legacy tests
+	DebianImagePath      string // Path to an image containing a Debian distribution with libc compatible to the host libc
 	OrasTestImage        string
 	TestDir              string // Path to the directory from which an Apptainer command needs to be executed
 	TestRegistry         string

--- a/e2e/internal/e2e/home.go
+++ b/e2e/internal/e2e/home.go
@@ -71,7 +71,7 @@ func SetupHomeDirectories(t *testing.T, testRegistry string) {
 
 		// create the temporary filesystem
 		if err := syscall.Mount("tmpfs", sessionDir, "tmpfs", 0, "mode=0777"); err != nil {
-			t.Fatalf("failed to mount temporary filesystem")
+			t.Fatalf("failed to mount temporary filesystem: %v", err)
 		}
 
 		// want the already resolved current working directory

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -173,6 +173,9 @@ func Run(t *testing.T) {
 	// If you need the test image, add the call at the top of your
 	// own test.
 
+	testenv.DebianImagePath = path.Join(name, "test-debian.sif")
+	defer os.Remove(testenv.DebianImagePath)
+
 	testenv.OrasTestImage = fmt.Sprintf("oras://%s/oras_test_sif:latest", testenv.TestRegistry)
 
 	// provision local registry

--- a/e2e/testdata/unprivileged_build.def
+++ b/e2e/testdata/unprivileged_build.def
@@ -1,5 +1,6 @@
-BootStrap: docker
-From: centos:centos7
+Bootstrap: localimage
+From: test-debian.sif
 
 %post
-    yum -y install openssh 
+    apt-get update
+    apt-get install -y openssh-client

--- a/e2e/testdata/unprivileged_build_2.def
+++ b/e2e/testdata/unprivileged_build_2.def
@@ -1,5 +1,8 @@
-BootStrap: docker
-From: centos:centos7
+Bootstrap: localimage
+From: test-debian.sif
 
+# In mode 2 there's no fakeroot command so cannot install any 
+# packages on Debian, since apt-get always does privileged operations
 %post
-    yum -y install epel-release
+    mkdir -m 0 /etc/denied
+    ls /etc/denied

--- a/e2e/testdata/unprivileged_build_4.def
+++ b/e2e/testdata/unprivileged_build_4.def
@@ -1,0 +1,7 @@
+Bootstrap: localimage
+From: test-debian.sif
+
+# mode 4 can't handle openssh-client, so install something simple instead
+%post
+    apt-get update
+    apt-get install -y cpio

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -670,6 +670,10 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
 	gid := os.Getgid()
 	suidRequired := uid != 0 && !file.UserNs
 
+	if e.EngineConfig.GetFakeroot() {
+		sylog.Infof("--fakeroot ignored when joining instance")
+	}
+
 	// basic checks:
 	// 1. a user must not use SUID workflow to join an instance
 	//    started with user namespace


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1195
 which fixed
- sylabs/singularity#817

The original PR description was:
> Stacked on top of sylabs/singularity#1186 - which itself actually makes limit flags effective and practical for instances.
> 
> Warn that limits only take effect on `instance start` and not when running an action against a running instance://`
> 
> Run the same set of tests as for interactive action resource limits against `instance start`.