### PR TITLE
fix overlay module not loaded under the root user leads to misleading error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   binding fakeroot into container during apptainer startup for --fakeroot
   with fakeroot command.
 - Fix memory usage calculation during apptainer compilation on RaspberryPi.
+- Fix misleading error when an overlay is requested by the root user while the
+  overlay kernel module is not loaded.
 
 ## v1.1.8 - \[2023-04-25\]
 

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -389,8 +389,14 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	}
 
 	loadOverlay := false
-	if !l.cfg.Namespaces.User && buildcfg.APPTAINER_SUID_INSTALL == 1 {
-		loadOverlay = true
+	if !l.cfg.Namespaces.User && (buildcfg.APPTAINER_SUID_INSTALL == 1 || os.Getuid() == 0) {
+		has, err := proc.HasFilesystem("overlay")
+		if err != nil {
+			return fmt.Errorf("while checking whether overlay filesystem is loaded: %w", err)
+		}
+		if !has {
+			loadOverlay = true
+		}
 	}
 
 	cfg := &config.Common{


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix overlay module not loaded under the root user leads to misleading error message


### This fixes or addresses the following GitHub issues:

 - Fixes #1325 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
