### PR TITLE
Fix typos found by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   join is from outside a user-owned cgroup.
 - Define EUID in %environment alongside UID.
 - Avoid UID / GID / EUID readonly var warnings with `--env-file`.
-- In `--rocm` mode, the whole of `/dev/dri` is now bound into the container whe
+- In `--rocm` mode, the whole of `/dev/dri` is now bound into the container when
   `--contain` is in use. This makes `/dev/dri/render` devices available,
   required for later ROCm versions.
 
@@ -291,7 +291,7 @@ Accidentally included no code changes.
 - Nesting of bind mounts now works even when a `--bind` option specified
   a different source and destination with a colon between them.  Now the
   APPTAINER_BIND environment variable makes sure the bind source is
-  from the bind destination so it will be succesfully re-bound into a
+  from the bind destination so it will be successfully re-bound into a
   nested apptainer container.
 - The warning about more than 50 bind mounts required for an underlay bind
   has been changed to an info message.
@@ -357,7 +357,7 @@ Accidentally included no code changes.
 - `remote add --insecure` may now be used to configure endpoints that are only
   accessible via http. Alternatively the environment variable
   `APPTAINER_ADD_INSECURE` can be set to true to allow http remotes to be
-  added wihtout the `--insecure` flag. Specifying https in the remote URI
+  added without the `--insecure` flag. Specifying https in the remote URI
   overrules both `--insecure` and `APPTAINER_ADD_INSECURE`.
 - Gpu flags `--nv` and `--rocm` can now be used from an apptainer nested
   inside another apptainer container.
@@ -539,7 +539,7 @@ in the next section.
   environment variables `APPTAINER_BIND`, `APPTAINER_BINDPATH`, `APPTAINER_NV`,
   `APPTAINER_ROCM` anymore due to side effects reported by users in this
   [issue](https://github.com/apptainer/singularity/pull/6211),
-  they must be explicitely requested via command line.
+  they must be explicitly requested via command line.
 - Build `--bind` option allows to set multiple bind mounts without specifying
   the `--bind` option for each bindings.
 - Honor image binds and user binds in the order they're given instead of

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,7 +25,7 @@
 - David Trudgian <david.trudgian@utsouthwestern.edu>,
   <david.trudgian@sylabs.io>, <dave@trudgian.net>
 - Diana Langenbach <dcl@dcl.sh>
-- Dimitri Papadopoulos <3234522+DimitriPapadopoulos@users.noreply.github.com>
+- Dimitri Papadopoulos Orfanos <3234522+DimitriPapadopoulos@users.noreply.github.com>
 - Divya Cote <divya.cote@gmail.com>
 - Edita Kizinevič <edita.kizinevic@cern.ch>
 - Eduardo Arango <eduardo@sylabs.io>, <arangogutierrez@gmail.com>

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -330,7 +330,7 @@ func handleConfDir(confDir, legacyConfigDir string) {
 		return
 	}
 
-	// apptainer user config directory doesnt exist, create it.
+	// apptainer user config directory doesn't exist, create it.
 	err = fs.Mkdir(confDir, 0o700)
 	if err != nil {
 		sylog.Debugf("Could not create %s: %s", confDir, err)
@@ -347,7 +347,7 @@ func handleConfDir(confDir, legacyConfigDir string) {
 		return
 	}
 
-	// singularity user config directory doesnt exist, return
+	// singularity user config directory doesn't exist, return
 	if !ok {
 		return
 	}

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -87,7 +87,7 @@ func fakerootExec(isDeffile bool) {
 		sylog.Infof("User not listed in %v, trying root-mapped namespace", fakeroot.SubUIDFile)
 		os.Setenv("_APPTAINER_FAKEFAKEROOT", "1")
 		if buildArgs.ignoreUserns {
-			err = errors.New("could not start root-mapped namesapce because of --ignore-userns is set")
+			err = errors.New("could not start root-mapped namespace because of --ignore-userns is set")
 		} else {
 			err = fakeroot.UnshareRootMapped(args)
 		}

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -34,7 +34,7 @@ type actionTests struct {
 	env e2e.TestEnv
 }
 
-// run tests min fuctionality for singularity symlink using actionRun
+// run tests min functionality for singularity symlink using actionRun
 func (c actionTests) singularityLink(t *testing.T) {
 	saveCmdPath := c.env.CmdPath
 	i := strings.LastIndex(saveCmdPath, "apptainer")
@@ -45,7 +45,7 @@ func (c actionTests) singularityLink(t *testing.T) {
 	c.env.CmdPath = saveCmdPath
 }
 
-// run tests min fuctionality for apptainer run
+// run tests min functionality for apptainer run
 func (c actionTests) actionRun(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
@@ -93,7 +93,7 @@ func (c actionTests) actionRun(t *testing.T) {
 	}
 }
 
-// exec tests min fuctionality for apptainer exec
+// exec tests min functionality for apptainer exec
 func (c actionTests) actionExec(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
@@ -473,7 +473,7 @@ func (c actionTests) STDPipe(t *testing.T) {
 	}
 }
 
-// RunFromURI tests min fuctionality for apptainer run/exec URI://
+// RunFromURI tests min functionality for apptainer run/exec URI://
 func (c actionTests) RunFromURI(t *testing.T) {
 	e2e.EnsureORASImage(t, c.env)
 

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -788,7 +788,7 @@ func (c *ctx) apptainerLocalKeyDirFlagRegression(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name:    "key list regression test should succeed but shoud return nothing because keysdir value is invalid",
+			name:    "key list regression test should succeed but should return nothing because keysdir value is invalid",
 			command: "key list",
 			args:    []string{"--secret"},
 			resultOp: []e2e.ApptainerCmdResultOp{

--- a/e2e/legacy/actions.go
+++ b/e2e/legacy/actions.go
@@ -37,7 +37,7 @@ func (c legacyTests) singularityCmd(command string, args ...string) []string {
 	return append(apptainerArgs, args...)
 }
 
-// run tests min fuctionality for apptainer run
+// run tests min functionality for apptainer run
 func (c legacyTests) runLegacy(t *testing.T) {
 	require.Arch(t, "amd64")
 
@@ -88,7 +88,7 @@ func (c legacyTests) runLegacy(t *testing.T) {
 	}
 }
 
-// exec tests min fuctionality for apptainer exec
+// exec tests min functionality for apptainer exec
 func (c legacyTests) execLegacy(t *testing.T) {
 	require.Arch(t, "amd64")
 

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -82,7 +82,7 @@ func (c ctx) remoteAdd(t *testing.T) {
 // remoteRemove tests the functionality of "apptainer remote remove" command.
 // 1. Adds remote endpoints
 // 2. Deletes the already added entries
-// 3. Verfies that removing an invalid entry results in a failure
+// 3. Verifies that removing an invalid entry results in a failure
 func (c ctx) remoteRemove(t *testing.T) {
 	config, err := os.CreateTemp(c.env.TestDir, "testConfig-")
 	if err != nil {

--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -25,7 +25,7 @@ type ctx struct {
 	env e2e.TestEnv
 }
 
-// testSecurityUnpriv tests the security flag fuctionality for apptainer exec without elevated privileges
+// testSecurityUnpriv tests the security flag functionality for apptainer exec without elevated privileges
 func (c ctx) testSecurityUnpriv(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -130,7 +130,7 @@ func (c ctx) testSecurityUnpriv(t *testing.T) {
 	}
 }
 
-// testSecurityPriv tests security flag fuctionality for apptainer exec with elevated privileges
+// testSecurityPriv tests security flag functionality for apptainer exec with elevated privileges
 func (c ctx) testSecurityPriv(t *testing.T) {
 	var caps uint64
 	var err error

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -108,7 +108,7 @@ func Run(t *testing.T) {
 	testenv.TestRegistry = e2e.StartRegistry(t, testenv)
 	testenv.InsecureRegistry = strings.Replace(testenv.TestRegistry, "localhost", "127.0.0.1.nip.io", 1)
 
-	// Make shared cache dirs for privileged and unpriviliged E2E tests.
+	// Make shared cache dirs for privileged and unprivileged E2E tests.
 	// Individual tests that depend on specific ordered cache behavior, or
 	// directly test the cache, should override the TestEnv values within the
 	// specific test.

--- a/internal/pkg/util/fs/helper_linux_test.go
+++ b/internal/pkg/util/fs/helper_linux_test.go
@@ -27,7 +27,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 
 	//
 	// First test: Ensure a already-existing file is the
-	// correct permssion.
+	// correct permission.
 	//
 
 	existFile := filepath.Join(tmpDir, "already-exists")
@@ -94,7 +94,7 @@ func TestEnsureFileWithPermission(t *testing.T) {
 
 	//
 	// Second test: Ensure a non-existing file is the
-	// correct permssion.
+	// correct permission.
 	//
 
 	nonExistFile := filepath.Join(tmpDir, "non-exists")

--- a/pkg/image/squashfs.go
+++ b/pkg/image/squashfs.go
@@ -127,7 +127,7 @@ func GetSquashfsComp(b []byte) (string, error) {
 		}
 		return compType, nil
 	} else if sb.Major < 4 {
-		// v3 and eariler super blocks always use gzip comp
+		// v3 and earlier super blocks always use gzip comp
 		// different compressors were introduced after the change
 		// to v4 super blocks
 		return "gzip", nil

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -61,7 +61,7 @@ type FuseMount struct {
 }
 
 // DMTCPConfig stores the DMTCP-related information required for
-// container process checkpoint/restart behvaior.
+// container process checkpoint/restart behavior.
 type DMTCPConfig struct {
 	Enabled    bool     `json:"enabled,omitempty"`
 	Restart    bool     `json:"restart,omitempty"`

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -113,7 +113,7 @@ func LegacyRemoteConf() string {
 	return filepath.Join(LegacyConfigDir(), RemoteConfFile)
 }
 
-// LegacyDockerConf reutrns where singularity stores user oci registry configuration.
+// LegacyDockerConf returns where singularity stores user oci registry configuration.
 // NOTE: this location should only be used for migration/compatibility and
 // never written to by apptainer.
 func LegacyDockerConf() string {

--- a/pkg/sylog/sylog_test.go
+++ b/pkg/sylog/sylog_test.go
@@ -339,7 +339,7 @@ func TestStderrOutput(t *testing.T) {
 		out  *os.File
 	}{
 		{
-			// We just call a few funtions that output to stderr, not much we can test
+			// We just call a few functions that output to stderr, not much we can test
 			// except make sure that whatever potential modification to the code does
 			// not make the code crash
 			name: "default Stderr",

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -686,7 +686,7 @@ func max(parts []int) (maxVal int) {
 // format into something readable by people.  If longOutput is set, more
 // detail is included.  See the input format in:
 // https://tools.ietf.org/html/draft-shaw-openpgp-hkp-00#section-5.2
-// Returns the number of keys(int), the formated string
+// Returns the number of keys(int), the formatted string
 // in []bytes, and an error if one occurs.
 func formatMROutput(mrString string, longOutput bool) (int, []byte, error) {
 	count := 0
@@ -909,7 +909,7 @@ func FetchPubkey(ctx context.Context, fingerprint string, noPrompt bool, opts ..
 		return nil, fmt.Errorf("failed to decode fingerprint: %v", err)
 	}
 
-	// theres probably a better way to do this
+	// there's probably a better way to do this
 	if len(fp) != 4 && len(fp) != 20 {
 		return nil, fmt.Errorf("not a valid key length: only accepts 8, or 40 chars")
 	}

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -440,7 +440,7 @@ mksquashfs procs = {{ .MksquashfsProcs }}
 # This allows the administrator to set the maximum amount of memory for mkswapfs
 # to use when building an image.  e.g. 1G for 1gb or 500M for 500mb. Restricting memory
 # can have a major impact on the time it takes mksquashfs to create the image.
-# NOTE: This fuctionality did not exist in squashfs-tools prior to version 4.3
+# NOTE: This functionality did not exist in squashfs-tools prior to version 4.3
 # If using an earlier version you should not set this.
 # mksquashfs mem = 1G
 {{ if ne .MksquashfsMem "" }}mksquashfs mem = {{ .MksquashfsMem }}{{ end }}

--- a/scripts/check-go.mod
+++ b/scripts/check-go.mod
@@ -17,7 +17,7 @@ export GO111MODULE=on
 git update-index --refresh
 
 if ! git diff-index --raw --exit-code HEAD ; then
-	echo "E: Workspace is unexpectly dirty. Abort."
+	echo "E: Workspace is unexpectedly dirty. Abort."
 	exit 2
 fi
 
@@ -42,7 +42,7 @@ fi
 git update-index --refresh
 
 if ! git diff-index --raw --exit-code HEAD ; then
-	echo "E: Workspace became dirty after runnig 'go mod tidy'. Abort."
+	echo "E: Workspace became dirty after running 'go mod tidy'. Abort."
 	exit 6
 fi
 

--- a/scripts/update-license-dependencies.sh
+++ b/scripts/update-license-dependencies.sh
@@ -17,7 +17,7 @@ if [ ! -f "go.mod" ]; then
 fi
 
 # Exclude ourselves, and github.com/vbauerster/mpb for which
-# the tool is not working properly, becuase it uses UNLICENSE
+# the tool is not working properly, because it uses UNLICENSE
 exclude="github.com/apptainer/apptainer|github.com/vbauerster/mpb"
 
 # Ensure a constant sort order


### PR DESCRIPTION
## Description of the Pull Request (PR):

For now, I have left out:
```
splitted ==> split
reenable ==> re-enable
childs ==> children, child's
```

This is not an essential change, and therefore I have not modified `CHANGELOG.md`.

Not that I have fixed a few typos in `CHANGELOG.md`. Perhaps you don't want that, for consistency with other forks. Feel free to ask me to revert such changes.