### PR TITLE
SUSE build update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,6 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - In `--rocm` mode, the whole of `/dev/dri` is now bound into the container when
   `--contain` is in use. This makes `/dev/dri/render` devices available,
   required for later ROCm versions.
-- Build via zypper on SLE systems will use repositories of host via
-  suseconnect-container
 
 ### Bug fixes
 
@@ -56,6 +54,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Ensure `DOCKER_HOST` is honored in non-build flows.
 - Make the error message more helpful in another place where a remote is found
   to have no library client.
+- Build via zypper on SLE systems will use repositories of host via
+  suseconnect-container
 
 ## v1.1.6 - \[2023-02-14\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - In `--rocm` mode, the whole of `/dev/dri` is now bound into the container when
   `--contain` is in use. This makes `/dev/dri/render` devices available,
   required for later ROCm versions.
+- Build via zypper on SLE systems will use repositories of host via
+  suseconnect-container
 
 ### Bug fixes
 

--- a/docs/content.go
+++ b/docs/content.go
@@ -90,6 +90,15 @@ Enterprise Performance Computing (EPC)`
           MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/x86_64/
           Include: yum
 
+      SUSE:
+          Bootstrap: zypper # on SLE system registration of build host is used
+          Include: zypper
+      
+      openSUSE:
+          Bootstrap: zypper
+          MirrorURL: http://download.opensuse.org/distribution/openSUSE-stable/repo/oss
+          Include: zypper
+
       Debian/Ubuntu:
           Bootstrap: debootstrap
           OSVersion: trusty

--- a/examples/sle/Apptainer
+++ b/examples/sle/Apptainer
@@ -1,38 +1,13 @@
+# use repos and registration from build host
 BootStrap: zypper
-OSVersion: 12.4
-Product: SLE-HPC/%{OSVERSION}/x86_64
-User: 
-Regcode: 
-# MirrorURL: 
-#  Modules: sle-module-basesystem,sle-module-server-applications,sle-module-web-scripting,sle-module-hpc
-Include: zypper
-# Otherurl0: 
-# Otherurl1: 
-ProductPGP: -----BEGIN PGP PUBLIC KEY BLOCK-----\n\
-Version: rpm-4.11.2 (NSS-3)\n\
-\n\
-mQENBFEKlmsBCADbpZZbbSC5Zi+HxCR/ynYsVxU5JNNiSSZabN5GMgc9Z0hxeXxp\n\
-YWvFoE/4n0+IXIsp83iKvxf06Eu8je/DXp0lMqDZu7WiT3XXAlkOPSNV4akHTDoY\n\
-91SJaZCpgUJ7K1QXOPABNbREsAMN1a7rxBowjNjBUyiTJ2YuvQRLtGdK1kExsVma\n\
-hieh/QxpoDyYd5w/aky3z23erCoEd+OPfAqEHd5tQIa6LOosa63BSCEl3milJ7J9\n\
-vDmoGPAoS6ui7S2R5X4/+PLN8Mm2kOBrFjhmL93LX0mrGCMxsNsKgP6zabYKQEb8\n\
-L028SXvl7EGoA+Vw5Vd3wIGbM73PfbgNrXjfABEBAAG0KFN1U0UgUGFja2FnZSBT\n\
-aWduaW5nIEtleSA8YnVpbGRAc3VzZS5kZT6JATwEEwECACYCGwMGCwkIBwMCBBUC\n\
-CAMEFgIDAQIeAQIXgAUCWEfrHwUJDsIitAAKCRBwr56BOdt8gpqUB/wPSSS5BcDu\n\
-Oi4n02cj4Hdt7WITKBjjo0lG1fXG1ppx1wOST+s8FertMVFY53TW6FGjcYtwVOIq\n\
-rsMYiV6kf1NxUV/jcAy7VmC5EZnO0R/D3sT4Oh5hsLtERauZolK5BZmd0S51Qa8e\n\
-TxZ5mX9PL2i3s/ShETc30drf83ugc7B4yZPNQWXNDPgGcC+hEeC5qw48RzHYIpUt\n\
-RzHmefR5Z3ioTUbDlzy+SGP2uA7mhR4Lfk/df5fYxWfCoKlyGjtrvA65cB+Pksyn\n\
-xrAeBuB+vBM+KnDrxW2Sn4AbWkzH//dfz9OJDJu4UM91hb7qxM0OkrXHQV3iNqzg\n\
-MDEhky/9NqMy\n\
-=GdP5\n\
------END PGP PUBLIC KEY BLOCK-----
+
 
 %runscript
     echo "This is what happens when you run the container..."
 
 
 %post
+    update-ca-certificates
     echo "Hello from inside the container"
     zypper lr -d
     SUSEConnect -l

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.2.1
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/sirupsen/logrus v1.9.0
 )
@@ -64,7 +65,6 @@ require (
 require (
 	github.com/AdamKorcz/go-fuzz-headers v0.0.0-20210319161527-f761c2329661 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -109,7 +109,11 @@ func (s *stage) runPostScript(sessionResolv, sessionHosts string) error {
 			}
 			cmdArgs = append(cmdArgs, "-B", strings.Join(fakerootBinds[:], ","))
 		}
-
+		if len(s.b.Opts.Binds) != 0 {
+			for _, bind := range s.b.Opts.Binds {
+				cmdArgs = append(cmdArgs, "-B", bind)
+			}
+		}
 		script := s.b.Recipe.BuildData.Post
 		scriptPath := filepath.Join(s.b.RootfsPath, ".post.script")
 		if err = createScript(scriptPath, []byte(script.Script)); err != nil {
@@ -152,6 +156,11 @@ func (s *stage) runTestScript(sessionResolv, sessionHosts string) error {
 		}
 		if sessionHosts != "" {
 			cmdArgs = append(cmdArgs, "-B", sessionHosts+":/etc/hosts")
+		}
+		if len(s.b.Opts.Binds) != 0 {
+			for _, bind := range s.b.Opts.Binds {
+				cmdArgs = append(cmdArgs, "-B", bind)
+			}
 		}
 
 		exe := filepath.Join(buildcfg.BINDIR, "apptainer")

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -82,6 +82,8 @@ type Options struct {
 	// To warn when the above is needed, we need to know if the target of this
 	// bundle will be a sandbox
 	SandboxTarget bool
+	// Binds stores bind mounts used for the post scripts
+	Binds []string
 }
 
 // NewEncryptedBundle creates an Encrypted Bundle environment.


### PR DESCRIPTION
## Simplify SLE builds

Add the possibility to build SUSE containers via suseconnect-container, what 
removed the need to register the container via SUSEConnect.
This needs the possibility to have bind mounts in the post stage of the build,
but this is not exposed in the def file.