### PR TITLE
Cherry pick commits for 1.1.9 to the release-1.1 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+### Bug fixes
+
+- Remove duplicated group ids.
+
 ## v1.1.8 - \[2023-04-25\]
 
 ### Security fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 ### Bug fixes
 
 - Remove duplicated group ids.
+- Fix not being able to handle multiple entries in `LD_PRELOAD` when
+  binding fakeroot into container during apptainer startup for --fakeroot
+  with fakeroot command.
 
 ## v1.1.8 - \[2023-04-25\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes since last release
+
 ### Bug fixes
 
 - Remove warning about unknown `xino=on` option from fuse-overlayfs,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Remove warning about unknown `xino=on` option from fuse-overlayfs,
   introduced in 1.1.8.
 - Ignore extraneous warning from fuse-overlayfs about a readonly `/proc`.
+- Fix dropped "n" characters on some platforms in definition file stored as part
+  of SIF metadata.
 - Remove duplicated group ids.
 - Fix not being able to handle multiple entries in `LD_PRELOAD` when
   binding fakeroot into container during apptainer startup for --fakeroot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Bug fixes
 
+- Remove warning about unknown `xino=on` option from fuse-overlayfs,
+  introduced in 1.1.8.
+- Ignore extraneous warning from fuse-overlayfs about a readonly `/proc`.
 - Remove duplicated group ids.
 - Fix not being able to handle multiple entries in `LD_PRELOAD` when
   binding fakeroot into container during apptainer startup for --fakeroot

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project leader (gmkurtzer@gmail.com). All
+reported by contacting the project leader (`gmkurtzer@gmail.com`). All
 complaints will be reviewed and investigated and will result in a
 response that is deemed necessary and appropriate to the circumstances.
 The project team is obligated to maintain confidentiality with regard to

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -81,6 +81,7 @@
 - Satish Chebrolu  <satish@sylabs.io>
 - Shane Loretz <sloretz@openrobotics.org>, <shane.loretz@gmail.com>
 - Shengjing Zhu <i@zhsj.me>
+- Subil Abraham <abrahams@ornl.gov>
 - Tarcisio Fedrizzi <tarcisio.fedrizzi@gmail.com>
 - Thomas Hamel <hmlth@t-hamel.fr>
 - Tim Wright <7im.Wright@protonmail.com>

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -247,7 +247,8 @@ func newCommand(allData bool, appName string, img *image.Image) *command {
 	cat_file() {
 		echo "%[3]s $1:$2"
 
-		local IFS=$'\n'
+		local IFS="
+"
 		while read -r content; do
 			printf "%%s\n" "$content"
 		done < "$2"

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -142,6 +142,13 @@ func GetFakeBinds(fakerootPath string) ([]string, error) {
 	if libraryPath == "" {
 		return binds, fmt.Errorf("No LD_LIBRARY_PATH in fakeroot environment")
 	}
+	preload_entries := strings.Split(preload, ":")
+	for _, entry := range preload_entries {
+		if strings.HasPrefix(entry, "libfakeroot") {
+			preload = entry
+			break
+		}
+	}
 
 	src := fakerootPath
 	point := binds[0]

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -142,8 +142,8 @@ func GetFakeBinds(fakerootPath string) ([]string, error) {
 	if libraryPath == "" {
 		return binds, fmt.Errorf("No LD_LIBRARY_PATH in fakeroot environment")
 	}
-	preload_entries := strings.Split(preload, ":")
-	for _, entry := range preload_entries {
+	preloadEntries := strings.Split(preload, ":")
+	for _, entry := range preloadEntries {
 		if strings.HasPrefix(entry, "libfakeroot") {
 			preload = entry
 			break

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -152,6 +152,8 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 	case "overlay":
 		f = &d.overlayFeature
 		optsStr := strings.Join(params.FSOptions, ",")
+		// Ignore xino=on option with fuse-overlayfs
+		optsStr = strings.Replace(optsStr, ",xino=on", "", -1)
 		// noacl is needed to avoid failures when the upper layer
 		// filesystem type (for example tmpfs) does not support it,
 		// when the fuse-overlayfs version is 1.8 or greater.
@@ -270,6 +272,9 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 		// from squashfuse_ll
 		"failed to clone device fd",
 		"continue without -o clone_fd",
+		// from fuse-overlayfs due to a bug
+		// (see https://github.com/containers/fuse-overlayfs/issues/397)
+		"/proc seems to be mounted as readonly",
 	}
 	filterMsg := func() string {
 		var errstr string


### PR DESCRIPTION
This cherry-picks the commits from #1296, #1322, #1369, and #1375 to the release-1.1 branch for the 1.1.9 release.