### PR TITLE
Restore copyright in e2e/run

### DIFF
--- a/e2e/run/regressions.go
+++ b/e2e/run/regressions.go
@@ -1,3 +1,12 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
 package run
 
 import (

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -1,3 +1,4 @@
+// Copyright (c) Contributors to the Apptainer project, established as
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies


### PR DESCRIPTION
This restores a copyright line accidentally removed in #1307.  I also happened to notice that another file in the same directory did not have a copyright statement at all for some reason.