### PR TITLE
Improve message when running encrypted sif without a key material option

### DIFF
--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -567,7 +567,7 @@ func (l *Launcher) checkEncryptionKey() error {
 		sylog.Debugf("Encrypted container filesystem detected")
 
 		if l.cfg.KeyInfo == nil {
-			return fmt.Errorf("no key was provided, cannot access encrypted container")
+			return fmt.Errorf("required option --passphrase or --pem-path missing")
 		}
 
 		plaintextKey, err := cryptkey.PlaintextKey(*l.cfg.KeyInfo, l.engineConfig.GetImage())


### PR DESCRIPTION
## Description of the Pull Request (PR):

Improve message when running encrypted sif without a key material option

### This fixes or addresses the following GitHub issues:

 - Fixes #1358 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
