### PR TITLE
Update for 1.2.0-rc.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    target-branch: release-1.2
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
     target-branch: release-1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,55 +5,86 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
-## Changes Since Last Release
+## v1.2.0-rc.1 - \[2023-06-07\]
 
 ### Changed defaults / behaviours
 
-- When the kernel supports unprivileged overlay mounts in a user
-  namespace, the container will be constructed using an overlay
-  instead of underlay layout.
+- Create the current working directory in a container when it doesn't exist.
+  This restores behavior as it was before singularity 3.6.0.
+  As a result, using `--no-mount home` won't have any effect when running
+  apptainer from a home directory and will require `--no-mount home,cwd` to
+  avoid mounting that directory.
+- Handle current working directory paths containing symlinks both on the
+  host and in a container but pointing to different destinations.
+  If detected, the current working directory is not mounted when the
+  destination directory in the container exists.
+- Destination mount points are now sorted by shortest path first to ensure that
+  a user bind doesn't override a previous bind path when set in arbitrary order
+  on the CLI.  This is also applied to image binds.
+- When the kernel supports unprivileged overlay mounts in a user namespace,
+  the container will be constructed by default using an overlay instead
+  of an underlay layout for bind mounts.
+  A new `--underlay` action option can be used to prefer underlay instead
+  of overlay.
+- `sessiondir maxsize` in `apptainer.conf` now defaults to 64 MiB for new
+  installations. This is an increase from 16 MiB in prior versions.
+- The apptainer cache is now architecture aware, so the same home directory
+  cache can be shared by machines with different architectures.
+- Overlay is blocked on the `panfs` filesystem, allowing sandbox directories
+  to be run from `panfs` without error.
+- Show standard output of yum bootstrap if log level is verbose or higher
+  while building a container.
+- Lookup and store user/group information in stage one prior to entering any
+  namespaces, to fix an issue with winbind not correctly looking up user/group
+  information when using user namespaces.
 - A new `--reproducible` flag for `./mconfig` will configure Apptainer so that
   its binaries do not contain non-reproducible paths. This disables plugin
   functionality.
-- Overlay is blocked on the `panfs` filesystem, allowing sandbox directories to be
-  run from `panfs` without error.
-- Instances are started in a cgroup, by default, when run as root or when
-  unified cgroups v2 with systemd as manager is configured. This allows
-  `apptainer instance stats` to be supported by default when possible.
-- `sessiondir maxsize` in `apptainer.conf` now defaults to 64 MiB for new
-  installations. This is an increase from 16 MiB in prior versions.
-- Show standard output of yum bootstrap if log level is verbose or higher.
-- Add architecture aware support for apptainer cache.
-- Handle current working directory path containing symlink boths on host and
-  container but pointing to different destinations, if detected the current
-  working directory is not mounted when the destination directory in container exists.
-- Lookup and store user/group information in stage one prior to entering any
-  namespaces to fix issue with winbind not correctly lookup user/group information
-  when using user namespace.
-- Destination mount points are now sorted by shortest path first to ensure that
-  a user bind doesn't override a previous bind path when set in arbitrary order
-  on CLI, this is also applied to image binds.
-- Create current working directory in container when it doesn't exist,
-  as a result, using `--no-mount home` won't have any effects when running
-  apptainer from a home directory and will require `--no-mount home,cwd` to
-  obtain the same behavior as with previous releases.
 
 ### New features / functionalities
 
-- Added a new `instance run` command that will execute the runscript when an
+- Support for unprivileged encryption of SIF files using gocryptfs.  The
+  gocryptfs command is included in rpm and debian packaging.
+  This is not compatible with privileged encryption, so containers encrypted
+  by root need to be rebuilt by an unprivileged user.
+- Templating support for definition files. Users can now define variables in
+  definition files via a matching pair of double curly brackets.
+  Variables of the form `{{ variable }}` will be replaced by a value defined
+  either by a `variable=value` entry in the `%arguments` section of the
+  definition file or through new build options
+  `--build-arg` or `--build-arg-file`.
+- Add a new `instance run` command that will execute the runscript when an
   instance is initiated instead of executing the startscript.
-- The `--no-mount` flag now accepts the value `bind-paths` to disable mounting
-  of all `bind path` entries in `apptainer.conf`.
-- Instances started by a non-root user can use `--apply-cgroups` to apply
-  resource limits. Requires cgroups v2, and delegation configured via systemd.
+- The `sign` and `verify` commands now support signing and verification
+  with non-PGP key material by specifying the path to a private key via
+  the `--key` flag.
+- The `verify` command now supports verification with X.509 certificates by
+  specifying the path to a certificate via the `--certificate` flag. By
+  default, the system root certificate pool is used as trust anchors unless
+  overridden via the `--certificate-roots` flag. A pool of intermediate
+  certificates that are not trust anchors, but can be used to form a
+  certificate chain, can also be specified via the `--certificate-intermediates`
+  flag.
+- Support for online verification checks of X.509 certificates using OCSP
+  protocol via the new `verify --ocsp-verify` option.
 - The `instance stats` command displays the resource usage every second. The
   `--no-stream` option disables this interactive mode and shows the
   point-in-time usage.
+- Instances are now started in a cgroup by default, when run as root or when
+  unified cgroups v2 with systemd as manager is configured.  This allows
+  `apptainer instance stats` to be supported by default when possible.
+- The `instance start` command now accepts an optional `--app <name>` argument
+  which invokes a start script within the `%appstart <name>` section in the
+  definition file.
+  The `instance stop` command still only requires the instance name.
+- The instance name is now available inside an instance via the new
+  `APPTAINER_INSTANCE` environment variable.
+- The `--no-mount` flag now accepts the value `bind-paths` to disable mounting
+  of all `bind path` entries in `apptainer.conf`.
 - Support for `DOCKER_HOST` parsing when using `docker-daemon://`
 - `DOCKER_USERNAME` and `DOCKER_PASSWORD` supported without `APPTAINER_` prefix.
-- Add new Linux capabilities: `CAP_PERFMON`, `CAP_BPF`, `CAP_CHECKPOINT_RESTORE`.
-- Instance name is available inside an instance via the new
-  `APPTAINER_INSTANCE` environment variable.
+- Add new Linux capabilities `CAP_PERFMON`, `CAP_BPF`, and
+  `CAP_CHECKPOINT_RESTORE`.
 - Add `setopt` definition file header for the `yum` bootstrap agent. The
   `setopt` value is passed to `yum / dnf` using the `--setopt` flag. This
   permits setting e.g. `install_weak_deps=False` to bootstrap recent versions of
@@ -61,52 +92,27 @@ For older changes see the [archived Singularity change log](https://github.com/a
   container. See `examples/Fedora` for an example definition file.
 - Warn user that a `yum` bootstrap of an older distro may fail if the host rpm
   `_db_backend` is not `bdb`.
-- The `sign` command now supports signing with non-PGP key material by
-  specifying the path to a private key via the `--key` flag.
-- The `verify` command now supports verification with non-PGP key material by
-  specifying the path to a public key via the `--key` flag.
-- The `verify` command now supports verification with X.509 certificates by
-  specifying the path to a certificate via the `--certificate` flag. By
-  default, the system root certificate pool is used as trust anchors unless
-  overridden via the `--certificate-roots` flag. A pool of intermediate
-  certificates that are not trust anchors, but can be used to form a
-  certificate chain can also be specified via the `--certificate-intermediates`
-  flag.
-- Support for online verification checks of x509 certificates using OCSP protocol.
-  (introduced flag: `verify --ocsp-verify`)
-- Support for unprivileged encryption of SIF files using gocryptfs.  The
-  gocryptfs command is included in rpm and debian packaging.
-- The `instance start` command now accepts an optional `--app <name>` argument which
-  invokes start script within the `%appstart <name>` section in the definition file.
-  The `instance stop` command still only requires the instance name.
 - The `remote get-login-password` command allows users to retrieve a remote's
   token. This enables piping the secret directly into docker login while
   preventing it from showing up in a shell's history.
-- Templating support for definition files. Users can now define variables in definition
-  files via a matching pair of double curly brackets. Variables of the form
-  `{{ variable }}` will be replaced by a value defined either by a `variable=value`
-  entry in the `%arguments` section of the definition file or through new build options
-  `--build-arg` or `--build-arg-file`.
+- Define EUID in %environment alongside UID.
+- In `--rocm` mode, the whole of `/dev/dri` is now bound into the container when
+  `--contain` is in use. This makes `/dev/dri/render` devices available,
+  required for later ROCm versions.
 
 ### Other changes
 
 - Update minimum go version to 1.19.
-- Fix non-root instance join with unprivileged systemd managed cgroups, when
-  join is from outside a user-owned cgroup.
-- Define EUID in %environment alongside UID.
-- Avoid UID / GID / EUID readonly var warnings with `--env-file`.
-- In `--rocm` mode, the whole of `/dev/dri` is now bound into the container when
-  `--contain` is in use. This makes `/dev/dri/render` devices available,
-  required for later ROCm versions.
-- Ensure consistent binding of libraries under `--nv/--rocm` when duplicate
-  `<library>.so[.version]` files are listed by `ldconfig -p`.
+- Fix non-root instance join with unprivileged systemd-managed cgroups v2,
+  when join is from outside a user-owned cgroup.
 - Fix joining cgroup of instance started as root, with cgroups v1,
   non-default cgroupfs manager, and no device rules.
+- Avoid UID / GID / EUID readonly var warnings with `--env-file`.
+- Ensure consistent binding of libraries under `--nv/--rocm` when duplicate
+  `<library>.so[.version]` files are listed by `ldconfig -p`.
 - Ensure `DOCKER_HOST` is honored in non-build flows.
 - Corrected `apptainer.conf` comment, to refer to correct file as source
   of default capabilities when `root default capabilities = file`.
-- Add an `--underlay` action option to prefer underlay instead of overlay
-  for bind mounts.
 - Fix memory usage calculation during apptainer compilation on RaspberryPi.
 - Fix misleading error when an overlay is requested by the root user while the
   overlay kernel module is not loaded.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,7 +137,7 @@ To build a specific version of Apptainer, check out a
 for example:
 
 ```sh
-git checkout v1.1.9
+git checkout v1.2.0-rc.1
 ```
 
 ## Compiling Apptainer
@@ -295,7 +295,7 @@ like this:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-VERSION=1.1.9  # this is the apptainer version, change as you need
+VERSION=1.2.0-rc.1  # this is the apptainer version, change as you need
 # Fetch the source
 wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/apptainer-${VERSION}.tar.gz
 ```
@@ -347,7 +347,7 @@ in your PATH:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-VERSION=1.1.9 # this is the latest apptainer version, change as you need
+VERSION=1.2.0-rc.1 # this is the latest apptainer version, change as you need
 ./mconfig
 make -C builddir rpm
 sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/apptainer-$(echo $VERSION|tr - \~)*.x86_64.rpm 


### PR DESCRIPTION
This rearranges the CHANGELOG and sets things up for the first 1.2.0 release candidate.