### PR TITLE
Remove extra fuse-overlayfs messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix misleading error when an overlay is requested by the root user while the
   overlay kernel module is not loaded.
 
+### Bug fixes
+
+- Remove warning about unknown `xino=on` option from fuse-overlayfs,
+  introduced in 1.1.8.
+- Ignore extraneous warning from fuse-overlayfs about a readonly `/proc`.
+
 ## v1.1.8 - \[2023-04-25\]
 
 ### Security fix

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -154,6 +154,8 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 	case "overlay":
 		f = &d.overlayFeature
 		optsStr := strings.Join(params.FSOptions, ",")
+		// Ignore xino=on option with fuse-overlayfs
+		optsStr = strings.Replace(optsStr, ",xino=on", "", -1)
 		// noacl is needed to avoid failures when the upper layer
 		// filesystem type (for example tmpfs) does not support it,
 		// when the fuse-overlayfs version is 1.8 or greater.
@@ -281,6 +283,9 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 		// from squashfuse_ll
 		"failed to clone device fd",
 		"continue without -o clone_fd",
+		// from fuse-overlayfs due to a bug
+		// (see https://github.com/containers/fuse-overlayfs/issues/397)
+		"/proc seems to be mounted as readonly",
 		// from gocryptfs
 		"Reading Password from stdin",
 		"Decrypting master key",


### PR DESCRIPTION
Removes extraneous INFO messages from fuse-overlayfs about an unknown `xino=on` message (introduced in v1.1.8), and about a `/proc` being readonly (bug reported [upstream](https://github.com/containers/fuse-overlayfs/issues/397)).