### PR TITLE
e2e: gate AllowNet* tests with require.Network, from sylabs1370

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -602,9 +602,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 255,
 		},
 		{
-			name:    "AllowNetUsersUserOK",
-			argv:    []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetUsersUserOK",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net users":    u.Name,
 				"allow net networks": "bridge",
@@ -612,9 +613,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name:    "AllowNetUsersUIDOK",
-			argv:    []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetUsersUIDOK",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net users":    fmt.Sprintf("%d", u.UID),
 				"allow net networks": "bridge",
@@ -649,9 +651,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 255,
 		},
 		{
-			name:    "AllowNetGroupsGroupOK",
-			argv:    []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetGroupsGroupOK",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net groups":   g.Name,
 				"allow net networks": "bridge",
@@ -659,9 +662,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name:    "AllowNetGroupsGIDOK",
-			argv:    []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetGroupsGIDOK",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "bridge", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net groups":   fmt.Sprintf("%d", g.GID),
 				"allow net networks": "bridge",
@@ -669,7 +673,8 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name: "AllowNetNetworksMultiMulti",
+			name:              "AllowNetNetworksMultiMulti",
+			addRequirementsFn: e2e.Privileged(require.Network),
 			// Two networks allowed, asking for both
 			argv:    []string{"--net", "--network", "bridge,ptp", c.env.ImagePath, "true"},
 			profile: e2e.UserProfile,
@@ -681,9 +686,10 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 		},
 		{
 			// Two networks allowed, asking for one
-			name:    "AllowNetNetworksMultiOne",
-			argv:    []string{"--net", "--network", "ptp", c.env.ImagePath, "true"},
-			profile: e2e.UserProfile,
+			name:              "AllowNetNetworksMultiOne",
+			addRequirementsFn: e2e.Privileged(require.Network),
+			argv:              []string{"--net", "--network", "ptp", c.env.ImagePath, "true"},
+			profile:           e2e.UserProfile,
 			directives: map[string]string{
 				"allow net users":    u.Name,
 				"allow net networks": "bridge,ptp",


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1370
 which fixed
- sylabs/singularity#1069

The original PR description was:
> Don't attempt to look for CNI bridge network success via the AllowNet* config directives on hosts that don't support setting up the network.