### PR TITLE
Enable "allow setuid-mount extfs" for all e2e tests

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -717,9 +717,6 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
-	e2e.SetDirective(t, c.env, "allow setuid-mount extfs", "yes")
-	defer e2e.ResetDirective(t, c.env, "allow setuid-mount extfs")
-
 	tests := []struct {
 		name    string
 		argv    []string
@@ -1933,9 +1930,6 @@ func (c actionTests) bindImage(t *testing.T) {
 		}...),
 		e2e.ExpectExit(0),
 	)
-
-	e2e.SetDirective(t, c.env, "allow setuid-mount extfs", "yes")
-	defer e2e.ResetDirective(t, c.env, "allow setuid-mount extfs")
 
 	tests := []struct {
 		name    string

--- a/e2e/internal/e2e/config.go
+++ b/e2e/internal/e2e/config.go
@@ -26,6 +26,8 @@ func SetupDefaultConfig(t *testing.T, path string) {
 	apptainerconf.SetCurrentConfig(c)
 	apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, true)
 
+	c.AllowSetuidMountExtfs = true
+
 	Privileged(func(t *testing.T) {
 		f, err := os.Create(path)
 		if err != nil {

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -75,9 +75,6 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
-	e2e.SetDirective(t, c.env, "allow setuid-mount extfs", "yes")
-	defer e2e.ResetDirective(t, c.env, "allow setuid-mount extfs")
-
 	type test struct {
 		name    string
 		profile e2e.Profile

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -1,4 +1,3 @@
-// Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
@@ -286,9 +285,6 @@ func (c ctx) testFuseExt3Mount(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-
-	e2e.SetDirective(t, c.env, "allow setuid-mount extfs", "yes")
-	defer e2e.ResetDirective(t, c.env, "allow setuid-mount extfs")
 
 	c.env.RunApptainer(
 		t,


### PR DESCRIPTION
The [code fix](https://github.com/apptainer/apptainer/commit/5a4964f5ba9c8d89a0e353b97f51fd607670a9f7) for [GHSA-j4rf-7357-f4cg](https://github.com/apptainer/apptainer/security/advisories/GHSA-j4rf-7357-f4cg) included enabling the `allow setuid-mount extfs` option around some parallel test groups.  Those are sometimes interfering with each other due to race conditions.

This PR changes that setting to be enabled once at the beginning and left on until the config file tests, which happen during the sequential portion of the tests at the end.