### PR TITLE
Add an --underlay action option to prefer underlay instead of overlay for bind mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Remove duplicated group ids.
 - Corrected `apptainer.conf` comment, to refer to correct file as source
   of default capabilities when `root default capabilities = file`.
+- Add an `--underlay` action option to prefer underlay instead of overlay
+  for bind mounts.
 
 ## v1.1.8 - \[2023-04-25\]
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -93,6 +93,8 @@ var (
 	ignoreSubuid      bool
 	ignoreFakerootCmd bool
 	ignoreUserns      bool
+
+	underlay bool // whether using underlay instead of overlay
 )
 
 // --app
@@ -850,6 +852,17 @@ var actionIgnoreUsernsFlag = cmdline.Flag{
 	Hidden:       true,
 }
 
+// --underlay
+var actionUnderlayFlag = cmdline.Flag{
+	ID:           "underlayFlag",
+	Value:        &underlay,
+	DefaultValue: false,
+	Name:         "underlay",
+	Usage:        "use underlay",
+	EnvKeys:      []string{"UNDERLAY"},
+	Hidden:       false,
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -945,5 +958,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionIgnoreSubuidFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreFakerootCommand, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreUsernsFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionUnderlayFlag, actionsInstanceCmd...)
 	})
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -359,6 +359,7 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 		launch.OptIgnoreUserns(ignoreUserns),
 		launch.OptUseBuildConfig(useBuildConfig),
 		launch.OptTmpDir(tmpDir),
+		launch.OptUnderlay(underlay),
 	}
 
 	l, err := launch.NewLauncher(opts...)

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1186,8 +1186,29 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "SimpleFileUnderlay",
+			args: []string{
+				"--underlay",
+				"--bind", canaryFileBind,
+				sandbox,
+				"test", "-f", contCanaryFile,
+			},
+			exit: 0,
+		},
+		{
 			name: "SimpleFilePwd",
 			args: []string{
+				"--bind", canaryFileBind,
+				"--pwd", contCanaryDir,
+				sandbox,
+				"test", "-f", "file",
+			},
+			exit: 0,
+		},
+		{
+			name: "SimpleFilePwdUnderlay",
+			args: []string{
+				"--underlay",
 				"--bind", canaryFileBind,
 				"--pwd", contCanaryDir,
 				sandbox,
@@ -1215,8 +1236,40 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "SimpleDirUnderlay",
+			args: []string{
+				"--underlay",
+				"--bind", canaryDirBind,
+				sandbox,
+				"test", "-f", contCanaryFile,
+			},
+			exit: 0,
+		},
+		{
+			name: "SimpleDirPwdUnderlay",
+			args: []string{
+				"--underlay",
+				"--bind", canaryDirBind,
+				"--pwd", contCanaryDir,
+				sandbox,
+				"test", "-f", "file",
+			},
+			exit: 0,
+		},
+		{
 			name: "SimpleFileWritableOK",
 			args: []string{
+				"--writable",
+				"--bind", hostCanaryFile,
+				sandbox,
+				"test", "-f", hostCanaryFile,
+			},
+			exit: 0,
+		},
+		{
+			name: "SimpleFileWritableUnderlayOK",
+			args: []string{
+				"--underlay",
 				"--writable",
 				"--bind", hostCanaryFile,
 				sandbox,
@@ -1265,8 +1318,30 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "HomeContainOverrideUnderlay",
+			args: []string{
+				"--underlay",
+				"--contain",
+				"--bind", hostCanaryDir + ":/home",
+				sandbox,
+				"test", "-f", "/home/file",
+			},
+			exit: 0,
+		},
+		{
 			name: "TmpContainOverride",
 			args: []string{
+				"--contain",
+				"--bind", hostCanaryDir + ":/tmp",
+				sandbox,
+				"test", "-f", "/tmp/file",
+			},
+			exit: 0,
+		},
+		{
+			name: "TmpContainOverrideUnderlay",
+			args: []string{
+				"--underlay",
 				"--contain",
 				"--bind", hostCanaryDir + ":/tmp",
 				sandbox,
@@ -1285,8 +1360,29 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "VarTmpContainOverrideUnderlay",
+			args: []string{
+				"--underlay",
+				"--contain",
+				"--bind", hostCanaryDir + ":/var/tmp",
+				sandbox,
+				"test", "-f", "/var/tmp/file",
+			},
+			exit: 0,
+		},
+		{
 			name: "SymlinkOneLevelFileBind",
 			args: []string{
+				"--bind", hostCanaryFile + ":/var/etc/symlink1",
+				sandbox,
+				"test", "-f", "/etc/symlink1",
+			},
+			exit: 0,
+		},
+		{
+			name: "SymlinkOneLevelFileBindUnderlay",
+			args: []string{
+				"--underlay",
 				"--bind", hostCanaryFile + ":/var/etc/symlink1",
 				sandbox,
 				"test", "-f", "/etc/symlink1",
@@ -1303,8 +1399,28 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "SymlinkTwoLevelFileBindUnderlay",
+			args: []string{
+				"--underlay",
+				"--bind", hostCanaryFile + ":/var/etc/madness/symlink2",
+				sandbox,
+				"test", "-f", "/madness/symlink2",
+			},
+			exit: 0,
+		},
+		{
 			name: "SymlinkOneLevelDirBind",
 			args: []string{
+				"--bind", hostCanaryDir + ":/var/etc",
+				sandbox,
+				"test", "-f", "/etc/file",
+			},
+			exit: 0,
+		},
+		{
+			name: "SymlinkOneLevelDirBindUnderlay",
+			args: []string{
+				"--underlay",
 				"--bind", hostCanaryDir + ":/var/etc",
 				sandbox,
 				"test", "-f", "/etc/file",
@@ -1321,6 +1437,16 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "SymlinkTwoLevelDirBindUnderlay",
+			args: []string{
+				"--underlay",
+				"--bind", hostCanaryDir + ":/var/etc/madness",
+				sandbox,
+				"test", "-f", "/madness/file",
+			},
+			exit: 0,
+		},
+		{
 			name: "SymlinkOneLevelNewDirBind",
 			args: []string{
 				"--bind", hostCanaryDir + ":/var/etc/new",
@@ -1330,8 +1456,28 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "SymlinkOneLevelNewDirBindUnderlay",
+			args: []string{
+				"--underlay",
+				"--bind", hostCanaryDir + ":/var/etc/new",
+				sandbox,
+				"test", "-f", "/etc/new/file",
+			},
+			exit: 0,
+		},
+		{
 			name: "SymlinkTwoLevelNewDirBind",
 			args: []string{
+				"--bind", hostCanaryDir + ":/var/etc/madness/new",
+				sandbox,
+				"test", "-f", "/madness/new/file",
+			},
+			exit: 0,
+		},
+		{
+			name: "SymlinkTwoLevelNewDirBindUnderlay",
+			args: []string{
+				"--underlay",
 				"--bind", hostCanaryDir + ":/var/etc/madness/new",
 				sandbox,
 				"test", "-f", "/madness/new/file",
@@ -1350,8 +1496,32 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit:    0,
 		},
 		{
+			name: "NestedBindFileUnderlay",
+			args: []string{
+				"--underlay",
+				"--bind", canaryDirBind,
+				"--bind", hostCanaryFile + ":" + filepath.Join(contCanaryDir, "file2"),
+				sandbox,
+				"test", "-f", "/canary/file2",
+			},
+			postRun: checkHostFile(filepath.Join(hostCanaryDir, "file2")),
+			exit:    0,
+		},
+		{
 			name: "NestedBindDir",
 			args: []string{
+				"--bind", canaryDirBind,
+				"--bind", hostCanaryDir + ":" + filepath.Join(contCanaryDir, "dir2"),
+				sandbox,
+				"test", "-d", "/canary/dir2",
+			},
+			postRun: checkHostDir(filepath.Join(hostCanaryDir, "dir2")),
+			exit:    0,
+		},
+		{
+			name: "NestedBindDirUnderlay",
+			args: []string{
+				"--underlay",
 				"--bind", canaryDirBind,
 				"--bind", hostCanaryDir + ":" + filepath.Join(contCanaryDir, "dir2"),
 				sandbox,
@@ -1373,6 +1543,19 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit:    0,
 		},
 		{
+			name: "MultipleNestedBindDirUnderlay",
+			args: []string{
+				"--underlay",
+				"--bind", canaryDirBind,
+				"--bind", hostCanaryDir + ":" + filepath.Join(contCanaryDir, "dir2"),
+				"--bind", hostCanaryFile + ":" + filepath.Join(filepath.Join(contCanaryDir, "dir2"), "nested"),
+				sandbox,
+				"test", "-f", "/canary/dir2/nested",
+			},
+			postRun: checkHostFile(filepath.Join(hostCanaryDir, "nested")),
+			exit:    0,
+		},
+		{
 			name: "CustomHomeOneToOne",
 			args: []string{
 				"--home", hostHomeDir,
@@ -1384,8 +1567,32 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit:    0,
 		},
 		{
+			name: "CustomHomeOneToOneUnderlay",
+			args: []string{
+				"--underlay",
+				"--home", hostHomeDir,
+				"--bind", hostCanaryDir + ":" + filepath.Join(hostHomeDir, "canary121RO"),
+				sandbox,
+				"test", "-f", filepath.Join(hostHomeDir, "canary121RO/file"),
+			},
+			postRun: checkHostDir(filepath.Join(hostHomeDir, "canary121RO")),
+			exit:    0,
+		},
+		{
 			name: "CustomHomeBind",
 			args: []string{
+				"--home", hostHomeDir + ":/home/e2e",
+				"--bind", hostCanaryDir + ":/home/e2e/canaryRO",
+				sandbox,
+				"test", "-f", "/home/e2e/canaryRO/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostHomeDir, "canaryRO")),
+			exit:    0,
+		},
+		{
+			name: "CustomHomeBindUnderlay",
+			args: []string{
+				"--underlay",
 				"--home", hostHomeDir + ":/home/e2e",
 				"--bind", hostCanaryDir + ":/home/e2e/canaryRO",
 				sandbox,
@@ -1429,6 +1636,19 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit:    0,
 		},
 		{
+			name: "WorkdirTmpBindUnderlay",
+			args: []string{
+				"--underlay",
+				"--workdir", hostWorkDir,
+				"--contain",
+				"--bind", hostCanaryDir + ":/tmp/canary/dir",
+				sandbox,
+				"test", "-f", "/tmp/canary/dir/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostWorkDir, "tmp", "canary/dir")),
+			exit:    0,
+		},
+		{
 			name: "WorkdirTmpBindWritable",
 			args: []string{
 				"--writable",
@@ -1444,6 +1664,19 @@ func (c actionTests) actionBinds(t *testing.T) {
 		{
 			name: "WorkdirVarTmpBind",
 			args: []string{
+				"--workdir", hostWorkDir,
+				"--contain",
+				"--bind", hostCanaryDir + ":/var/tmp/canary/dir",
+				sandbox,
+				"test", "-f", "/var/tmp/canary/dir/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostWorkDir, "var_tmp", "canary/dir")),
+			exit:    0,
+		},
+		{
+			name: "WorkdirVarTmpBindUnderlay",
+			args: []string{
+				"--underlay",
 				"--workdir", hostWorkDir,
 				"--contain",
 				"--bind", hostCanaryDir + ":/var/tmp/canary/dir",
@@ -1477,6 +1710,17 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "ScratchTmpfsBindUnderlay",
+			args: []string{
+				"--underlay",
+				"--scratch", "/scratch",
+				"--bind", hostCanaryDir + ":/scratch/dir",
+				sandbox,
+				"test", "-f", "/scratch/dir/file",
+			},
+			exit: 0,
+		},
+		{
 			name: "ScratchWorkdirBind",
 			args: []string{
 				"--workdir", hostWorkDir,
@@ -1489,8 +1733,31 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit:    0,
 		},
 		{
+			name: "ScratchWorkdirBindUnderlay",
+			args: []string{
+				"--underlay",
+				"--workdir", hostWorkDir,
+				"--scratch", "/scratch",
+				"--bind", hostCanaryDir + ":/scratch/dir",
+				sandbox,
+				"test", "-f", "/scratch/dir/file",
+			},
+			postRun: checkHostDir(filepath.Join(hostWorkDir, "scratch/scratch", "dir")),
+			exit:    0,
+		},
+		{
 			name: "BindFileWithCommaOK",
 			args: []string{
+				"--bind", strings.ReplaceAll(hostCanaryFileWithComma, ",", "\\,") + ":" + contCanaryFile,
+				sandbox,
+				"test", "-f", contCanaryFile,
+			},
+			exit: 0,
+		},
+		{
+			name: "BindFileWithCommaUnderlayOK",
+			args: []string{
+				"--underlay",
 				"--bind", strings.ReplaceAll(hostCanaryFileWithComma, ",", "\\,") + ":" + contCanaryFile,
 				sandbox,
 				"test", "-f", contCanaryFile,

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1080,6 +1080,11 @@ func (e *EngineOperations) setSessionLayer(img *image.Image) error {
 		}
 		if !writableImage {
 			if e.EngineConfig.File.EnableOverlay == "yes" || e.EngineConfig.File.EnableOverlay == "try" {
+				if e.EngineConfig.GetUnderlay() && e.EngineConfig.File.EnableUnderlay {
+					sylog.Debugf("Attempting to use 'underlay' over 'overlay': '--underlay' is set")
+					e.EngineConfig.SetSessionLayer(apptainerConfig.UnderlayLayer)
+					return nil
+				}
 				err := overlay.CheckRootless()
 				if err == nil {
 					e.EngineConfig.SetSessionLayer(apptainerConfig.OverlayLayer)

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -204,6 +204,9 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	l.engineConfig.SetOverlayImage(l.cfg.OverlayPaths)
 	l.engineConfig.SetWritableImage(l.cfg.Writable)
 
+	// Prefer underlay for bind
+	l.engineConfig.SetUnderlay(l.cfg.Underlay)
+
 	// Check key is available for encrypted image, if applicable.
 	// If we are joining an instance, then any encrypted image is already mounted.
 	if !l.engineConfig.GetInstanceJoin() {

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -150,6 +150,7 @@ type launchOptions struct {
 	IgnoreUserns      bool
 	UseBuildConfig    bool
 	TmpDir            string
+	Underlay          bool // whether prefer underlay over overlay
 }
 
 type Launcher struct {
@@ -554,6 +555,14 @@ func OptUseBuildConfig(b bool) Option {
 func OptTmpDir(a string) Option {
 	return func(lo *launchOptions) error {
 		lo.TmpDir = a
+		return nil
+	}
+}
+
+// OptUnderlay
+func OptUnderlay(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.Underlay = b
 		return nil
 	}
 }

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -139,6 +139,7 @@ type JSONConfig struct {
 	XdgRuntimeDir         string            `json:"xdgRuntimeDir,omitempty"`
 	DbusSessionBusAddress string            `json:"dbusSessionBusAddress,omitempty"`
 	NoEval                bool              `json:"noEval,omitempty"`
+	Underlay              bool              `json:"underlay,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -881,4 +882,14 @@ func (e *EngineConfig) SetNoEval(noEval bool) {
 // runscripts generated from OCI containers CMD/ENTRYPOINT.
 func (e *EngineConfig) GetNoEval() bool {
 	return e.JSON.NoEval
+}
+
+// SetUnderlay sets whether to use underlay instead of overlay
+func (e *EngineConfig) SetUnderlay(underlay bool) {
+	e.JSON.Underlay = underlay
+}
+
+// GetUnderlay gets the value of whether to use underlay instead of overlay
+func (e *EngineConfig) GetUnderlay() bool {
+	return e.JSON.Underlay
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add an --underlay action option to prefer underlay instead of overlay for bind mounts


### This fixes or addresses the following GitHub issues:

 - Fixes #893 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
