### PR TITLE
Move if statement to Requires instead of BuildRequires

### DIFF
--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -89,11 +89,6 @@ BuildRequires: git
 BuildRequires: gcc
 BuildRequires: make
 BuildRequires: libseccomp-devel
-%if "%{_target_vendor}" == "suse"
-Requires: squashfs
-%else
-Requires: squashfs-tools
-%endif
 BuildRequires: cryptsetup
 %if "%{?squashfuse_version}" != ""
 BuildRequires: autoconf
@@ -102,6 +97,11 @@ BuildRequires: libtool
 BuildRequires: pkgconfig
 BuildRequires: fuse3-devel
 BuildRequires: zlib-devel
+%endif
+%if "%{_target_vendor}" == "suse"
+Requires: squashfs
+%else
+Requires: squashfs-tools
 %endif
 Requires: squashfuse
 Requires: fakeroot


### PR DESCRIPTION
Move if statement of squashfs/squashfs-tools down a little bit where Requires are instead of BuildRequires. It was inspired by
- sylabs/singularity#1456,

but there is no need to pull in a commit.