### PR TITLE
Is a warning message sufficient when staging /etc/resolv.conf fails?

### DIFF
--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -411,7 +411,7 @@ func (b *Build) Full(ctx context.Context) error {
 		// create stage file for /etc/resolv.conf and /etc/hosts
 		sessionResolv, err := createStageFile("/etc/resolv.conf", stage.b, "Name resolution could fail")
 		if err != nil {
-			return err
+			sylog.Warningf("Failed to create stage file /etc/resolv.conf. Name resolution could fail!")
 		} else if sessionResolv != "" {
 			defer os.Remove(sessionResolv)
 		}


### PR DESCRIPTION
I'm trying to use "apptainer build" to create containers inside the sandbox environment of the Nix package manager.

So far I've successfully been using mksquashfs to create the images for apptainer (see also #1209). But I think it may have advantages to use "apptainer build" instead to create the container from the file tree. It seems to work well, except for /etc/resolv.conf that is missing in the sandbox environment. This makes the Full() function fail and abort the build.

The attached patch makes this a non-fatal error. It's the only change needed to make the build succeed.

An alternative approach could be to make createStageFile use etc/resolv.conf from the sandbox tree or somewhere else if present. Not sure if that's better.

