### PR TITLE
1138 consider gnu vs fhs definition of localstatedir, from sylabs 1452 & 1455

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - `--cwd` is now the preferred form of the flag for setting the container's
   working directory, though `--pwd` is still supported for compatibility.
+- When building RPM, we will now use `/var/lib/apptainer` (rather than
+  `/var/apptainer`) to store local state files.
 
 ## Changes since last pre-release
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -308,9 +308,9 @@ fi
 %dir %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/*
 %{_datadir}/bash-completion/completions/*
-%dir %{_localstatedir}/%{name}
-%dir %{_localstatedir}/%{name}/mnt
-%dir %{_localstatedir}/%{name}/mnt/session
+%dir %{_sharedstatedir}/%{name}
+%dir %{_sharedstatedir}/%{name}/mnt
+%dir %{_sharedstatedir}/%{name}/mnt/session
 %{_mandir}/man1/%{name}*
 %{_mandir}/man1/singularity*
 %license LICENSE.md

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -209,7 +209,7 @@ fi
         --includedir=%{_includedir} \
         --libdir=%{_libdir} \
         --libexecdir=%{_libexecdir} \
-        --localstatedir=%{_localstatedir} \
+        --localstatedir=%{_sharedstatedir} \
         --sharedstatedir=%{_sharedstatedir} \
         --mandir=%{_mandir} \
         --infodir=%{_infodir}

--- a/internal/pkg/buildcfg/confgen/gen.go
+++ b/internal/pkg/buildcfg/confgen/gen.go
@@ -172,7 +172,8 @@ func relocatePath(original string) string {
 	rootPrefix := false
 	if !strings.HasPrefix(original, "{{.Prefix}}") {
 		if strings.HasPrefix(original, "/etc/apptainer") ||
-			strings.HasPrefix(original, "/var/apptainer") {
+			strings.HasPrefix(original, "/var/apptainer") ||
+			strings.HasPrefix(original, "/var/lib/apptainer") {
 			// These are typically the only pieces not under
 			// "/usr" (which is the prefix) in packages
 			rootPrefix = true


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity#1452
- sylabs/singularity#1455
 which fixed
- sylabs/singularity#1138
- sylabs/singularity#1454

The original PR description was:
> Changed value of `--localstatedir` in `dist/rpm/singularity-ce.spec.in` to `/var/lib` (by pulling from the macro `%{_sharedstatedir}` instead of `%{_localstatedir}`, as was the case previously).
> 
> This brings the behavior of our RPM packaging in line with [current FHS specifications](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s08.html), as well as what Red Hat are now [requiring](https://bugzilla.redhat.com/show_bug.cgi?id=2145834).
> 
> This also brings the behavior of RPM builds in line, in this respect, with what we do for `.deb` packaging (see `debian/rules`).

> Make the %files section match with the change in sylabs/singularity#1452.
> 
> Apologies that I missed this in review.