### PR TITLE
ci: bump go to 1.20.5, from sylabs 1742

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   check_go_mod:
     name: check_go_mod
     runs-on: ubuntu-22.04
-    container: golang:1.20.4
+    container: golang:1.20.5
     steps:
       - uses: actions/checkout@v2
 
@@ -54,7 +54,7 @@ jobs:
   alpine:
     name: alpine
     runs-on: ubuntu-22.04
-    container: golang:1.20.4-alpine
+    container: golang:1.20.5-alpine
     steps:
       - name: Fetch deps
         run: apk add -q --no-cache git bash alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
@@ -87,7 +87,7 @@ jobs:
   check_test_corpus:
     name: check_test_corpus
     runs-on: ubuntu-22.04
-    container: golang:1.20.4
+    container: golang:1.20.5
     steps:
       - uses: actions/checkout@v2
 
@@ -106,7 +106,7 @@ jobs:
   check_license_dependencies:
     name: check_license_dependencies
     runs-on: ubuntu-22.04
-    container: golang:1.20.4
+    container: golang:1.20.5
     steps:
       - uses: actions/checkout@v2
 
@@ -239,7 +239,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.4
+          go-version: 1.20.5
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
@@ -269,7 +269,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.4
+          go-version: 1.20.5
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup dbus-user-session
@@ -314,7 +314,7 @@ jobs:
         if: env.run_tests
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.4
+          go-version: 1.20.5
 
       - name: Fetch deps
         if: env.run_tests
@@ -376,7 +376,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.4
+          go-version: 1.20.5
 
       - name: Check pkg/... doesn't depend on buildcfg
         run: |


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1742