### PR TITLE
e2e: force arch for pull by hash, from sylabs 1371

### DIFF
--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -41,6 +41,7 @@ type testStruct struct {
 	desc             string // case description
 	srcURI           string // source URI for image
 	library          string // use specific library, XXX(mem): not tested yet
+	arch             string // architecture to force, if any
 	force            bool   // pass --force
 	createDst        bool   // create destination file before pull
 	unauthenticated  bool   // pass --allow-unauthenticated
@@ -67,6 +68,10 @@ func (c *ctx) imagePull(t *testing.T, tt testStruct) {
 	// element in the slice, which would cause the command to fail, without
 	// over-complicating the code.
 	argv := ""
+
+	if tt.arch != "" {
+		argv += "--arch " + tt.arch + " "
+	}
 
 	if tt.force {
 		argv += "--force "
@@ -226,6 +231,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 		{
 			desc:             "image with specific hash",
 			srcURI:           "oras://ghcr.io/apptainer/alpine@sha256:aef2a1baf177ee2e6f21da40bdb7025f58466d39116507837f74c2ab4abf5606",
+			arch:             "amd64",
 			unauthenticated:  true,
 			expectedExitCode: 0,
 		},


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1371

The original PR description was:
> The v2 library won't serve up an image by hash unless is matches the requestors architecture, or the `--arch` flag is used to specify a different architecture.
> 
> Image we pull by hash is always amd64, so set the `--arch` flag appropriately in the test.
> 
> Fixes test on non amd64 systems.