### PR TITLE
a temp hotfix for e2e build failure

### DIFF
--- a/cmd/internal/cli/build_linux_test.go
+++ b/cmd/internal/cli/build_linux_test.go
@@ -215,19 +215,19 @@ func TestProcessDefsMultipleDef(t *testing.T) {
 	assert.NilError(t, err)
 
 	args := []string{
-		"DEVEL_IMAGE=golang:1.12.3-alpine3.9",
-		"FINAL_IMAGE=alpine:3.9",
+		"DEVEL_IMAGE=alpine:3.9",
+		"FINAL_IMAGE=alpine:3.17",
 	}
 
 	d, err = processDefs(args, "", d)
 	assert.NilError(t, err)
-	assert.Equal(t, d[0].Header["from"], "golang:1.12.3-alpine3.9")
+	assert.Equal(t, d[0].Header["from"], "alpine:3.9")
 	rt := strings.Contains(d[0].BuildData.Post.Script, "export HOME=/root")
 	assert.Equal(t, rt, true)
 	rt = strings.Contains(d[0].BuildData.Post.Script, "cd /root")
 	assert.Equal(t, rt, true)
 
-	assert.Equal(t, d[1].Header["from"], "alpine:3.9")
+	assert.Equal(t, d[1].Header["from"], "alpine:3.17")
 	rt = strings.Contains(d[1].BuildData.Files[0].Files[0].Src, "/root/hello")
 	assert.Equal(t, rt, true)
 }

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -999,13 +999,13 @@ func (c imgBuildTests) buildDefinitionWithBuildArgs(t *testing.T) {
 		{
 			name: "ok case multiple stage build",
 			buildArgs: []string{
-				"DEVEL_IMAGE=golang:1.12.3-alpine3.9",
-				"FINAL_IMAGE=alpine:3.9",
+				"DEVEL_IMAGE=alpine:3.9",
+				"FINAL_IMAGE=alpine:3.17",
 				"HOME=/root",
 			},
 			verify: []string{
-				"from: golang:1.12.3-alpine3.9",
 				"from: alpine:3.9",
+				"from: alpine:3.17",
 				"cd /root",
 			},
 			deffile: path.Join("testdata", "build-template", "multiple-stage.def"),
@@ -1015,13 +1015,13 @@ func (c imgBuildTests) buildDefinitionWithBuildArgs(t *testing.T) {
 		{
 			name: "ok case multiple stage build with arg file",
 			buildArgs: []string{
-				"DEVEL_IMAGE=golang:1.12.3-alpine3.9",
-				"FINAL_IMAGE=alpine:3.9",
+				"DEVEL_IMAGE=alpine:3.9",
+				"FINAL_IMAGE=alpine:3.17",
 			},
 			buildArgFile: argfile,
 			verify: []string{
-				"from: golang:1.12.3-alpine3.9",
 				"from: alpine:3.9",
+				"from: alpine:3.17",
 				"cd /root",
 			},
 			deffile: path.Join("testdata", "build-template", "multiple-stage.def"),
@@ -1031,8 +1031,8 @@ func (c imgBuildTests) buildDefinitionWithBuildArgs(t *testing.T) {
 		{
 			name: "ko case multiple stage build",
 			buildArgs: []string{
-				"DEVEL_IMAGE=golang:1.12.3-alpine3.9",
-				"FINAL_IMAGE=alpine:3.9",
+				"DEVEL_IMAGE=alpine:3.9",
+				"FINAL_IMAGE=alpine:3.17",
 			},
 			verify:  []string{},
 			deffile: path.Join("testdata", "build-template", "multiple-stage.def"),
@@ -1041,8 +1041,8 @@ func (c imgBuildTests) buildDefinitionWithBuildArgs(t *testing.T) {
 		},
 	}
 
-	t.Run("build definition", func(t *testing.T) {
-		for _, tt := range tests {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			dn, cleanup := c.tempDir(t, "build-definition-template")
 			t.Cleanup(func() {
 				if !t.Failed() {
@@ -1078,7 +1078,6 @@ func (c imgBuildTests) buildDefinitionWithBuildArgs(t *testing.T) {
 			expects = append(expects, e2e.ExpectOutput(e2e.UnwantedExactMatch, "}}"))
 			c.env.RunApptainer(
 				t,
-				e2e.AsSubtest(tt.name),
 				e2e.WithProfile(e2e.UserProfile),
 				e2e.WithCommand("build"),
 				e2e.WithArgs(args...),
@@ -1106,8 +1105,8 @@ func (c imgBuildTests) buildDefinitionWithBuildArgs(t *testing.T) {
 					e2e.ExpectError(e2e.ContainMatch, tt.err),
 				),
 			)
-		}
-	})
+		})
+	}
 }
 
 func (c *imgBuildTests) ensureImageIsEncrypted(t *testing.T, imgPath string) {

--- a/e2e/testdata/build-template/multiple-stage-unit-test.def
+++ b/e2e/testdata/build-template/multiple-stage-unit-test.def
@@ -7,22 +7,17 @@ Stage: devel
 
 %post
   # prep environment
-  export PATH="/go/bin:/usr/local/go/bin:$PATH"
   export HOME={{ HOME }}
   cd {{ HOME }}
 
   # insert source code, could also be copied from the host with %files
-  cat << EOF > hello.go
-  package main
-  import "fmt"
+  cat << EOF > hello.sh
+  #!/bin/sh
 
-  func main() {
-    fmt.Printf("Hello World!\n")
-  }
-EOF
+  echo "hello"
+  EOF
 
-  go build -o hello hello.go
-
+  chmod a+x hello.sh
 
 # Install binary into the final image
 Bootstrap: docker
@@ -35,4 +30,4 @@ Stage: final
 
 # install binary from stage one
 %files from devel
-  {{ HOME }}/hello /bin/hello
+  {{ HOME }}/hello.sh /bin/hello

--- a/e2e/testdata/build-template/multiple-stage.def
+++ b/e2e/testdata/build-template/multiple-stage.def
@@ -7,22 +7,17 @@ Stage: devel
 
 %post
   # prep environment
-  export PATH="/go/bin:/usr/local/go/bin:$PATH"
   export HOME={{ HOME }}
   cd {{ HOME }}
 
   # insert source code, could also be copied from the host with %files
-  cat << EOF > hello.go
-  package main
-  import "fmt"
+  cat << EOF > hello.sh
+  #!/bin/sh
 
-  func main() {
-    fmt.Printf("Hello World!\n")
-  }
-EOF
+  echo "hello"
+  EOF
 
-  go build -o hello hello.go
-
+  chmod a+x hello.sh
 
 # Install binary into the final image
 Bootstrap: docker
@@ -34,4 +29,4 @@ Stage: final
 
 # install binary from stage one
 %files from devel
-  {{ HOME }}/hello /bin/hello
+  {{ HOME }}/hello.sh /bin/hello

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -238,22 +238,25 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		// Grab the modified source ref from the cache
 		cp.srcRef, err = oci.ConvertReference(ctx, b.Opts.ImgCache, cp.srcRef, cp.sysCtx)
 		if err != nil {
-			return err
+			return fmt.Errorf("while converting reference: %w", err)
 		}
 	}
 
 	// To to do the RootFS extraction we also have to have a location that
 	// contains *only* this image
 	cp.tmpfsRef, err = ocilayout.ParseReference(cp.b.TmpDir + ":" + "tmp")
+	if err != nil {
+		return fmt.Errorf("while parsing reference: %w", err)
+	}
 
 	err = cp.fetch(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("while fetching image: %w", err)
 	}
 
 	cp.imgConfig, err = cp.getConfig(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("while getting config: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

@cclerget found that there were random failures related to image build

```
2023-06-01T09:57:28.0322314Z     imgbuild.go:375: Running command "/usr/local/bin/apptainer build --fakeroot /tmp/stest.843361627/build-local-image.2014779030/image-0 /tmp/stest.843361627/test.sif"
2023-06-01T09:57:28.0766769Z === NAME  TestE2E/PAR/BUILD/definition_build_with_template_support/build_definition/ok_case_multiple_stage_build
2023-06-01T09:57:28.0767293Z     imgbuild.go:1079: 
2023-06-01T09:57:28.0769606Z         "/usr/local/bin/apptainer build --build-arg DEVEL_IMAGE=golang:1.12.3-alpine3.9 --build-arg FINAL_IMAGE=alpine:3.9 --build-arg HOME=/root /tmp/stest.843361627/build-definition-template.3694182379/container testdata/build-template/multiple-stage.def" output:
2023-06-01T09:57:28.0771141Z         INFO:    Starting build...
2023-06-01T09:57:28.0771526Z         Getting image source signatures
2023-06-01T09:57:28.0772091Z         Copying blob sha256:f53f6727338a286b50152f2950451f2965fcad5470097a611854921e0a453b40
2023-06-01T09:57:28.0772945Z         Copying blob sha256:bdf0201b3a056acc4d6062cc88cd8a4ad5979983bfb640f15a145e09ed985f92
2023-06-01T09:57:28.0773634Z         Copying blob sha256:38f114998adb0933d6bd188536093008212eb087b211bbb06c806f5066d250a4
2023-06-01T09:57:28.0774558Z         Copying blob sha256:21134b1a9e68ce4374901b7a552e521e3860c228fe02de4d88f249f924fb1a28
2023-06-01T09:57:28.0775229Z         Copying blob sha256:06fc5905660758bc9ed54ba2f92288b9364fec66412856229aad42680842b4af
2023-06-01T09:57:28.0775929Z         Copying config sha256:76ec6b444a143c9fa788da6c536160986d9b9ae23ca9bd31c26cb3078395b87c
2023-06-01T09:57:28.0776601Z         Writing manifest to image destination
2023-06-01T09:57:28.0776938Z         Storing signatures
2023-06-01T09:57:28.0778359Z         FATAL:   While performing build: conveyor failed to get: no descriptor found for reference "0353ff91502d17ed9def42c4008d4b14aa1adf9a175008a2cdf93151694b17fd"
2023-06-01T09:57:28.0778785Z         
2023-06-01T09:57:28.0779385Z     imgbuild.go:1079: got 255 as exit code and was expecting 0: exit status 255
2023-06-01T09:57:28.0781203Z         waiting for command "/usr/local/bin/apptainer build --build-arg DEVEL_IMAGE=golang:1.12.3-alpine3.9 --build-arg FINAL_IMAGE=alpine:3.9 --build-arg HOME=/root /tmp/stest.843361627/build-definition-template.3694182379/container testdata/build-template/multiple-stage.def"
2023-06-01T09:57:28.0782081Z         github.com/apptainer/apptainer/e2e/internal/e2e.TestEnv.RunApptainer.func1
2023-06-01T09:57:28.0782742Z         	github.com/apptainer/apptainer/e2e/internal/e2e/apptainercmd.go:669
2023-06-01T09:57:28.0783252Z         testing.tRunner
2023-06-01T09:57:28.0784070Z         	testing/testing.go:1576
2023-06-01T09:57:28.0784389Z         runtime.goexit
2023-06-01T09:57:28.0784714Z         	runtime/asm_amd64.s:1598
```

It's related to the image build procedure, we doubt that it might be related to previous cache architecture aware merge (https://github.com/apptainer/apptainer/pull/1295). 

In this PR, I replace the original big Golang image with a smaller alpine image for multiple-stage builds.
Also wrapping errors in `conveyorPacker_oci.go` to help locate the errors if we are faced with this random failure again. 

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
