### PR TITLE
bci like container if no registration is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix joining cgroup of instance started as root, with cgroups v1,
   non-default cgroupfs manager, and no device rules.
 - Ensure `DOCKER_HOST` is honored in non-build flows.
+- Build via zypper on SLE systems will use repositories of host via
+  suseconnect-container
 
 ### Bug fixes
 


### PR DESCRIPTION
Signed-off-by: Christian Goll <cgoll@suse.de>

## Simplify SLE builds

Add the possibility to build SUSE containers via suseconnect-container, what
removed the need to register the container via SUSEConnect.
This needs the possibility to have bind mounts in the post stage of the build,
but this is not exposed in the def file.

PR for the 1.1-release branch, cherry picked from main
