### PR TITLE
Update gocryptfs to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - `--cwd` is now the preferred form of the flag for setting the container's
   working directory, though `--pwd` is still supported for compatibility.
 
+## Changes since last pre-release
+
+- Upgrade gocryptfs to version 2.4.0, removing the need for fusermount from
+  the fuse package.
+
 ## v1.2.0-rc.1 - \[2023-06-07\]
 
 ### Changed defaults / behaviours

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -228,22 +228,10 @@ install on some operating systems as described in its
 [documentation](https://nuetzlich.net/gocryptfs/quickstart/), but
 otherwise to compile it from source follow these instructions.
 
-First, make sure that the additional required package is installed.  On Debian:
-
-```sh
-apt-get install -y fuse3
-```
-
-On CentOS/RHEL:
-
-```sh
-yum install -y fuse
-```
-
 To download the source code do this:
 
 ```sh
-GOCRYPTFSVERSION=2.3.2
+GOCRYPTFSVERSION=2.4.0
 curl -L -O https://github.com/rfjakob/gocryptfs/archive/v$GOCRYPTFSVERSION/gocryptfs-$GOCRYPTFSVERSION.tar.gz
 ```
 

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -36,7 +36,6 @@ Depends:
  squashfuse,
  fuse2fs,
  fuse-overlayfs,
- fuse3,
  fakeroot
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute" formerly known as Singularity

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -34,7 +34,7 @@
 %global package_version @PACKAGE_VERSION@
 
 # Uncomment this to include gocryptfs
-# %%global gocryptfs_version 2.3.2
+# %%global gocryptfs_version 2.4.0
 # Uncomment this to include a multithreaded version of squashfuse_ll
 # %%global squashfuse_version 0.1.105
 

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -21,7 +21,7 @@ usage()
 	echo "   or Fedora."
 	echo " dist can start with el or fc and ends with the major version number,"
 	echo "   e.g. el9 or fc37, default based on the current system."
-	echo "   As a convenience, active debian and ubuntu versions (not counting 18.04)"
+	echo "   As a convenience, active debian and ubuntu versions"
 	echo "   get translated into a compatible el version for downloads."
 	echo "   OpenSUSE based distributions are also mapped to el, or native openSUSE"
 	echo "   binaries can be used via the -o switch."
@@ -285,10 +285,10 @@ OSUTILS=""
 EXTRASUTILS="fuse-overlayfs"
 EPELUTILS="fakeroot"
 if [ "$DIST" = el7 ]; then
-	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs fuse"
+	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs"
 	EPELUTILS="$EPELUTILS libzstd fuse2fs fuse3-libs fakeroot-libs"
 elif [ "$DIST" = el8 ]; then
-	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs fuse libzstd e2fsprogs-libs e2fsprogs fuse3-libs"
+	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs libzstd e2fsprogs-libs e2fsprogs fuse3-libs"
 	EPELUTILS="$EPELUTILS fakeroot-libs"
 elif [ "$DIST" = "opensuse-tumbleweed" ]; then
 	OSUTILS="$OSUTILS libseccomp2 squashfs liblzo2-2 libzstd1 e2fsprogs fuse3 libfuse3-3 fakeroot fuse2fs $EXTRASUTILS $EPELUTILS"
@@ -299,7 +299,7 @@ elif [ "$DIST" = "suse15" ]; then
 	EXTRASUTILS="$EXTRASUTILS fuse2fs"
 	EPELUTILS=""
 else
-	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs fuse libzstd e2fsprogs-libs e2fsprogs"
+	OSUTILS="$OSUTILS lzo libseccomp squashfs-tools fuse-libs libzstd e2fsprogs-libs e2fsprogs"
 	EXTRASUTILS="$EXTRASUTILS fuse3-libs"
 	EPELUTILS="$EPELUTILS fakeroot-libs"
 fi


### PR DESCRIPTION
This updates gocryptfs to version 2.4.0, removing the need for fusermount.
- Fixes #1364 

It also removes an obsolete reference to Ubuntu 18.04 in install-unprvileged.sh.