### PR TITLE
squashfuse_ll: do not use -o if optsStr is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Bug fixes
 
+- Avoid `unknown option` error when using a bare squashfs image with
+  an unpatched `squashfuse_ll`.
 - Fix `GOCACHE` settings for golang build on PPA build environment.
 - Make the error message more helpful in another place where a remote is found
   to have no library client.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -84,6 +84,7 @@
 - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
 - Thomas Hamel <hmlth@t-hamel.fr>
 - Tim Wright <7im.Wright@protonmail.com>
+- Tobias Poschwatta <poschwatta@zib.de>
 - Tru Huynh <tru@pasteur.fr>
 - Tyson Whitehead <twhitehead@gmail.com>
 - Vanessa Sochat <vsoch@users.noreply.github.com>

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -176,7 +176,11 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 			// this will be passed as the first ExtraFile below, always fd 3
 			srcPath = "/proc/self/fd/3"
 		}
-		cmdArgs = append(cmdArgs, f.cmdPath, "-f", "-o", optsStr, srcPath, params.Target)
+		if optsStr != "" {
+			cmdArgs = append(cmdArgs, f.cmdPath, "-f", "-o", optsStr, srcPath, params.Target)
+		} else {
+			cmdArgs = append(cmdArgs, f.cmdPath, "-f", srcPath, params.Target)
+		}
 		cmd = exec.Command(cmdArgs[0], cmdArgs[1:]...)
 
 	case "ext3":


### PR DESCRIPTION
## Description of the Pull Request (PR):

This cherry-picks #1209 for release-1.1 branch.
