### PR TITLE
Sort all mount points for a mount tag by shortest destination path first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Lookup and store user/group information in stage one prior to entering any
   namespaces to fix issue with winbind not correctly lookup user/group information
   when using user namespace.
+- Destination mount points are now sorted by shortest path first to ensure that
+  a user bind doesn't override a previous bind path when set in arbitrary order
+  on CLI, this is also applied to image binds.
 
 ### New features / functionalities
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2396,7 +2396,7 @@ func (c actionTests) bindImage(t *testing.T) {
 				c.env.ImagePath,
 				"test", "-f", filepath.Join("/scratch/bin", squashMarkerFile),
 			},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name:    "ScratchBeforeSquashfs",

--- a/internal/pkg/util/fs/mount/mount_linux_test.go
+++ b/internal/pkg/util/fs/mount/mount_linux_test.go
@@ -335,7 +335,7 @@ func TestImport(t *testing.T) {
 		t.Fatalf("%s != %s", mountLabel, points.GetContext())
 	}
 
-	validImport := map[AuthorizedTag][]Point{
+	validImport := map[AuthorizedTag]PointList{
 		UserbindsTag: {
 			{
 				Mount: specs.Mount{
@@ -467,7 +467,7 @@ func TestImport(t *testing.T) {
 	}
 	points.RemoveAll()
 
-	invalidImport := map[AuthorizedTag][]Point{
+	invalidImport := map[AuthorizedTag]PointList{
 		UserbindsTag: {
 			{
 				Mount: specs.Mount{
@@ -483,7 +483,7 @@ func TestImport(t *testing.T) {
 		t.Errorf("import should failed: %s", err)
 	}
 
-	validForceContextImport := map[AuthorizedTag][]Point{
+	validForceContextImport := map[AuthorizedTag]PointList{
 		SessionTag: {
 			{
 				Mount: specs.Mount{
@@ -515,7 +515,7 @@ func TestImport(t *testing.T) {
 	}
 	points.RemoveAll()
 
-	validContextImport := map[AuthorizedTag][]Point{
+	validContextImport := map[AuthorizedTag]PointList{
 		SessionTag: {
 			{
 				Mount: specs.Mount{

--- a/internal/pkg/util/fs/mount/system_linux.go
+++ b/internal/pkg/util/fs/mount/system_linux.go
@@ -78,6 +78,9 @@ func (b *System) MountAll() error {
 				return fmt.Errorf("hook function for tag %s returns error: %s", tag, err)
 			}
 		}
+		if authorizedTags[tag].sortedMount {
+			b.Points.GetByTag(tag).Sort()
+		}
 		for _, point := range b.Points.GetByTag(tag) {
 			if b.Mount != nil {
 				if err := b.Mount(&point, b); err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Destination mount points are now sorted by shortest path first to ensure that  a user bind doesn't override a previous bind path when set in arbitrary order  on CLI.

### This fixes or addresses the following GitHub issues:

 - Fixes #1143 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
