### PR TITLE
Add helpful error message when remote has no library client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Fix `GOCACHE` settings for golang build on PPA build environment.
 - Ensure `DOCKER_HOST` is honored in non-build flows.
+- Make the error message more helpful in another place where a remote is found
+  to have no library client.
 
 ## v1.1.6 - \[2023-02-14\]
 

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -860,7 +860,7 @@ func getLibraryClientConfig(uri string) (*libClient.Config, error) {
 		return nil, err
 	}
 	if libClientConfig.BaseURL == "" {
-		return nil, fmt.Errorf("remote has no library client")
+		return nil, fmt.Errorf("remote has no library client (see https://apptainer.org/docs/user/latest/endpoint.html#no-default-remote)")
 	}
 	return libClientConfig, nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add helpful error message when remote has no library client.


### This fixes or addresses the following GitHub issues:

 - Fixes #1103 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)


#### Test
```
vagrant@bullseye:~/apptainer$ apptainer pull library://alpine:latest
FATAL:   Unable to get library client configuration: remote has no library client (see https://apptainer.org/docs/user/latest/endpoint.html#no-default-remote)
```
