### PR TITLE
Enable "allow setuid-mount extfs" for all e2e tests (release-1.1)

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -790,9 +790,6 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
-	e2e.SetDirective(t, c.env, "allow setuid-mount extfs", "yes")
-	defer e2e.ResetDirective(t, c.env, "allow setuid-mount extfs")
-
 	tests := []struct {
 		name    string
 		argv    []string
@@ -1936,9 +1933,6 @@ func (c actionTests) bindImage(t *testing.T) {
 		}...),
 		e2e.ExpectExit(0),
 	)
-
-	e2e.SetDirective(t, c.env, "allow setuid-mount extfs", "yes")
-	defer e2e.ResetDirective(t, c.env, "allow setuid-mount extfs")
 
 	tests := []struct {
 		name    string

--- a/e2e/internal/e2e/config.go
+++ b/e2e/internal/e2e/config.go
@@ -26,6 +26,8 @@ func SetupDefaultConfig(t *testing.T, path string) {
 	apptainerconf.SetCurrentConfig(c)
 	apptainerconf.SetBinaryPath(buildcfg.LIBEXECDIR, true)
 
+	c.AllowSetuidMountExtfs = true
+
 	Privileged(func(t *testing.T) {
 		f, err := os.Create(path)
 		if err != nil {

--- a/e2e/overlay/overlay.go
+++ b/e2e/overlay/overlay.go
@@ -74,9 +74,6 @@ func (c ctx) testOverlayCreate(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
-	e2e.SetDirective(t, c.env, "allow setuid-mount extfs", "yes")
-	defer e2e.ResetDirective(t, c.env, "allow setuid-mount extfs")
-
 	type test struct {
 		name    string
 		profile e2e.Profile

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -286,9 +286,6 @@ func (c ctx) testFuseExt3Mount(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	e2e.SetDirective(t, c.env, "allow setuid-mount extfs", "yes")
-	defer e2e.ResetDirective(t, c.env, "allow setuid-mount extfs")
-
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(e2e.UserProfile),


### PR DESCRIPTION
This cherry-picks #1307 into the release-1.1 branch.