### PR TITLE
Use bash shebang for mconfig

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -1,4 +1,4 @@
-#!/bin/sh -
+#!/bin/bash
 # Copyright (c) Contributors to the Apptainer project, established as
 #   Apptainer a Series of LF Projects LLC.
 #   For website terms of use, trademark policy, privacy policy and other
@@ -7,6 +7,7 @@
 # Copyright (c) 2015-2018, Yannick Cote <yhcote@gmail.com>. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be found
 # in the LICENSE file.
+# shellcheck disable=SC2001
 set -e
 
 verbose=0


### PR DESCRIPTION
This puts a bash shebang on mconfig which enables using the bashism of `read -r`. Apptainer is only supported on Linux anyway so it doesn't need to avoid requiring bash.

 - Fixes #1117