### PR TITLE
Fixing GetFakeBinds to account for multiple entries in LD_PRELOAD when looking for the libfakeroot*.so

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -87,6 +87,7 @@
 - Shane Loretz <sloretz@openrobotics.org>, <shane.loretz@gmail.com>
 - Simon Leary <simon.leary42@gmail.com>
 - Shengjing Zhu <i@zhsj.me>
+- Subil Abraham <abrahams@ornl.gov>
 - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
 - Thomas Hamel <hmlth@t-hamel.fr>
 - Tim Wright <7im.Wright@protonmail.com>

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -142,6 +142,13 @@ func GetFakeBinds(fakerootPath string) ([]string, error) {
 	if libraryPath == "" {
 		return binds, fmt.Errorf("No LD_LIBRARY_PATH in fakeroot environment")
 	}
+	preload_entries := strings.Split(preload, ":")
+	for _, entry := range preload_entries {
+		if strings.HasPrefix(entry, "libfakeroot") {
+			preload = entry
+			break
+		}
+	}
 
 	src := fakerootPath
 	point := binds[0]

--- a/peakbuild
+++ b/peakbuild
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+module load gcc/9.1.0
+rm -rf builddir
+export PATH=/gpfs/alpine/stf007/scratch/subil/containerstuff/apptainertests/mpitests/apptainervariants/install/peak/go/bin:$PATH
+./mconfig --prefix=/gpfs/alpine/stf007/scratch/subil/containerstuff/apptainertests/mpitests/apptainervariants/install/peak/apptainer1.1.8 # --without-suid
+cd `pwd`/builddir
+make -C builddir test

--- a/peakbuild
+++ b/peakbuild
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-module load gcc/9.1.0
-rm -rf builddir
-export PATH=/gpfs/alpine/stf007/scratch/subil/containerstuff/apptainertests/mpitests/apptainervariants/install/peak/go/bin:$PATH
-./mconfig --prefix=/gpfs/alpine/stf007/scratch/subil/containerstuff/apptainertests/mpitests/apptainervariants/install/peak/apptainer1.1.8 # --without-suid
-cd `pwd`/builddir
-make -C builddir test


### PR DESCRIPTION


## Description of the Pull Request (PR):

Before stage 1 during binding of fakeroot binaries and libraries into /.singularity.d/libs, the LD_PRELOAD value is assumed to only have one entry, the libfakeroot*.so`, by `GetFakeBinds` function (in `internal/pkg/fakeroot/fakefake.go`) . But when there is more than one entry in LD_PRELOAD, the third value of `binds` returned by `GetFakeBinds` is set to just `/.singularity.d/libs/libfakeroot.so` instead of something like `/usr/lib64/libfakeroot/libfakeroot-sysv.so:/.singularity.d/libs/libfakeroot.so` like it should. This leads to a later error that looks like 

```
FATAL:   container creation failed: mount hook function failure: mount /.singularity.d/libs/libfakeroot.so->/home/subil/Tools/apptainerversions/v1.1.8/var/apptainer/mnt/session/libs/libfakeroot.so error: while mounting /.singularity.d/libs/libfakeroot.so: mount source /.singularity.d/libs/libfakeroot.so doesn't exist
```

This because in this snippet from GetFakeBinds function in `internal/pkg/fakeroot/fakefake.go`


```
	splits = strings.Split(libraryPath, ":")
	for _, dir := range splits {
		// Find the preload library in libraryPath
		src = filepath.Join(dir, preload)
		if _, err = os.Stat(src); err == nil {
			binds[2] = src + ":" + point
			break
		}
```
`src` simply joins `dir` (which would be something like `/usr/lib64/libfakeroot`) with `preload` (which is the LD_PRELOAD value which is expected to be just `libfakeroot-sysv.so` or something like that) and checks to see if the joined `src` (`/usr/lib64/libfakeroot/libfakeroot-sysv.so`) exists as a file with `os.Stat`. But when you have multiple entries in LD_PRELOAD (because you're adding some other library into LD_PRELOAD ahead of time), `os.Stat` is now checking the existence of a file named something like `/usr/lib64/libfakeroot/libfakeroot-sysv.so:libadd.so` which obviously doesn't exist (where `libadd.so` is some other library you wanted to be preloaded and so you put it in LD_PRELOAD). 

This PR makes sure that the `preload` variable is updated with just the `libfakeroot*.so` entry and leaves out any other entries from `LD_PRELOAD` before the above mentioned snippet runs, in order to make sure `os.Stat` is stat-ing an actual file path and the `binds[2]` is updated correctly.


### This fixes or addresses the following GitHub issues:

 - Fixes #


