### PR TITLE
fix: force casting to uint64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix not being able to handle multiple entries in `LD_PRELOAD` when
   binding fakeroot into container during apptainer startup for --fakeroot
   with fakeroot command.
+- Fix memory usage calculation during apptainer compilation on RaspberryPi.
 
 ## v1.1.8 - \[2023-04-25\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -107,4 +107,5 @@
 - Xu Yang <jasonyangshadow@gmail.com>
 - Charles Vejnar <charles.vejnar@gmail.com>
 - Carmelo Piccione <carmelo.piccione@gmail.com>
+- Filip Gorczyca <filip.gorczyca141@gmail.com>
 ```

--- a/internal/app/apptainer/instance_linux.go
+++ b/internal/app/apptainer/instance_linux.go
@@ -175,7 +175,7 @@ func calculateMemoryUsage(stats *libcgroups.MemoryStats) (float64, float64, floa
 		in := &syscall.Sysinfo_t{}
 		err := syscall.Sysinfo(in)
 		if err == nil {
-			memLimit = in.Totalram * uint64(in.Unit)
+			memLimit = uint64(in.Totalram) * uint64(in.Unit)
 		}
 	}
 	if memLimit != 0 {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Added casting prevents this kind of error:
<img width="514" alt="image" src="https://github.com/apptainer/apptainer/assets/80070678/1aa711d9-adbe-476b-9141-c6f78b2aa123">


### This fixes or addresses the following GitHub issues:

 - Fixes #
https://github.com/apptainer/apptainer/issues/1324

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
