### PR TITLE
chore: wire up context for sign/verify, from sylabs 1367

### DIFF
--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2017-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2017-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -168,7 +168,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	}
 
 	// Sign the image.
-	if err := apptainer.Sign(cpath, opts...); err != nil {
+	if err := apptainer.Sign(cmd.Context(), cpath, opts...); err != nil {
 		sylog.Fatalf("Failed to sign container: %v", err)
 	}
 	sylog.Infof("Signature created and applied to image '%v'", cpath)

--- a/internal/app/apptainer/sign.go
+++ b/internal/app/apptainer/sign.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -10,6 +10,8 @@
 package apptainer
 
 import (
+	"context"
+
 	"github.com/apptainer/apptainer/pkg/sypgp"
 	"github.com/apptainer/sif/v2/pkg/integrity"
 	"github.com/apptainer/sif/v2/pkg/sif"
@@ -70,9 +72,13 @@ func OptSignObjects(ids ...uint32) SignOpt {
 //
 // By default, one digital signature is added per object group in f. To override this behavior,
 // consider using OptSignGroup and/or OptSignObject.
-func Sign(path string, opts ...SignOpt) error {
+func Sign(ctx context.Context, path string, opts ...SignOpt) error {
 	// Apply options to signer.
-	s := signer{}
+	s := signer{
+		opts: []integrity.SignerOpt{
+			integrity.OptSignWithContext(ctx),
+		},
+	}
 	for _, opt := range opts {
 		if err := opt(&s); err != nil {
 			return err

--- a/internal/app/apptainer/sign_test.go
+++ b/internal/app/apptainer/sign_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -10,6 +10,7 @@
 package apptainer
 
 import (
+	"context"
 	"crypto"
 	"errors"
 	"io"
@@ -147,7 +148,7 @@ func TestSign(t *testing.T) {
 			}
 			defer os.Remove(path)
 
-			if got, want := Sign(path, tt.opts...), tt.wantErr; !errors.Is(got, want) {
+			if got, want := Sign(context.Background(), path, tt.opts...), tt.wantErr; !errors.Is(got, want) {
 				t.Errorf("got error %v, want %v", got, want)
 			}
 		})

--- a/internal/app/apptainer/verify.go
+++ b/internal/app/apptainer/verify.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -179,7 +179,9 @@ func verifyCertificate(c *x509.Certificate, intermediates, roots *x509.CertPool)
 
 // getOpts returns integrity.VerifierOpt necessary to validate f.
 func (v verifier) getOpts(ctx context.Context, f *sif.FileImage) ([]integrity.VerifierOpt, error) {
-	var iopts []integrity.VerifierOpt
+	iopts := []integrity.VerifierOpt{
+		integrity.OptVerifyWithContext(ctx),
+	}
 
 	// Add key material from certificate(s).
 	for _, c := range v.certs {

--- a/internal/app/apptainer/verify_test.go
+++ b/internal/app/apptainer/verify_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -264,7 +264,7 @@ func Test_verifier_getOpts(t *testing.T) {
 				roots:         roots,
 			},
 			f:        oneGroupImage,
-			wantOpts: 1,
+			wantOpts: 2,
 		},
 		{
 			name: "Verifier",
@@ -274,7 +274,7 @@ func Test_verifier_getOpts(t *testing.T) {
 				},
 			},
 			f:        oneGroupImage,
-			wantOpts: 1,
+			wantOpts: 2,
 		},
 		{
 			name: "PGP",
@@ -282,7 +282,7 @@ func Test_verifier_getOpts(t *testing.T) {
 				pgp: true,
 			},
 			f:        oneGroupImage,
-			wantOpts: 1,
+			wantOpts: 2,
 		},
 		{
 			name: "PGPOpts",
@@ -293,55 +293,55 @@ func Test_verifier_getOpts(t *testing.T) {
 				},
 			},
 			f:        oneGroupImage,
-			wantOpts: 1,
+			wantOpts: 2,
 		},
 		{
 			name:     "Group1",
 			v:        verifier{groupIDs: []uint32{1}},
 			f:        oneGroupImage,
-			wantOpts: 1,
+			wantOpts: 2,
 		},
 		{
 			name:     "Object1",
 			v:        verifier{objectIDs: []uint32{1}},
 			f:        oneGroupImage,
-			wantOpts: 1,
+			wantOpts: 2,
 		},
 		{
 			name:     "All",
 			v:        verifier{all: true},
 			f:        oneGroupImage,
-			wantOpts: 0,
+			wantOpts: 1,
 		},
 		{
 			name:     "Legacy",
 			v:        verifier{legacy: true},
 			f:        oneGroupImage,
-			wantOpts: 2,
+			wantOpts: 3,
 		},
 		{
 			name:     "LegacyGroup1",
 			v:        verifier{legacy: true, groupIDs: []uint32{1}},
 			f:        oneGroupImage,
-			wantOpts: 2,
+			wantOpts: 3,
 		},
 		{
 			name:     "LegacyObject1",
 			v:        verifier{legacy: true, objectIDs: []uint32{1}},
 			f:        oneGroupImage,
-			wantOpts: 2,
+			wantOpts: 3,
 		},
 		{
 			name:     "LegacyAll",
 			v:        verifier{legacy: true, all: true},
 			f:        oneGroupImage,
-			wantOpts: 1,
+			wantOpts: 2,
 		},
 		{
 			name:     "Callback",
 			v:        verifier{cb: cb},
 			f:        oneGroupImage,
-			wantOpts: 1,
+			wantOpts: 2,
 		},
 	}
 

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,6 +12,7 @@ package apptainer
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1238,7 +1239,7 @@ func (e *EngineOperations) loadImages(starterConfig *starter.Config) error {
 				}
 			}
 
-			if ok, err := ecl.ShouldRunFp(img.File, kr); err != nil {
+			if ok, err := ecl.ShouldRunFp(context.TODO(), img.File, kr); err != nil {
 				return fmt.Errorf("while checking container image with ECL: %s", err)
 			} else if !ok {
 				return errors.New("image prohibited by ECL")

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -15,6 +15,7 @@
 package syecl
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -207,7 +208,7 @@ func checkBlackList(v *integrity.Verifier, egroup *Execgroup) (ok bool, err erro
 	return true, nil
 }
 
-func shouldRun(ecl *EclConfig, fp *os.File, kr openpgp.KeyRing) (ok bool, err error) {
+func shouldRun(ctx context.Context, ecl *EclConfig, fp *os.File, kr openpgp.KeyRing) (ok bool, err error) {
 	var egroup *Execgroup
 
 	// look what execgroup a container is part of
@@ -263,6 +264,7 @@ func shouldRun(ecl *EclConfig, fp *os.File, kr openpgp.KeyRing) (ok bool, err er
 	}
 
 	opts := []integrity.VerifierOpt{
+		integrity.OptVerifyWithContext(ctx),
 		integrity.OptVerifyWithKeyRing(kr),
 		integrity.OptVerifyCallback(verifyCallback),
 	}
@@ -299,7 +301,7 @@ func shouldRun(ecl *EclConfig, fp *os.File, kr openpgp.KeyRing) (ok bool, err er
 }
 
 // ShouldRun determines if a container should run according to its execgroup rules
-func (ecl *EclConfig) ShouldRun(cpath string, kr openpgp.KeyRing) (ok bool, err error) {
+func (ecl *EclConfig) ShouldRun(ctx context.Context, cpath string, kr openpgp.KeyRing) (ok bool, err error) {
 	// look if ECL rules are activated
 	if !ecl.Activated {
 		return true, nil
@@ -311,15 +313,15 @@ func (ecl *EclConfig) ShouldRun(cpath string, kr openpgp.KeyRing) (ok bool, err 
 	}
 	defer fp.Close()
 
-	return shouldRun(ecl, fp, kr)
+	return shouldRun(ctx, ecl, fp, kr)
 }
 
 // ShouldRunFp determines if an already opened container should run according to its execgroup rules
-func (ecl *EclConfig) ShouldRunFp(fp *os.File, kr openpgp.KeyRing) (ok bool, err error) {
+func (ecl *EclConfig) ShouldRunFp(ctx context.Context, fp *os.File, kr openpgp.KeyRing) (ok bool, err error) {
 	// look if ECL rules are activated
 	if !ecl.Activated {
 		return true, nil
 	}
 
-	return shouldRun(ecl, fp, kr)
+	return shouldRun(ctx, ecl, fp, kr)
 }

--- a/internal/pkg/syecl/syecl_test.go
+++ b/internal/pkg/syecl/syecl_test.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -11,6 +11,7 @@
 package syecl
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -439,7 +440,7 @@ func TestShouldRun(t *testing.T) {
 			}
 
 			// Test ShouldRun (takes path).
-			got, err := c.ShouldRun(tt.path, openpgp.EntityList{getTestEntity(t)})
+			got, err := c.ShouldRun(context.Background(), tt.path, openpgp.EntityList{getTestEntity(t)})
 
 			if want := !tt.wantErr; got != want {
 				t.Errorf("got run %v, want %v", got, want)
@@ -456,7 +457,7 @@ func TestShouldRun(t *testing.T) {
 			}
 			defer f.Close()
 
-			got, err = c.ShouldRunFp(f, openpgp.EntityList{getTestEntity(t)})
+			got, err = c.ShouldRunFp(context.Background(), f, openpgp.EntityList{getTestEntity(t)})
 
 			if want := !tt.wantErr; got != want {
 				t.Errorf("got run %v, want %v", got, want)


### PR DESCRIPTION
This pulls in sylabs part of PR

- sylabs/singularity#1367