### PR TITLE
fix: apptainer.conf default root capabilities comment, from sylabs 1584

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   non-default cgroupfs manager, and no device rules.
 - Ensure `DOCKER_HOST` is honored in non-build flows.
 - Remove duplicated group ids.
+- Corrected `apptainer.conf` comment, to refer to correct file as source
+  of default capabilities when `root default capabilities = file`.
 
 ## v1.1.8 - \[2023-04-25\]
 

--- a/internal/pkg/confgen/testdata/test_1.out.correct
+++ b/internal/pkg/confgen/testdata/test_1.out.correct
@@ -198,10 +198,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/apptainer/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/apptainer/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/internal/pkg/confgen/testdata/test_2.in
+++ b/internal/pkg/confgen/testdata/test_2.in
@@ -198,10 +198,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/apptainer/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/apptainer/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/internal/pkg/confgen/testdata/test_2.out.correct
+++ b/internal/pkg/confgen/testdata/test_2.out.correct
@@ -198,10 +198,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/apptainer/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/apptainer/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/internal/pkg/confgen/testdata/test_3.in
+++ b/internal/pkg/confgen/testdata/test_3.in
@@ -189,10 +189,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/apptainer/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/apptainer/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/internal/pkg/confgen/testdata/test_3.out.correct
+++ b/internal/pkg/confgen/testdata/test_3.out.correct
@@ -198,10 +198,11 @@ always use nv = no
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/apptainer/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/apptainer/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = full
 

--- a/internal/pkg/confgen/testdata/test_default.tmpl
+++ b/internal/pkg/confgen/testdata/test_default.tmpl
@@ -209,10 +209,11 @@ always use nv = {{ if eq .AlwaysUseNv true }}yes{{ else }}no{{ end }}
 
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
-# DEFAULT: no
+# DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/apptainer/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/apptainer/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = {{ .RootDefaultCapabilities }}
 

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -437,7 +437,8 @@ always use rocm = {{ if eq .AlwaysUseRocm true }}yes{{ else }}no{{ end }}
 # DEFAULT: full
 # Define default root capability set kept during runtime
 # - full: keep all capabilities (same as --keep-privs)
-# - file: keep capabilities configured in ${prefix}/etc/apptainer/capabilities/user.root
+# - file: keep capabilities configured for root in
+#         ${prefix}/etc/apptainer/capability.json
 # - no: no capabilities (same as --no-privs)
 root default capabilities = {{ .RootDefaultCapabilities }}
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1584
 which fixed
- sylabs/singularity#1583

The original PR description was:
> Corrected `singularity.conf` comment, to refer to correct file as source of default capabilities when `root default capabilities = file`.