### PR TITLE
fix: avoid incorrect error with --fakeroot --net --network=fakeroot, from sylabs 1355 (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix `GOCACHE` settings for golang build on PPA build environment.
 - Make the error message more helpful in another place where a remote is found
   to have no library client.
+- Avoid incorrect error when reqesting fakeroot network.
 
 ## v1.1.6 - \[2023-02-14\]
 

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -673,8 +673,6 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 			engineConfig.SetNetwork(Network)
 		}
 		if IsFakeroot && Network != "none" {
-			engineConfig.SetNetwork("fakeroot")
-
 			// unprivileged installation could not use fakeroot
 			// network because it requires a setuid installation
 			// so we fallback to none


### PR DESCRIPTION
This cherry-picks #1186 to the release-1.1 branch