### PR TITLE
Allow suid installation prefix to be symlinked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Ensure `DOCKER_HOST` is honored in non-build flows.
 - Make the error message more helpful in another place where a remote is found
   to have no library client.
+- Allow symlinks to the compiled prefix for suid installations.  Fixes a
+  regression introduced in 1.1.4.
 - Build via zypper on SLE systems will use repositories of host via
-  suseconnect-container
+  suseconnect-container.
 - Avoid incorrect error when reqesting fakeroot network.
 
 ## v1.1.6 - \[2023-02-14\]

--- a/internal/pkg/buildcfg/confgen/gen.go
+++ b/internal/pkg/buildcfg/confgen/gen.go
@@ -88,7 +88,12 @@ var (
 )
 
 func getPrefix() (string) {
+	// NOTE: the first time this is called (from isSuidInstall()) is very
+	// early, and some error conditions may happen before debug messages
+	// are enabled.  Warnings and info messages do still work at that point.
 	prefixOnce.Do(func() {
+		// Although this is a sync.Once, there are multiple address
+		// spaces using this code so it does get called more than once
 		executablePath, err := os.Executable()
 		if err != nil {
 			sylog.Warningf("Error getting executable path, using default: %v", err)
@@ -99,7 +104,9 @@ func getPrefix() (string) {
 		_, err = os.Stat(executablePath)
 		if err != nil {
 			// Due to mount namespace issues, os.Executable may return a non-existing
-			// location
+			// location.  This is normal when starter-suid is in its compiled location,
+			// but assuming the original prefix here may help also in other circumstances.
+			// See https://github.com/apptainer/apptainer/issues/1061
 			installPrefix = "{{.Prefix}}"
 			return
 		}
@@ -109,7 +116,8 @@ func getPrefix() (string) {
 
 		switch base {
 		case "apptainer":
-			if bin == "{{.Bindir}}" {
+			realBindir, err := filepath.EvalSymlinks("{{.Bindir}}")
+			if err == nil && bin == realBindir {
 				// apptainer binary was not relocated
 				installPrefix = "{{.Prefix}}"
 			} else {
@@ -120,7 +128,8 @@ func getPrefix() (string) {
 			// The default LIBEXECDIR is PREFIX/libexec
 			// LIBEXECDIR/apptainer/bin/starter{|-suid}
 			installLibexecdir := filepath.Dir(filepath.Dir(bin))
-			if installLibexecdir == "{{.Libexecdir}}" {
+			realLibexecdir, err := filepath.EvalSymlinks("{{.Libexecdir}}")
+			if err == nil && installLibexecdir == realLibexecdir {
 				// starter was not relocated
 				installPrefix = "{{.Prefix}}"
 			} else {


### PR DESCRIPTION
This fixes a regression introduced in v1.1.4 which prevented suid installations to be placed at a location that is symlinked to the prefix as opposed to at the prefix directly.

- Fixes #1144 