### PR TITLE
Inherit all libraries in a parent's /.singularity.d/libs (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Bug fixes
 
+- Allow gpu options such as `--nv` to be nested by always inheriting all
+  libraries bound in to a parent container's `/.singularity.d/libs`.
 - Avoid `unknown option` error when using a bare squashfs image with
   an unpatched `squashfuse_ll`.
 - Fix `GOCACHE` settings for golang build on PPA build environment.

--- a/internal/pkg/util/paths/resolve.go
+++ b/internal/pkg/util/paths/resolve.go
@@ -71,20 +71,25 @@ func Resolve(fileList []string) ([]string, []string, error) {
 		return nil, nil, fmt.Errorf("could not retrieve ld cache: %v", err)
 	}
 
-	boundLibsDir := "/.singularity.d/libs"
-	boundLibs, err := ioutil.ReadDir(boundLibsDir)
-	if err != nil {
-		boundLibs = nil // just in case
-	}
-
 	// Track processed binaries/libraries to eliminate duplicates
 	bins := make(map[string]struct{})
 	libs := make(map[string]struct{})
 
 	var libraries []string
 	var binaries []string
+
+	boundLibsDir := "/.singularity.d/libs"
+	boundLibs, err := ioutil.ReadDir(boundLibsDir)
+	if err == nil {
+		// Inherit all libraries from a parent
+		for _, boundLib := range boundLibs {
+			libName := boundLib.Name()
+			libs[libName] = struct{}{}
+			libraries = append(libraries, filepath.Join(boundLibsDir, libName))
+		}
+	}
+
 	for _, file := range fileList {
-		// if the file contains an ".so", treat it as a library
 		if strings.Contains(file, ".so") {
 			// If we have an absolute path, add it 'as-is', plus any symlinks that resolve to it
 			if filepath.IsAbs(file) {
@@ -107,21 +112,6 @@ func Resolve(fileList []string) ([]string, []string, error) {
 					sylog.Warningf("Could not close ELIB: %v", err)
 				}
 			} else {
-				// look first in /.singularity.d/libs
-				// this enables using gpu options in nested containers
-				gotone := false
-				for _, boundLib := range boundLibs {
-					libName := boundLib.Name()
-					if !strings.HasPrefix(libName, file) {
-						continue
-					}
-					libraries = append(libraries, filepath.Join(boundLibsDir, libName))
-					gotone = true
-					break
-				}
-				if gotone {
-					continue
-				}
 				for libPath, libName := range ldCache {
 					if !strings.HasPrefix(libName, file) {
 						continue

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -151,8 +151,11 @@ esac
 # $4 -- if true, try replacing "/updates/" with "/releases/" if nothing found
 # If return value 0, succeeded and stdout contains latest url
 # If return value not zero, failed and stdout contains final directory url
+# If a package is not found, the listing will be silently retried up to 3 times,
+# because sometimes not all mirrors are up to date
 LASTURL=""
 LASTPKGS=""
+RETRY=0
 latesturl()
 {
 	typeset URL="$1"
@@ -164,16 +167,25 @@ latesturl()
 		# optimization: re-use last list if it hasn't changed
 		LASTURL="$URL"
 		LASTPKGS="$(curl -Ls "$URL")"
+	elif [ $RETRY -gt 0 ]; then
+		LASTPKGS="$(curl -Ls "$URL")"
 	fi
 	typeset LATEST="$(echo "$LASTPKGS"|sed 's/.*href="//;s/".*//'|grep "^$2-[0-9].*$ARCH"|tail -1)"
 	if [ -n "$LATEST" ]; then
+		RETRY=0
 		echo "$URL/$LATEST"
 	elif [ "$4" = true ]; then
+		RETRY=0
 		URL="${URL/\/updates\///releases/}"
 		URL="${URL/\/Packages\///os/Packages/}"
 		latesturl "$URL" "$2" false false
 		return $?
+	elif [ $RETRY -lt 3 ]; then
+		RETRY=$((RETRY+1))
+		latesturl "$URL" "$2" false "$4"
+		return $?
 	else
+		RETRY=0
 		echo "$URL"
 		return 1
 	fi


### PR DESCRIPTION
This cherry-picks #1220 to the release-1.1 branch.

It also cherry-picks #1165 because without it, CI checks keep failing.