### PR TITLE
Package gocryptfs with apptainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   flag.
 - Support for online verification checks of x509 certificates using OCSP protocol.
   (introduced flag: `verify --ocsp-verify`)
-- Support for unprivileged encryption of SIF files using gocryptfs.
+- Support for unprivileged encryption of SIF files using gocryptfs.  The
+  gocryptfs command is included in rpm and debian packaging.
 - The `instance start` command now accepts an optional `--app <name>` argument which
   invokes start script within the `%appstart <name>` section in the definition file.
   The `instance stop` command still only requires the instance name.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -220,6 +220,42 @@ make squashfuse_ll
 sudo cp squashfuse_ll /usr/local/libexec/apptainer/bin
 ```
 
+## Installing gocryptfs
+
+If you want to support SIF encryption and/or decryption in unprivileged
+mode, then gocryptfs needs to installed.  It is available as a package
+install on some operating systems as described in its
+[documentation](https://nuetzlich.net/gocryptfs/quickstart/), but
+otherwise to compile it from source follow these instructions.
+
+First, make sure that the additional required package is installed.  On Debian:
+
+```sh
+apt-get install -y fuse3
+```
+
+On CentOS/RHEL:
+
+```sh
+yum install -y fuse
+```
+
+To download the source code do this:
+
+```sh
+GOCRYPTFSVERSION=2.3.2
+curl -L -O https://github.com/rfjakob/gocryptfs/archive/v$GOCRYPTFSVERSION/gocryptfs-$GOCRYPTFSVERSION.tar.gz
+```
+
+Then to compile and install do this:
+
+```sh
+tar xzf gocryptfs-$GOCRYPTFSVERSION.tar.gz
+cd gocryptfs-$GOCRYPTFSVERSION
+./build-without-openssl.bash
+sudo cp gocryptfs /usr/local/libexec/apptainer/bin
+```
+
 ## Building & Installing from RPM
 
 On a RHEL / CentOS / Fedora machine you can build an Apptainer into rpm
@@ -264,20 +300,23 @@ VERSION=1.1.8  # this is the apptainer version, change as you need
 wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/apptainer-${VERSION}.tar.gz
 ```
 
-At this point if you don't care about improved squashfuse performance
-then skip down to the rpmbuild command below.
-If you do want it then you need to modify the tarball.
-First unpack it and uncomment one line like this:
+Next we need to include the source of squashfuse_ll and gocryptfs.
+The easiest way to do that is to modify the apptainer tarball and
+include them inside of it.  First unpack it like this:
 
 ```sh
 tar xf apptainer-${VERSION}.tar.gz
 cd apptainer-${VERSION}
-sed -i 's/^# %\(%global squashfuse_version\)/\1/' apptainer.spec
 ```
 
-Then install the extra packages and download the source code as shown at
-[the above link](#installing-improved-performance-squashfuse_ll)
-and recreate the tarball like this:
+Then install the extra packages and download the source code into the
+current directory as shown at
+[the above squashfuse link](#installing-improved-performance-squashfuse_ll)
+and [the above gocryptfs link](#installing-gocryptfs).
+(If the rpm needs to be built offline from the internet see
+additional instructions for the gocryptfs source code in
+dist/rpm/apptainer.spec.in).
+Then recreate the apptainer tarball like this:
 
 ```sh
 cd ..
@@ -317,6 +356,10 @@ sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/apptainer-suid-$(echo $VERSION|tr - \~)*.x8
 ```
 
 <!-- markdownlint-enable MD013 -->
+
+That will not include squashfuse_ll and gocryptfs in the rpm unless you
+uncomment the %global definitions of their version numbers in apptainer.spec
+first and have their source tarballs available in the current directory.
 
 By default, the rpms will be built so that Apptainer is installed in
 standard Linux paths under ``/``.

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -43,6 +43,9 @@ wget -O debian/$TARBALL https://dl.google.com/go/$TARBALL
 Finally, install the additional dependencies in the section on the
 [improved performance squashfuse](../../INSTALL.md##installing-improved-performance-squashfuse_ll)
 and download the additional files listed there into the debian directory.
+Also install the additional file from the section on
+[installing gocryptfs)(../../INSTALL.md##installing-gocryptfs)
+into the debian directory.
 
 ## Configuration
 

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -36,6 +36,7 @@ Depends:
  squashfuse,
  fuse2fs,
  fuse-overlayfs,
+ fuse3,
  fakeroot
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute" formerly known as Singularity

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -65,7 +65,7 @@ export APPTAINER_CACHEDIR=$(pkgdir)/var/lib/apptainer/cache
 
 override_dh_auto_configure:
 	@SQUASHFUSETGZ="`echo debian/squashfuse-*.tar.gz`"; \
-	  if [ -f $$SQUASHFUSETGZ ]; then \
+	  if [ -f "$$SQUASHFUSETGZ" ]; then \
 	    set -x; \
 	    tar -C debian -xf $$SQUASHFUSETGZ; \
 	    cd $${SQUASHFUSETGZ%.tar.gz}; \
@@ -87,6 +87,13 @@ override_dh_auto_configure:
 	    cd go/src; \
 	    GOCACHE=$(GOCACHE) ./make.bash; \
 	  fi
+	@GOCRYPTFSTGZ="`echo debian/gocryptfs-*.tar.gz`"; \
+	  if [ -f "$$GOCRYPTFSTGZ" ]; then \
+	    set -x; \
+	    tar -C debian -xf $$GOCRYPTFSTGZ; \
+	    cd $${GOCRYPTFSTGZ%.tar.gz}; \
+	    PATH=$(GOROOT)/bin:$$PATH GOCACHE=$(GOCACHE) ./build-without-openssl.bash; \
+	  fi
 ifneq ($(NEW_VERSION),)
 	$(warning "Setting new version in debian changelog: $(NEW_VERSION)")
 	@debchange -v $(NEW_VERSION)$(VERSION_POSTFIX) "Version $(NEW_VERSION)" && debchange -m -r ""
@@ -102,7 +109,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	@dh_auto_install -Smakefile -D$(DEB_SC_BUILDDIR)
-	cp debian/squashfuse-*/squashfuse_ll debian/tmp/usr/libexec/apptainer/bin
+	cp debian/squashfuse-*/squashfuse_ll debian/gocryptfs-*/gocryptfs debian/tmp/usr/libexec/apptainer/bin
 
 override_dh_install:
 	@dh_install -papptainer-suid usr/libexec/apptainer/bin/starter-suid

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -33,6 +33,8 @@
 # For example, it has dash instead of tilde for release candidates.
 %global package_version @PACKAGE_VERSION@
 
+# Uncomment this to include gocryptfs
+# %%global gocryptfs_version 2.3.2
 # Uncomment this to include a multithreaded version of squashfuse_ll
 # %%global squashfuse_version 0.1.105
 
@@ -51,8 +53,15 @@ License: BSD and LBNL BSD and ASL 2.0
 URL: https://apptainer.org
 Source: https://github.com/%{name}/%{name}/releases/download/v%{package_version}/%{name}-%{package_version}.tar.gz
 @PACKAGE_GOLANG_SOURCE@
+%if "%{?gocryptfs_version}" != ""
+# In order to build offline, this source tarball needs to have the "vendor"
+# directory added, which can be done by unpacking it, doing the command
+#   go mod vendor
+# and then recreating the tarball.
+Source10: https://github.com/rfjakob/gocryptfs/archive/v%{gocryptfs_version}/gocryptfs-%{gocryptfs_version}.tar.gz
+%endif
 %if "%{?squashfuse_version}" != ""
-Source10: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squashfuse-%{squashfuse_version}.tar.gz
+Source11: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squashfuse-%{squashfuse_version}.tar.gz
 Patch10: https://github.com/vasi/squashfuse/pull/70.patch
 Patch11: https://github.com/vasi/squashfuse/pull/77.patch
 Patch12: https://github.com/vasi/squashfuse/pull/81.patch
@@ -107,6 +116,8 @@ Requires: squashfuse
 Requires: fakeroot
 Requires: fuse-overlayfs
 Requires: e2fsprogs
+# only gocryptfs requires fuse
+Requires: fuse
 # Uncomment this for the epel build, but we don't want it for the Apptainer
 #  release build because there the same rpm is shared across OS versions
 #%%if 0%{?el7}
@@ -131,10 +142,14 @@ Provides: alternative-for(singularity)
 Provides the optional setuid-root portion of Apptainer.
 
 %prep
+%if "%{?gocryptfs_version}" != ""
+%setup -b 10 -n gocryptfs-%{gocryptfs_version}
+%endif
+
 %if "%{?squashfuse_version}" != ""
 # the default directory for other steps is where the %%prep section ends
 # so do main package last
-%setup -b 10 -n squashfuse-%{squashfuse_version}
+%setup -b 11 -n squashfuse-%{squashfuse_version}
 %patch -P 10 -p1
 %patch -P 11 -p1
 %patch -P 12 -p1
@@ -144,6 +159,22 @@ Provides the optional setuid-root portion of Apptainer.
 %endif
 
 %build
+%if "%{?gocryptfs_version}" != ""
+pushd ../gocryptfs-%{gocryptfs_version}
+if [ ! -d vendor ]; then
+    (
+    export GOPATH="`pwd`/gopath"
+    go mod vendor
+    go clean -modcache
+    )
+fi
+# GOPROXY=off makes sure we fail instead of making network requests
+# the -B ldflags prevent rpm complaints about "No build ID note found"
+CGO_ENABLED=0 GOPROXY=off ./build.bash -mod=vendor -tags without_openssl \
+    -ldflags="-X main.GitVersion=%{gocryptfs_version} -B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`" 
+popd
+%endif
+
 %if "%{?squashfuse_version}" != ""
 pushd ../squashfuse-%{squashfuse_version}
 ./autogen.sh
@@ -191,6 +222,11 @@ export PATH=$PWD/go/bin:$PATH
 %endif
 
 %make_install -C builddir V=
+
+%if "%{?gocryptfs_version}" != ""
+install -m 755 ../gocryptfs-%{gocryptfs_version}/gocryptfs %{buildroot}%{_libexecdir}/%{name}/bin/gocryptfs
+%endif
+
 %if "%{?squashfuse_version}" != ""
 install -m 755 ../squashfuse-%{squashfuse_version}/squashfuse_ll %{buildroot}%{_libexecdir}/%{name}/bin/squashfuse_ll
 %endif
@@ -261,6 +297,9 @@ fi
 %dir %{_libexecdir}/%{name}
 %dir %{_libexecdir}/%{name}/bin
 %{_libexecdir}/%{name}/bin/starter
+%if "%{?gocryptfs_version}" != ""
+%{_libexecdir}/%{name}/bin/gocryptfs
+%endif
 %if "%{?squashfuse_version}" != ""
 %{_libexecdir}/%{name}/bin/squashfuse_ll
 %endif

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -41,8 +41,9 @@ su testuser -c '
     fi
   fi
   go version
-  # enable the multithreading squashfuse
+  # enable the multithreading squashfuse and gocryptfs
   sed -i "s/^# %\(%global squashfuse_version\)/\1/" apptainer.spec
+  sed -i "s/^# %\(%global gocryptfs_version\)/\1/" apptainer.spec
   # download any additional source & patch urls
   DOWNLOADURL="$(sed -n "s/^Source[1-9][0-9]*: //p" apptainer.spec)"
   DOWNLOADURL="$DOWNLOADURL $(sed -n "s/^Patch[1-9][0-9]*: //p" apptainer.spec)"

--- a/scripts/ci-unpriv-test
+++ b/scripts/ci-unpriv-test
@@ -25,7 +25,7 @@ su testuser -c '
   export PATH=$PATH:/usr/sbin
   set -x
   set -e
-  rm -rf ins image.sif overlay.img
+  rm -rf ins image*.sif overlay.img
   tools/install-unprivileged.sh -v apptainer-[1-9]*.$(arch).rpm ins
 
   ins/bin/apptainer build image.sif docker://'$DOCKER_HUB_URI'
@@ -34,4 +34,6 @@ su testuser -c '
   ins/bin/apptainer exec --overlay overlay.img -f image.sif touch /bin/newfile
   ins/bin/apptainer exec -B $PWD -f image.sif ins/bin/apptainer exec --overlay overlay.img image.sif cat /bin/newfile
   ins/bin/apptainer exec --unsquash image.sif true
+  echo testphrase|ins/bin/apptainer build --encrypt --passphrase image-e.sif image.sif
+  echo testphrase|ins/bin/apptainer exec --passphrase image-e.sif true
 '

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -285,10 +285,10 @@ OSUTILS=""
 EXTRASUTILS="fuse-overlayfs"
 EPELUTILS="fakeroot"
 if [ "$DIST" = el7 ]; then
-	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs"
+	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs fuse"
 	EPELUTILS="$EPELUTILS libzstd fuse2fs fuse3-libs fakeroot-libs"
 elif [ "$DIST" = el8 ]; then
-	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs libzstd e2fsprogs-libs e2fsprogs fuse3-libs"
+	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs fuse libzstd e2fsprogs-libs e2fsprogs fuse3-libs"
 	EPELUTILS="$EPELUTILS fakeroot-libs"
 elif [ "$DIST" = "opensuse-tumbleweed" ]; then
 	OSUTILS="$OSUTILS libseccomp2 squashfs liblzo2-2 libzstd1 e2fsprogs fuse3 libfuse3-3 fakeroot fuse2fs $EXTRASUTILS $EPELUTILS"
@@ -299,7 +299,7 @@ elif [ "$DIST" = "suse15" ]; then
 	EXTRASUTILS="$EXTRASUTILS fuse2fs"
 	EPELUTILS=""
 else
-	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs libzstd e2fsprogs-libs e2fsprogs"
+	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs fuse libzstd e2fsprogs-libs e2fsprogs"
 	EXTRASUTILS="$EXTRASUTILS fuse3-libs"
 	EPELUTILS="$EPELUTILS fakeroot-libs"
 fi
@@ -355,7 +355,7 @@ rmdir lib 2>/dev/null || true
 # move everything needed out of tmp to utils
 mkdir -p utils/bin utils/lib utils/libexec
 mv tmp/usr/lib*/* utils/lib
-mv tmp/usr/bin/fuse-overlayfs tmp/usr/*bin/fuse2fs tmp/usr/*bin/*squashfs utils/libexec
+mv tmp/usr/*bin/fuse* tmp/usr/*bin/*squashfs utils/libexec
 mv tmp/usr/bin/fake*sysv utils/bin
 cat >utils/bin/.wrapper <<'!EOF!'
 #!/bin/bash
@@ -393,7 +393,7 @@ PARENT="${HERE%/*}"
 GGPARENT="${PARENT%/*/*}"
 REALME=$PARENT/libexec/$BASEME
 ARG0="${_WRAPPER_ARG0:-$REALME}"
-LD_LIBRARY_PATH=$GGPARENT/utils/lib ${_WRAPPER_EXEC_CMD:-exec -a "$ARG0"} $REALME "$@"
+LD_LIBRARY_PATH=$GGPARENT/utils/lib PATH=$PATH:$GGPARENT/utils/bin ${_WRAPPER_EXEC_CMD:-exec -a "$ARG0"} $REALME "$@"
 !EOF!
 chmod +x libexec/apptainer/bin/.wrapper
 for TOOL in libexec/apptainer/bin/*; do


### PR DESCRIPTION
This PR adds gocryptfs to apptainer rpm and debian packages and to the installation instructions. It also adds a test of encryption and decryption to the ci check for unprivileged installations, which uses the rpm it builds as input.

- Fixes #1285

Unfortunately I found that gocryptfs, unlike fuse packages based on fuse-libs, [requires](https://github.com/rfjakob/gocryptfs/pull/749) using the `fusermount` command even when run in a root-mapped unprivileged user namespace.  At least it does not depend on the setuid-root functionality of fusermount, but it does require the fuse (or fuse3 package on Debian) package to be installed.

I also re-ran the benchmark in #665 on a gocryptfs-encrypted SIF file and got almost identical results, an average of 6:28 on two runs.  That was using apptainer installed by install-unprivileged.sh with an rpm as input that was built with this PR.