### PR TITLE
Bind in user's home directory to /root with fake fakeroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Fix non-root instance join with unprivileged systemd managed cgroups, when
   join is from outside a user-owned cgroup.
+- Map the user's home directory to the root home directory by default in the
+  non-subuid fakeroot mode like it was in the subuid fakeroot mode, for both
+  action commands and building containers from definition files.
 - Define EUID in %environment alongside UID.
 - Avoid UID / GID / EUID readonly var warnings with `--env-file`.
 - In `--rocm` mode, the whole of `/dev/dri` is now bound into the container when

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -18,6 +18,7 @@ import (
 	osExec "os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/apptainer/apptainer/internal/pkg/build"
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
@@ -87,7 +88,7 @@ func fakerootExec(isDeffile bool) {
 		sylog.Infof("User not listed in %v, trying root-mapped namespace", fakeroot.SubUIDFile)
 		os.Setenv("_APPTAINER_FAKEFAKEROOT", "1")
 		if buildArgs.ignoreUserns {
-			err = errors.New("could not start root-mapped namespace because of --ignore-userns is set")
+			err = errors.New("could not start root-mapped namespace because --ignore-userns is set")
 		} else {
 			err = fakeroot.UnshareRootMapped(args)
 		}
@@ -142,10 +143,25 @@ func runBuild(cmd *cobra.Command, args []string) {
 
 	fakerootPath := ""
 	if os.Getenv("_APPTAINER_FAKEFAKEROOT") == "1" {
+		var err error
+		uid := os.Getuid()
+		if uid == 0 {
+			// Try to bind-mount the original user's home directory to /root.
+			// This enables things like git clone to work in the %setup section
+			// of a definition file.
+			homedir := os.Getenv("HOME")
+			if homedir != "" {
+				err = syscall.Mount(homedir, "/root", "", syscall.MS_BIND, "")
+				if err != nil {
+					sylog.Debugf("Failure bind-mounting %s to /root: %v, skipping", homedir, err)
+				} else {
+					sylog.Debugf("Bind-mounting %s to /root", homedir)
+				}
+			}
+		}
 		// Try fakeroot command
 		os.Unsetenv("_APPTAINER_FAKEFAKEROOT")
 		buildArgs.fakeroot = false
-		var err error
 		if buildArgs.ignoreFakerootCmd {
 			err = errors.New("fakeroot command is ignored because of --ignore-fakeroot-command")
 		} else {
@@ -153,7 +169,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		}
 		if err != nil {
 			sylog.Infof("fakeroot command not found")
-			if os.Getuid() != 0 {
+			if uid != 0 {
 				if fs.IsFile(spec) && !isImage(spec) {
 					sylog.Fatalf("Building from a definition file requires root or some kind of fake root")
 				}
@@ -163,7 +179,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 			sylog.Infof("Installing some packages may fail")
 		} else {
 			sylog.Infof("The %%post section will be run under fakeroot")
-			if !buildArgs.fixPerms && os.Getuid() != 0 {
+			if !buildArgs.fixPerms && uid != 0 {
 				sylog.Infof("Using --fix-perms because building from a definition file")
 				sylog.Infof(" without either root user or unprivileged user namespaces")
 				buildArgs.fixPerms = true

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -25,14 +25,14 @@ import (
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
-// re-exec the command effectively under unshare -r
+// re-exec the command effectively under unshare -rm
 func UnshareRootMapped(args []string) error {
 	cmd := osExec.Command(args[0], args[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWUSER
+	cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS
 	cmd.SysProcAttr.UidMappings = []syscall.SysProcIDMap{
 		{ContainerID: 0, HostID: syscall.Getuid(), Size: 1},
 	}


### PR DESCRIPTION
This bind's in $HOME to /root when using the non-subuid "fake" fakeroot mode, as it had been for the subuid-based fakeroot.

- Fixes #1122
- Fixes #1195