### PR TITLE
fix: Pass LD_LIBRARY_PATH to wrapped unsquashfs correctly, from sylabs 1356 (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Avoid incorrect error when requesting fakeroot network.
 - Build via zypper on SLE systems will use repositories of host via
   suseconnect-container.
+- Pass computed `LD_LIBRARY_PATH` to wrapped unsquashfs. Fixes issues where
+  `unsquashfs` on host uses libraries in non-default paths.
 
 ## v1.1.6 - \[2023-02-14\]
 

--- a/internal/pkg/image/unpacker/squashfs_apptainer.go
+++ b/internal/pkg/image/unpacker/squashfs_apptainer.go
@@ -363,6 +363,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	cmd.Dir = "/"
 	cmd.Env = []string{
 		fmt.Sprintf("LD_LIBRARY_PATH=%s", strings.Join(libraryPath, string(os.PathListSeparator))),
+		fmt.Sprintf("APPTAINERENV_LD_LIBRARY_PATH=%s", strings.Join(libraryPath, string(os.PathListSeparator))),
 		fmt.Sprintf("APPTAINER_DEBUG=%s", os.Getenv("APPTAINER_DEBUG")),
 	}
 


### PR DESCRIPTION
This cherry-picks #1236 to the release-1.1 branch