### PR TITLE
Add new option --warn-unused-build-args to output warnings rather than fatals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - The `remote status` command will now print the username, realname, and email
   of the logged-in user, if available.
+- New option `--warn-unused-build-args` is provided to output warnings rather than
+  fatal errors for any unused variables given in --build-arg or --build-arg-file.
 
 ## Changes since last pre-release
 

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -28,31 +28,32 @@ import (
 )
 
 var buildArgs struct {
-	sections          []string
-	bindPaths         []string
-	mounts            []string
-	libraryURL        string
-	keyServerURL      string
-	webURL            string
-	encrypt           bool
-	fakeroot          bool
-	fixPerms          bool
-	isJSON            bool
-	noCleanUp         bool
-	noTest            bool
-	sandbox           bool
-	update            bool
-	nvidia            bool
-	nvccli            bool
-	rocm              bool
-	writableTmpfs     bool     // For test section only
-	userns            bool     // Enable user namespaces
-	ignoreSubuid      bool     // Ignore /etc/subuid entries (hidden)
-	ignoreFakerootCmd bool     // Ignore fakeroot command (hidden)
-	ignoreUserns      bool     // Ignore user namespace(hidden)
-	remote            bool     // Remote flag(hidden, only for helpful error message)
-	buildVarArgs      []string // Variables passed to build procedure.
-	buildVarArgFile   string   // Variables file passed to build procedure.
+	sections            []string
+	bindPaths           []string
+	mounts              []string
+	libraryURL          string
+	keyServerURL        string
+	webURL              string
+	encrypt             bool
+	fakeroot            bool
+	fixPerms            bool
+	isJSON              bool
+	noCleanUp           bool
+	noTest              bool
+	sandbox             bool
+	update              bool
+	nvidia              bool
+	nvccli              bool
+	rocm                bool
+	writableTmpfs       bool     // For test section only
+	userns              bool     // Enable user namespaces
+	ignoreSubuid        bool     // Ignore /etc/subuid entries (hidden)
+	ignoreFakerootCmd   bool     // Ignore fakeroot command (hidden)
+	ignoreUserns        bool     // Ignore user namespace(hidden)
+	remote              bool     // Remote flag(hidden, only for helpful error message)
+	buildVarArgs        []string // Variables passed to build procedure.
+	buildVarArgFile     string   // Variables file passed to build procedure.
+	buildArgsUnusedWarn bool     // Variables passed to build procedure to turn fatal error to warn.
 }
 
 // -s|--sandbox
@@ -303,6 +304,14 @@ var buildVarArgFileFlag = cmdline.Flag{
 	Usage:        "specifies a file containing variable=value lines to replace '{{ variable }}' with value in build definition files",
 }
 
+var buildArgUnusedWarn = cmdline.Flag{
+	ID:           "buildArgUnusedWarnFlag",
+	Value:        &buildArgs.buildArgsUnusedWarn,
+	DefaultValue: false,
+	Name:         "warn-unused-build-args",
+	Usage:        "shows warning instead of fatal message when build args are not exact matched",
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(buildCmd)
@@ -345,6 +354,7 @@ func init() {
 
 		cmdManager.RegisterFlagForCmd(&buildVarArgsFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildVarArgFileFlag, buildCmd)
+		cmdManager.RegisterFlagForCmd(&buildArgUnusedWarn, buildCmd)
 	})
 }
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -510,7 +510,13 @@ func processDefs(args []string, argFile string, defs []types.Definition) ([]type
 	diff := provideKeys.Difference(matchedKeys)
 	if !diff.Empty() {
 		vars := strings.Fields(strings.TrimPrefix(diff.String(), "HashSet"))
-		return defs, fmt.Errorf("while matching all variables, there are unmatched %s variables", strings.Join(vars, ""))
+
+		// All mismatched keys are in provided keys
+		if buildArgs.buildArgsUnusedWarn {
+			sylog.Warningf("Unused build args: %s", strings.Join(vars, " "))
+		} else {
+			return defs, fmt.Errorf("unused build args: %s. Use option --warn-unused-build-args to show a warning instead of a fatal message", strings.Join(vars, " "))
+		}
 	}
 
 	types.UpdateDefinitionRaw(defs)

--- a/cmd/internal/cli/build_linux_test.go
+++ b/cmd/internal/cli/build_linux_test.go
@@ -243,5 +243,20 @@ func TestProcessWithAdditionalArgs(t *testing.T) {
 	}
 
 	_, err = processDefs(args, "", d)
-	assert.ErrorContains(t, err, "there are unmatched ADDITION variables")
+	assert.ErrorContains(t, err, "unused build args: ADDITION. Use option --warn-unused-build-args to show a warning instead of a fatal message")
+}
+
+func TestProcessWithAdditionalArgsNoErrorReturn(t *testing.T) {
+	buildArgs.buildArgsUnusedWarn = true
+	d, err := build.MakeAllDefs("../../../e2e/testdata/build-template/single-stage-unit-test.def")
+	assert.NilError(t, err)
+
+	args := []string{
+		"OS_VER=1",
+		"AUTHOR=jason",
+		"ADDITION=1",
+	}
+
+	_, err = processDefs(args, "", d)
+	assert.NilError(t, err)
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

New option `--warn-unused-build-args` is provided to output warnings rather than fatals for any additional variables given in --build-arg or --build-arg-file.

### This fixes or addresses the following GitHub issues:

 - Fixes #1386 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
