### PR TITLE
Add --cwd as preferred equivalent to --pwd, from sylabs 1496

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes since last release
+
+### Changed defaults / behaviours
+
+- `--cwd` is now the preferred form of the flag for setting the container's
+  working directory, though `--pwd` is still supported for compatibility.
+
 ## v1.2.0-rc.1 - \[2023-06-07\]
 
 ### Changed defaults / behaviours

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -24,7 +24,7 @@ var (
 	overlayPath      []string
 	scratchPath      []string
 	workdirPath      string
-	pwdPath          string
+	cwdPath          string
 	shellPath        string
 	hostname         string
 	network          string
@@ -202,13 +202,25 @@ var actionShellFlag = cmdline.Flag{
 	Tag:          "<path>",
 }
 
+// --cwd
+var actionCwdFlag = cmdline.Flag{
+	ID:           "actionCwdFlag",
+	Value:        &cwdPath,
+	DefaultValue: "",
+	Name:         "cwd",
+	Usage:        "initial working directory for payload process inside the container (synonym for --pwd)",
+	EnvKeys:      []string{"CWD", "TARGET_CWD"},
+	Tag:          "<path>",
+}
+
 // --pwd
 var actionPwdFlag = cmdline.Flag{
 	ID:           "actionPwdFlag",
-	Value:        &pwdPath,
+	Value:        &cwdPath,
 	DefaultValue: "",
 	Name:         "pwd",
-	Usage:        "initial working directory for payload process inside the container",
+	Usage:        "initial working directory for payload process inside the container (synonym for --cwd)",
+	Hidden:       true,
 	EnvKeys:      []string{"PWD", "TARGET_PWD"},
 	Tag:          "<path>",
 }
@@ -917,6 +929,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&commonPromptForPassphraseFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonPEMFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPidNamespaceFlag, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionCwdFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPwdFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionScratchFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionSecurityFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -342,7 +342,7 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 		launch.OptCgroupsJSON(cgJSON),
 		launch.OptConfigFile(configurationFile),
 		launch.OptShellPath(shellPath),
-		launch.OptPwdPath(pwdPath),
+		launch.OptCwdPath(cwdPath),
 		launch.OptFakeroot(isFakeroot),
 		launch.OptBoot(isBoot),
 		launch.OptNoInit(noInit),

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -226,6 +226,11 @@ func (c actionTests) actionExec(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "CwdGood",
+			argv: []string{"--cwd", "/etc", c.env.ImagePath, "true"},
+			exit: 0,
+		},
+		{
 			name: "PwdGood",
 			argv: []string{"--pwd", "/etc", c.env.ImagePath, "true"},
 			exit: 0,
@@ -434,6 +439,13 @@ func (c actionTests) STDPipe(t *testing.T) {
 			command: "run",
 			argv:    []string{"--app", "foo", c.env.ImagePath},
 			output:  "RUNNING FOO",
+			exit:    0,
+		},
+		{
+			name:    "CwdPath",
+			command: "exec",
+			argv:    []string{"--cwd", "/etc", c.env.ImagePath, "pwd"},
+			output:  "/etc",
 			exit:    0,
 		},
 		{
@@ -1196,6 +1208,16 @@ func (c actionTests) actionBinds(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "SimpleFileCwd",
+			args: []string{
+				"--bind", canaryFileBind,
+				"--cwd", contCanaryDir,
+				sandbox,
+				"test", "-f", "file",
+			},
+			exit: 0,
+		},
+		{
 			name: "SimpleFilePwd",
 			args: []string{
 				"--bind", canaryFileBind,
@@ -1222,6 +1244,16 @@ func (c actionTests) actionBinds(t *testing.T) {
 				"--bind", canaryDirBind,
 				sandbox,
 				"test", "-f", contCanaryFile,
+			},
+			exit: 0,
+		},
+		{
+			name: "SimpleDirCwd",
+			args: []string{
+				"--bind", canaryDirBind,
+				"--cwd", contCanaryDir,
+				sandbox,
+				"test", "-f", "file",
 			},
 			exit: 0,
 		},

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -111,8 +111,8 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	// Save the current working directory if not set
 	if e.EngineConfig.GetCwd() == "" {
-		if pwd, err := os.Getwd(); err == nil {
-			e.EngineConfig.SetCwd(pwd)
+		if cwd, err := os.Getwd(); err == nil {
+			e.EngineConfig.SetCwd(cwd)
 		} else {
 			sylog.Warningf("can't determine current working directory")
 			e.EngineConfig.SetCwd("/")

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -745,9 +745,9 @@ func (l *Launcher) setHome() error {
 	targetUID := l.engineConfig.GetTargetUID()
 	if l.cfg.CustomHome && targetUID != 0 {
 		if targetUID > 500 {
-			if pwd, err := user.GetPwUID(uint32(targetUID)); err == nil {
-				sylog.Debugf("Target UID requested, set home directory to %s", pwd.Dir)
-				l.cfg.HomeDir = pwd.Dir
+			if pu, err := user.GetPwUID(uint32(targetUID)); err == nil {
+				sylog.Debugf("Target UID requested, set home directory to %s", pu.Dir)
+				l.cfg.HomeDir = pu.Dir
 				l.engineConfig.SetCustomHome(true)
 			} else {
 				sylog.Verbosef("Home directory for UID %d not found, home won't be mounted", targetUID)
@@ -1017,10 +1017,10 @@ func (l *Launcher) setEnvVars(ctx context.Context, args []string) error {
 
 // setProcessCwd sets the container process working directory
 func (l *Launcher) setProcessCwd() {
-	if pwd, err := os.Getwd(); err == nil {
-		l.engineConfig.SetCwd(pwd)
-		if l.cfg.PwdPath != "" {
-			l.generator.SetProcessCwd(l.cfg.PwdPath)
+	if cwd, err := os.Getwd(); err == nil {
+		l.engineConfig.SetCwd(cwd)
+		if l.cfg.CwdPath != "" {
+			l.generator.SetProcessCwd(l.cfg.CwdPath)
 			if l.generator.Config.Annotations == nil {
 				l.generator.Config.Annotations = make(map[string]string)
 			}
@@ -1029,7 +1029,7 @@ func (l *Launcher) setProcessCwd() {
 			if l.engineConfig.GetContain() {
 				l.generator.SetProcessCwd(l.engineConfig.GetHomeDest())
 			} else {
-				l.generator.SetProcessCwd(pwd)
+				l.generator.SetProcessCwd(cwd)
 			}
 		}
 	} else {
@@ -1160,11 +1160,11 @@ func (l *Launcher) starterInteractive(loadOverlay bool, useSuid bool, cfg *confi
 
 // starterInstance executes the starter binary to run an instance given the supplied engineConfig
 func (l *Launcher) starterInstance(loadOverlay bool, insideUserNs bool, name string, useSuid bool, cfg *config.Common) error {
-	pwd, err := user.GetPwUID(l.uid)
+	pu, err := user.GetPwUID(l.uid)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve user information for UID %d: %w", l.uid, err)
 	}
-	procname, err := instance.ProcName(name, pwd.Name)
+	procname, err := instance.ProcName(name, pu.Name)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -115,8 +115,8 @@ type launchOptions struct {
 
 	// ShellPath is a custom shell executable to be launched in the container.
 	ShellPath string
-	// PwdPath is the initial working directory in the container.
-	PwdPath string
+	// CwdPath is the initial working directory in the container.
+	CwdPath string
 
 	// Fakeroot enables the fake root mode, using user namespaces and subuid / subgid mapping.
 	Fakeroot bool
@@ -423,10 +423,10 @@ func OptShellPath(s string) Option {
 	}
 }
 
-// OptPwdPath specifies the initial working directory in the container.
-func OptPwdPath(p string) Option {
+// OptCwdPath specifies the initial working directory in the container.
+func OptCwdPath(p string) Option {
 	return func(lo *launchOptions) error {
-		lo.PwdPath = p
+		lo.CwdPath = p
 		return nil
 	}
 }


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1496
 which fixed
- sylabs/singularity#1481

The original PR description was:
> 1. Support `--pwd` in OCI mode.
> 2. Replace `--pwd` with `--cwd` (see comments by @ dtrudg on [Support `--pwd` in `--oci` mode # 1481](https://github.com/sylabs/singularity/issues/1481)), and adjust code throughout to reflect this (i.e., misleading references to "{p,P}wd" in the code replaced with "{c,C}wd"). Keep `--pwd` flag as a synonym, for backwards compatibility.