### PR TITLE
squashfuse_ll: do not use -o if optsStr is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Bug fixes
 
+- Avoid `unknown option` error when using a bare squashfs image with
+  an unpatched `squashfuse_ll`.
 - Fix `GOCACHE` settings for golang build on PPA build environment.
 - Ensure `DOCKER_HOST` is honored in non-build flows.
 - Make the error message more helpful in another place where a remote is found

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -89,6 +89,7 @@
 - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
 - Thomas Hamel <hmlth@t-hamel.fr>
 - Tim Wright <7im.Wright@protonmail.com>
+- Tobias Poschwatta <poschwatta@zib.de>
 - Tru Huynh <tru@pasteur.fr>
 - Tyson Whitehead <twhitehead@gmail.com>
 - Vanessa Sochat <vsoch@users.noreply.github.com>

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -175,7 +175,11 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 			// this will be passed as the first ExtraFile below, always fd 3
 			srcPath = "/proc/self/fd/3"
 		}
-		cmdArgs = append(cmdArgs, f.cmdPath, "-f", "-o", optsStr, srcPath, params.Target)
+		if optsStr != "" {
+			cmdArgs = append(cmdArgs, f.cmdPath, "-f", "-o", optsStr, srcPath, params.Target)
+		} else {
+			cmdArgs = append(cmdArgs, f.cmdPath, "-f", srcPath, params.Target)
+		}
 		cmd = exec.Command(cmdArgs[0], cmdArgs[1:]...)
 
 	case "ext3":


### PR DESCRIPTION
## Description of the Pull Request (PR):

When apptainer invokes squashfuse_ll, it always includes the "-o" option. But if optsStr is empty, squashfuse_ll fails with:

> unknown option `'

This makes apptainer fail when used with squashfs images:

> $ apptainer shell container.sqfs 
> FATAL:   container creation failed: mount hook function failure: mount /proc/self/fd/3->/.../apptainer/mnt/session/rootfs error: while mounting image /proc/self/fd/3: squashfuse_ll exited with status 1: fuse: unknown option `

This patch removes '-o' if optsStr is empty. The squashfs image now works as expected:

> $ apptainer shell container.sqfs 
> Apptainer> 

### This fixes or addresses the following GitHub issues:

Maybe fixes #1037


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
