### PR TITLE
refine the misleading message trying to use encrypted filesystem in unprivileged mode

### DIFF
--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -232,7 +232,7 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 		}
 
 	case "encryptfs":
-		return fmt.Errorf("mounting an encrypted filesystem requires root or a suid installation")
+		return fmt.Errorf("reading a root-encrypted SIF requires root or a suid installation")
 
 	default:
 		return fmt.Errorf("filesystem type %v not recognized by image driver", params.Filesystem)


### PR DESCRIPTION
## Description of the Pull Request (PR):

refine the misleading message trying to use encrypted filesystem in unprivileged mode.

### This fixes or addresses the following GitHub issues:

 - Fixes #1303 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
