### PR TITLE
Add xino=on for writable overlay mount points (release-1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix loop device 'no such device or address' spurious errors when using shared
   loop devices.
 - Remove unwanted colors to STDERR.
+- Add `xino=on` mount option for writable kernel overlay mount points to fix
+  inode numbers consistency after kernel cache flush (not applicable to fuse-overlayfs).
 
 ## v1.1.7 - \[2023-03-28\]
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -722,6 +722,10 @@ mount:
 				sylog.Verbosef("Overlay mount failed with %s, mounting with index=off", err)
 				optsString = fmt.Sprintf("%s,index=off", optsString)
 				goto mount
+			} else if mnt.Type == "overlay" && err == syscall.EINVAL {
+				sylog.Verbosef("Overlay mount failed with %s, mounting without xino option", err)
+				optsString = strings.Replace(optsString, ",xino=on", "", -1)
+				goto mount
 			} else if mnt.Type == "overlay" && tag == mount.LayerTag {
 				if imageDriver != nil && imageDriver.Features()&image.OverlayFeature != 0 {
 

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -701,7 +701,7 @@ func (p *Points) AddOverlay(tag AuthorizedTag, dest string, flags uintptr, lower
 		if !strings.HasPrefix(workdir, "/") {
 			return fmt.Errorf("workdir must be an absolute path")
 		}
-		options = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerdir, upperdir, workdir)
+		options = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,xino=on", lowerdir, upperdir, workdir)
 	} else {
 		options = fmt.Sprintf("lowerdir=%s", lowerdir)
 	}


### PR DESCRIPTION
### Description

- Pick 69552743893439f8fd3511d432c6cb3ad5544ef9

### This fixes or addresses the following GitHub issues:

- Fixes #1267 