### PR TITLE
Lookup and store user/group information in stage one prior to creating namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Handle current working directory path containing symlink boths on host and
   container but pointing to different destinations, if detected the current
   working directory is not mounted when the destination directory in container exists.
+- Lookup and store user/group information in stage one prior to entering any
+  namespaces to fix issue with winbind not correctly lookup user/group information
+  when using user namespace.
 
 ### New features / functionalities
 

--- a/internal/pkg/util/fs/files/files_linux_test.go
+++ b/internal/pkg/util/fs/files/files_linux_test.go
@@ -24,11 +24,11 @@ func TestGroup(t *testing.T) {
 	var gids []int
 	uid := os.Getuid()
 
-	_, err := Group("/fake", uid, gids)
+	_, err := Group("/fake", uid, gids, nil)
 	if err == nil {
 		t.Errorf("should have failed with bad group file")
 	}
-	_, err = Group("/etc/group", uid, gids)
+	_, err = Group("/etc/group", uid, gids, nil)
 	if err != nil {
 		t.Errorf("should have passed with correct group file")
 	}
@@ -41,7 +41,7 @@ func TestGroup(t *testing.T) {
 	defer os.Remove(emptyGroup)
 	f.Close()
 
-	_, err = Group(emptyGroup, uid, gids)
+	_, err = Group(emptyGroup, uid, gids, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -53,11 +53,11 @@ func TestPasswd(t *testing.T) {
 
 	uid := os.Getuid()
 
-	_, err := Passwd("/fake", "/fake", uid)
+	_, err := Passwd("/fake", "/fake", uid, nil)
 	if err == nil {
 		t.Errorf("should have failed with bad passwd file")
 	}
-	_, err = Passwd("/etc/passwd", "/home", uid)
+	_, err = Passwd("/etc/passwd", "/home", uid, nil)
 	if err != nil {
 		t.Errorf("should have passed with correct passwd file")
 	}
@@ -70,7 +70,7 @@ func TestPasswd(t *testing.T) {
 	defer os.Remove(emptyPasswd)
 	f.Close()
 
-	_, err = Passwd(emptyPasswd, "/home", uid)
+	_, err = Passwd(emptyPasswd, "/home", uid, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/pkg/util/fs/files/group.go
+++ b/internal/pkg/util/fs/files/group.go
@@ -21,7 +21,7 @@ import (
 
 // Group creates a group template based on content of file provided in path,
 // updates content with current user information and returns content
-func Group(path string, uid int, gids []int) (content []byte, err error) {
+func Group(path string, uid int, gids []int, customLookup UserGroupLookup) (content []byte, err error) {
 	duplicate := false
 	var groups []int
 
@@ -37,16 +37,26 @@ func Group(path string, uid int, gids []int) (content []byte, err error) {
 	}
 	defer groupFile.Close()
 
-	pwInfo, err := user.GetPwUID(uint32(uid))
+	getPwUID := user.GetPwUID
+	getGrGID := user.GetGrGID
+	getGroups := os.Getgroups
+
+	if customLookup != nil {
+		getPwUID = customLookup.GetPwUID
+		getGrGID = customLookup.GetGrGID
+		getGroups = customLookup.Getgroups
+	}
+
+	pwInfo, err := getPwUID(uint32(uid))
 	if err != nil || pwInfo == nil {
 		return content, err
 	}
 	if len(gids) == 0 {
-		grInfo, err := user.GetGrGID(pwInfo.GID)
+		grInfo, err := getGrGID(pwInfo.GID)
 		if err != nil || grInfo == nil {
 			return content, err
 		}
-		groups, err = os.Getgroups()
+		groups, err = getGroups()
 		if err != nil {
 			return content, err
 		}
@@ -77,7 +87,7 @@ func Group(path string, uid int, gids []int) (content []byte, err error) {
 	// only deduplicate newly added groups
 	deduplicateStrs := make(map[string]bool)
 	for _, gid := range groups {
-		grInfo, err := user.GetGrGID(uint32(gid))
+		grInfo, err := getGrGID(uint32(gid))
 		if err != nil || grInfo == nil {
 			sylog.Verbosef("Skipping GID %d as group entry doesn't exist.\n", gid)
 			continue

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -69,6 +69,16 @@ type DMTCPConfig struct {
 	Args       []string `json:"args,omitempty"`
 }
 
+type UserInfo struct {
+	Username string         `json:"username,omitempty"`
+	Home     string         `json:"home,omitempty"`
+	UID      int            `json:"uid,omitempty"`
+	GID      int            `json:"gid,omitempty"`
+	Groups   map[int]string `json:"groups,omitempty"`
+	Gecos    string         `json:"gecos,omitempty"`
+	Shell    string         `json:"shell,omitempty"`
+}
+
 // JSONConfig stores engine specific configuration that is allowed to be set by the user.
 type JSONConfig struct {
 	ScratchDir            []string          `json:"scratchdir,omitempty"`
@@ -140,6 +150,7 @@ type JSONConfig struct {
 	DbusSessionBusAddress string            `json:"dbusSessionBusAddress,omitempty"`
 	NoEval                bool              `json:"noEval,omitempty"`
 	Underlay              bool              `json:"underlay,omitempty"`
+	UserInfo              UserInfo          `json:"userInfo,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Lookup and store user/group information in stage one prior to entering any namespaces to fix issue with winbind not correctly lookup user/group information when using user namespace.


### This fixes or addresses the following GitHub issues:

 - Fixes #1136 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
