### PR TITLE
Make full-line read work with any posix sh (release-1.1)

### DIFF
--- a/mconfig
+++ b/mconfig
@@ -882,7 +882,7 @@ if [ "$host" = "unix" ]; then
 	    -e "s/@PACKAGE_RELEASE@/${release_info}/" \
 	    -e "s,@PACKAGE_GOLANG_SOURCE@,${package_golang_source}," \
 		$sourcedir/dist/rpm/$RPMSPEC.in | \
-		while read -r; do
+		while IFS='' read -r REPLY; do
 			if [ "$REPLY" = "@BUNDLED_PROVIDES@" ]; then
 				# Calculate bundled provides
 				awk '{if (index($1, "/") != 0 && ($1 != "//")) {print "Provides: bundled(golang("$1")) = "$2}}' go.mod | sed -e 's/-/_/g' | sort | uniq


### PR DESCRIPTION
This cherry-picks #1234 to the release-1.1 branch.