### PR TITLE
more robust way of setting IFS to newline, from sylabs 1708

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Remove warning about unknown `xino=on` option from fuse-overlayfs,
   introduced in 1.1.8.
 - Ignore extraneous warning from fuse-overlayfs about a readonly `/proc`.
+- Fix dropped "n" characters on some platforms in definition file stored as part
+  of SIF metadata.
 
 ## v1.1.8 - \[2023-04-25\]
 

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -246,7 +246,8 @@ func newCommand(allData bool, appName string, img *image.Image) *command {
 	cat_file() {
 		echo "%[3]s $1:$2"
 
-		local IFS=$'\n'
+		local IFS="
+"
 		while read -r content; do
 			printf "%%s\n" "$content"
 		done < "$2"

--- a/e2e/docker/docker.go
+++ b/e2e/docker/docker.go
@@ -912,6 +912,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		// Regressions
 		"issue 4943": c.issue4943,
 		"issue 5172": c.issue5172,
-		"issue 274":  c.issue274, // https://github.com/sylabs/singularity/issues/274
+		"issue 274":  c.issue274,  // https://github.com/sylabs/singularity/issues/274
+		"issue 1704": c.issue1704, // https://github.com/sylabs/singularity/issues/1704
 	}
 }

--- a/test/defs/issue1704.def
+++ b/test/defs/issue1704.def
@@ -1,0 +1,10 @@
+bootstrap: docker
+from: ubuntu:22.04
+
+%setup
+    #an
+    #abn
+    #nn
+    #ann
+    #nan
+    #anan


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1708
 which fixed
- sylabs/singularity#1704
and fixes
- apptainer/apptainer#1336

The original PR description was:
> As part of the function of `singularity inspect`, an ad-hoc shell script is set up, by concatenating programmatically-generated snippets of shell code. One of these snippets, created in cmd/internal/cli/inspect.go:227, includes a line whose function is to set IFS (the Input Field Separator) _back_ to newline in the scope of the `cat_file()` function, despite being set to ":" (colon) in the global scope (cmd/internal/cli/inspect.go:256).
> 
> However, the way this was done until now uses escaping of the newline, as follows: `local IFS=$'\n'` This escaping apparently doesn't work on certain platforms, resulting in the relevant input being split using the character "n" as the relevant delimiter, rather than using newlines.
> 
> I have verified that it fails on Debian 11 "bullseye" on amd64, and the user who reported sylabs/singularity#1704 encountered the same thing on Ubuntu 22.04 "jammy" on amd64. There is a newer syntax for this - `local IFS=$'...'` - but there is a worry this won't work on older systems; see discussion in [this](https://stackoverflow.com/questions/16831429/when-setting-ifs-to-split-on-newlines-why-is-it-necessary-to-include-a-backspac) StackOverflow post. In the same post, however, it is mentioned that there is a rather simple and possibly more robust way to achieve the same effect, namely, to use a literal newline between double-quotes:
> 
> ```
>       <clipped>
>       local IFS="
> "
>       <clipped>
> ```
> 
> This PR replaces the previous implementation, using `$'\n'`, with the one above.