### PR TITLE
Handle CWD symlink schizophrenia between host/container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   installations. This is an increase from 16 MiB in prior versions.
 - Show standard output of yum bootstrap if log level is verbose or higher.
 - Add architecture aware support for apptainer cache.
+- Handle current working directory path containing symlink boths on host and
+  container but pointing to different destinations, if detected the current
+  working directory is not mounted when the destination directory in container exists.
 
 ### New features / functionalities
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Handle current working directory path containing symlink boths on host and container but pointing to different destinations, if detected the current working directory is not mounted when the destination directory in container exists.

### This fixes or addresses the following GitHub issues:

 - Fixes #547 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
