### PR TITLE
Migrate to gopkg.in/yaml.v3, from sylabs 1398

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,6 +65,7 @@
 - Michael Herzberg <michael@mherzberg.de>
 - Michael Milton <ttmigueltt@gmail.com>
 - Michael Moore <michael.moore@nuance.com>
+- Michael Richards <m.richards@utexas.edu>
 - Mike Frisch <michael.frisch@sylabs.io>
 - Mike Gray <mike@sylabs.io>
 - Nathan Chou <nathan.chou@sylabs.io>, <choun@berkeley.edu>
@@ -99,6 +100,7 @@
 - Westley Kurtzer <westley@sylabs.io>, <westleyk@nym.hush.com>
 - Yannick Cote <y@sylabs.io>, <yhcote@gmail.com>
 - Yaroslav Halchenko <debian@onerussian.com>
+- Yinuo Chen <ynchen2829@utexas.edu>
 - Yoshiaki Senda <yoshiaki@live.it>
 - Onur Yılmaz <csonuryilmaz@gmail.com>
 - Pranathi Locula <locula@deshaw.com>

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/sys v0.9.0
 	golang.org/x/term v0.9.0
 	golang.org/x/text v0.10.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.4.0
 	mvdan.cc/sh/v3 v3.6.1-0.20221221181323-d3feb15bed3a
 	oras.land/oras-go v1.2.3
@@ -60,6 +60,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/emirpasic/gods v1.18.1
 	github.com/sirupsen/logrus v1.9.3
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -181,5 +182,4 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/app/apptainer/remote_add_test.go
+++ b/internal/app/apptainer/remote_add_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/remote"
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	"github.com/apptainer/apptainer/internal/pkg/test"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/internal/pkg/remote/remote.go
+++ b/internal/pkg/remote/remote.go
@@ -11,6 +11,7 @@
 package remote
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -23,7 +24,7 @@ import (
 	remoteutil "github.com/apptainer/apptainer/internal/pkg/remote/util"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // ErrNoDefault indicates no default remote being set
@@ -79,7 +80,9 @@ func ReadFrom(r io.Reader) (*Config, error) {
 		// If we had data to read in io.Reader, attempt to unmarshal as YAML.
 		// Also, it will fail if the YAML file does not have the expected
 		// structure.
-		if err := yaml.UnmarshalStrict(b, c); err != nil {
+		dec := yaml.NewDecoder(bytes.NewReader(b))
+		dec.KnownFields(true)
+		if err := dec.Decode(c); err != nil {
 			return nil, fmt.Errorf("failed to decode YAML data from io.Reader: %s", err)
 		}
 	}

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1398
 which fixed
- sylabs/singularity#1217

The original PR description was:
> Updates the Go dependency to [yaml v3](https://gopkg.in/yaml.v3).