### PR TITLE
fix: avoid incorrect error with --fakeroot --net --network=fakeroot, from sylabs 1355

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   to have no library client.
 - Build via zypper on SLE systems will use repositories of host via
   suseconnect-container
+- Avoid incorrect error when reqesting fakeroot network.
 
 ## v1.1.6 - \[2023-02-14\]
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2384,7 +2384,6 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 		sessionNetNs = "/netns"
 	)
 
-	fakeroot := c.engine.EngineConfig.GetFakeroot()
 	net := c.engine.EngineConfig.GetNetwork()
 
 	// If we haven't requested a network namespace, or we have but with no config, we are done here
@@ -2392,10 +2391,21 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 		return nil, nil
 	}
 
-	// Otherwise start checking what's permitted for the current user
+	// In fakeroot mode only permit the `fakeroot` CNI config, overriding any other request.
 	euid := os.Geteuid()
+	fakeroot := c.engine.EngineConfig.GetFakeroot()
+	forceFakerootNet := false
+	if fakeroot && euid != 0 {
+		if net != fakerootNet {
+			sylog.Warningf("Only --network=%s is permitted in --fakeroot mode. You requested '%s'.", fakerootNet, net)
+			sylog.Warningf("Overriding with --network=%s", fakerootNet)
+		}
+		forceFakerootNet = true
+		net = fakerootNet
+	}
+
 	allowedNetUnpriv := false
-	if euid != 0 {
+	if euid != 0 && !forceFakerootNet {
 		// Is the user permitted in the list of unpriv users / groups permitted to use CNI?
 		allowedNetUser, err := user.UIDInList(euid, c.engine.EngineConfig.File.AllowNetUsers)
 		if err != nil {
@@ -2408,7 +2418,11 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 		// Is/are the requested network(s) in the list of networks allowed for unpriv CNI?
 		allowedNetNetwork := false
 		for _, n := range strings.Split(net, ",") {
-			allowedNetNetwork = slice.ContainsString(c.engine.EngineConfig.File.AllowNetNetworks, n)
+			// Allowed in apptainer.conf
+			adminPermitted := slice.ContainsString(c.engine.EngineConfig.File.AllowNetNetworks, n)
+			// 'fakeroot' network is always allowed in --fakeroot mode
+			fakerootPermitted := fakeroot && net == fakerootNet
+			allowedNetNetwork = adminPermitted || fakerootPermitted
 			// If any one requested network is not allowed, disallow the whole config
 			if !allowedNetNetwork {
 				if !fakeroot {
@@ -2435,14 +2449,7 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 	if err := system.Points.AddBind(mount.SharedTag, procNetNs, nspath, 0); err != nil {
 		return nil, fmt.Errorf("could not hold network namespace reference: %s", err)
 	}
-	networks := strings.Split(c.engine.EngineConfig.GetNetwork(), ",")
-
-	// In fakeroot mode only permit the `fakeroot` CNI config
-	if fakeroot && euid != 0 && net != fakerootNet {
-		// set as debug message to avoid annoying warning
-		sylog.Debugf("only '%s' network is allowed for regular user, you requested '%s'", fakerootNet, net)
-		networks = []string{fakerootNet}
-	}
+	networks := strings.Split(net, ",")
 
 	cniPath := &network.CNIPath{}
 

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -898,8 +898,6 @@ func (l *Launcher) setNamespaces() {
 			l.engineConfig.SetNetwork(l.cfg.Network)
 		}
 		if l.cfg.Fakeroot && l.cfg.Network != "none" {
-			l.engineConfig.SetNetwork("fakeroot")
-
 			// unprivileged installation could not use fakeroot
 			// network because it requires a setuid installation
 			// so we fallback to none


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1355
 which fixed
- sylabs/singularity#1352

The original PR description was:
> Due to incorrect logic / ordering of checks in prepareNetworkSetup, the combination of `--fakeroot --net --network=fakeroot` generated a false error stating that the fakeroot network was not permitted.
> 
> However, execution continued, and the fakeroot network was (correctly) used.
> 
> This is a minimal PR to correct the ordering of checks, such that `--fakeroot --net --network=fakeroot` doesn't give a false error.
> 
> The code handling checks for permitted networks is messy, and still needs a proper refactor. There is overriding of the `--network` setting for `--fakeroot` in the CLI->launcher layer as well, due to way in which the default network is implemented, via flag default value.
> 
> In addition, there doesn't seem to be a good reason as to why `allowed net networks` shouldn't apply when `--fakeroot` is being used. This can be tackled in the deferred refactor.