### PR TITLE
add username & email in 'remote status' output, from sylabs 1490 & 1521

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - `--cwd` is now the preferred form of the flag for setting the container's
   working directory, though `--pwd` is still supported for compatibility.
 
+### New Features & Functionality
+
+- The `remote status` command will now print the username, realname, and email
+  of the logged-in user, if available.
+
 ## Changes since last pre-release
 
 - Upgrade gocryptfs to version 2.4.0, removing the need for fusermount from

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -144,10 +144,11 @@ const (
 	RemoteStatusShort string = `Check the status of the apptainer services at an endpoint, and your authentication token`
 	RemoteStatusLong  string = `
   The 'remote status' command checks the status of the specified remote endpoint
-  and reports the availability of services and their versions. If no endpoint is
-  specified, it will check the status of the default remote. If you
-  have logged in with an authentication token the validity of that token will be
-  checked.`
+  and reports the availability of services and their versions, and reports the
+  user's logged-in status (or lack thereof) on that endpoint. If no endpoint is
+  specified, it will check the status of the default remote. If
+  you have logged in with an authentication token the validity of that token
+  will be checked.`
 	RemoteStatusExample string = `
   $ apptainer remote status`
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/internal/app/apptainer/remote_get_login_password.go
+++ b/internal/app/apptainer/remote_get_login_password.go
@@ -22,7 +22,7 @@ import (
 // RemoteGetLoginPassword retrieves cli token from oci library shim
 func RemoteGetLoginPassword(config *scslibclient.Config) (string, error) {
 	client := http.Client{Timeout: 5 * time.Second}
-	path := "/v1/rbac/users/current"
+	path := userServicePath
 	endPoint := config.BaseURL + path
 
 	req, err := http.NewRequest(http.MethodGet, endPoint, nil)
@@ -44,23 +44,15 @@ func RemoteGetLoginPassword(config *scslibclient.Config) (string, error) {
 		return "", fmt.Errorf("status is not ok: %v", res.StatusCode)
 	}
 
-	var u oUser
-	err = json.NewDecoder(res.Body).Decode(&u)
+	var ud userData
+	err = json.NewDecoder(res.Body).Decode(&ud)
 	if err != nil {
 		return "", fmt.Errorf("error decoding json response: %v", err)
 	}
 
-	if u.OidcUserMeta.Secret == "" {
+	if ud.OidcMeta.Secret == "" {
 		return "", fmt.Errorf("user does not have cli token set")
 	}
 
-	return u.OidcUserMeta.Secret, nil
-}
-
-type oidcUserMeta struct {
-	Secret string `json:"secret"`
-}
-
-type oUser struct {
-	OidcUserMeta oidcUserMeta `json:"oidc_user_meta"`
+	return ud.OidcMeta.Secret, nil
 }

--- a/internal/app/apptainer/remote_get_login_password_test.go
+++ b/internal/app/apptainer/remote_get_login_password_test.go
@@ -84,7 +84,7 @@ func TestRemoteGetLoginPassword(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				isTokenValid := r.Header.Get("Authorization") == "Bearer "+validToken
 
-				if r.URL.Path == "/v1/rbac/users/current" && isTokenValid {
+				if r.URL.Path == userServicePath && isTokenValid {
 					w.Header().Set("Content-Type", "application/json")
 					fmt.Fprintln(w, tt.jsonResp)
 				} else {

--- a/internal/app/apptainer/user.go
+++ b/internal/app/apptainer/user.go
@@ -1,0 +1,25 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package apptainer
+
+const (
+	userServicePath = "/v1/rbac/users/current"
+)
+
+type userOidcMeta struct {
+	Secret string `json:"secret"`
+}
+
+type userData struct {
+	OidcMeta userOidcMeta `json:"oidc_user_meta"`
+	Email    string       `json:"email"`
+	Realname string       `json:"realname"`
+	Username string       `json:"username"`
+}

--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	remoteutil "github.com/apptainer/apptainer/internal/pkg/remote/util"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -103,10 +102,11 @@ func (config *Config) LibraryClientConfig(uri string) (*libClient.Config, error)
 	isDefault := uri == ""
 
 	libraryConfig := &libClient.Config{
-		BaseURL:    uri,
-		UserAgent:  useragent.Value(),
-		Logger:     (golog.Logger)(sylog.DebugLogger{}),
-		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		BaseURL:   uri,
+		UserAgent: useragent.Value(),
+		Logger:    (golog.Logger)(sylog.DebugLogger{}),
+		// TODO - probably should establish an appropriate client timeout here.
+		HTTPClient: &http.Client{},
 	}
 
 	if isDefault {

--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -11,7 +11,9 @@ package endpoint
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	remoteutil "github.com/apptainer/apptainer/internal/pkg/remote/util"
 	"github.com/apptainer/apptainer/pkg/sylog"
@@ -101,9 +103,10 @@ func (config *Config) LibraryClientConfig(uri string) (*libClient.Config, error)
 	isDefault := uri == ""
 
 	libraryConfig := &libClient.Config{
-		BaseURL:   uri,
-		UserAgent: useragent.Value(),
-		Logger:    (golog.Logger)(sylog.DebugLogger{}),
+		BaseURL:    uri,
+		UserAgent:  useragent.Value(),
+		Logger:     (golog.Logger)(sylog.DebugLogger{}),
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
 	}
 
 	if isDefault {


### PR DESCRIPTION
This pulls in sylabs PRs

- sylabs/singularity#1490
- sylabs/singularity#1521
 which fixed
- sylabs/singularity#946

The original PR descriptions were:
> In the `remote status` command, print the logged-in user's username & email address.

> The timeout added to the library http client in sylabs/singularity#1490 caused library pull failures.
> 
> There probably should be a sensibly large timeout here, to accommodate large pulls. The code path down through scs-library-client needs to be reviewed and considered to set an appropriate value.