### PR TITLE
Set custom configuration directory via environment variable, from sylabs 1687

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - `--cwd` is now the preferred form of the flag for setting the container's
   working directory, though `--pwd` is still supported for compatibility.
 
+### New Features & Functionality
+
+- Added ability to set a custom config directory via the new
+  `APPTAINER_CONFIGDIR` environment variable.
+
 ## Changes since last pre-release
 
 - Upgrade gocryptfs to version 2.4.0, removing the need for fusermount from

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,6 +58,7 @@
 - Kundan Kumar <iamkundankumar28@gmail.com>
 - Maciej Sieczka <msieczka@sieczka.org>
 - Marcelo Magallon <marcelo@sylabs.io>
+- Marco Rubin <marco.rubin@protonmail.com>
 - Mark Egan-Fuller <markeganfuller@googlemail.com>
 - Matthias Gerstner <matthias.gerstner@suse.com>
 - Matt Wiens <mwiens91@gmail.com>

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/apptainer/apptainer/docs"
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
-	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/pkg/cmdline"
+	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/spf13/cobra"
 )
@@ -109,7 +109,7 @@ var keyRemoveBothKeyFlag = cmdline.Flag{
 var keyLocalDirKeyFlag = cmdline.Flag{
 	ID:           "keyLocalDirKeyFlag",
 	Value:        &keyLocalDir,
-	DefaultValue: env.DefaultLocalKeyDirPath(),
+	DefaultValue: syfs.DefaultLocalKeyDirPath(),
 	Name:         "keysdir",
 	ShortHand:    "d",
 	Usage:        "set local keyring dir path, an alternative way is to set environment variable 'APPTAINER_KEYSDIR'",

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -12,10 +12,8 @@ package env
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
@@ -28,9 +26,6 @@ const (
 
 	// ApptainerEnvPrefix Apptainer environment variables recognized prefixes for passthru to container
 	ApptainerEnvPrefix = "APPTAINERENV_"
-
-	// defaultLocalKeyDirName represents the default local key storage folder name
-	defaultLocalKeyDirName = "keys"
 
 	// Legacy singularity prefix
 	LegacySingularityPrefix = "SINGULARITY_"
@@ -84,12 +79,4 @@ func GetenvLegacy(key, legacyKey string) string {
 // TrimApptainerKey returns the key without APPTAINER_ prefix.
 func TrimApptainerKey(key string) string {
 	return strings.TrimPrefix(key, ApptainerPrefixes[0])
-}
-
-func DefaultLocalKeyDirPath() string {
-	// read this as: look for APPTAINER_KEYSDIR and/or SINGULARITY_SYPGPDIR
-	if dir := GetenvLegacy("KEYSDIR", "SYPGPDIR"); dir != "" {
-		return dir
-	}
-	return filepath.Join(syfs.ConfigDir(), defaultLocalKeyDirName)
 }

--- a/pkg/sypgp/sypgp.go
+++ b/pkg/sypgp/sypgp.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
-	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/internal/pkg/util/interactive"
 	"github.com/apptainer/apptainer/pkg/syfs"
@@ -118,7 +117,7 @@ func NewHandle(path string, opts ...HandleOpt) *Handle {
 		if newHandle.global {
 			panic("global public keyring requires a path")
 		}
-		newHandle.path = env.DefaultLocalKeyDirPath()
+		newHandle.path = syfs.DefaultLocalKeyDirPath()
 	}
 
 	return newHandle


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1687

The original PR description was:
> This PR adds a new check for the configuration directory via the `SINGULARITY_CONFIGDIR` environment variable, which is checked before the current user's home directory in `sysfs.configDir()`. This is useful if one does not want `.singularity` in their home directory, and can be used to enforce the XDG config directory of the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) defining `SINGULARITY_CONFIGDIR=$XDG_CONFIG_HOME/singularity`. This environment variable complements `SINGULARITY_CACHEDIR`, which can be used to do the same for the XDG cache directory with `SINGULARITY_CACHEDIR=$XDG_CACHE_HOME/singularity`.