### PR TITLE
Use the image driver overlay even when the overlay is not writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   the fuse package.
 - Fix seccomp filters to allow mknod/mknodat syscalls to create pipe/socket
   and character devices with device number 0 for fakeroot builds.
+- Use fuse-overlayfs instead of the kernel overlayfs when a lower dir is
+  a FUSE filesystem, even when the overlay layer is not writable.  That
+  always used to be done when the overlay layer was writable, but this
+  fixes a problem seen when squashfuse (which is read-only) was used for
+  the overlay layer.
 
 ## v1.2.0-rc.1 - \[2023-06-07\]
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -666,29 +666,33 @@ mount:
 	if !bindMount && !remount && mnt.Type == "overlay" && tag == mount.LayerTag &&
 		imageDriver != nil && imageDriver.Features()&image.OverlayFeature != 0 {
 		lowerdirs := ""
-		hasUpper := false
 		for _, opt := range opts {
 			if strings.HasPrefix(opt, "lowerdir=") {
 				lowerdirs = opt[len("lowerdir="):]
-			} else if strings.HasPrefix(opt, "upperdir=") {
-				hasUpper = true
 			}
 		}
-		if hasUpper {
-			// This is a writable overlay and there is an overlay
-			//  image driver.  When the lower layer is of type FUSE
-			//  we want to skip trying the kernel overlayfs. That's
-			//  because sometimes the mount succeeds but the
-			//  operation doesn't work, due to a kernel regression
-			//  related to fuse under overlayfs that first showed up
-			//  in kernel version 5.15, as discussed at
-			//   https://lore.kernel.org/lkml/CAJfpegvaUyCUkucNwP0P419hC8v78PEM25pW5mBho94HRCgO3Q@mail.gmail.com/
+		// This is an overlay and there is an overlay image
+		//  driver.  When a lower layer is of type FUSE
+		//  we want to skip trying the kernel overlayfs. That's
+		//  because sometimes the mount succeeds but the
+		//  operation doesn't work, due to a kernel regression
+		//  related to fuse under overlayfs that first showed up
+		//  in kernel version 5.15, as discussed at
+		//   https://lore.kernel.org/lkml/CAJfpegvaUyCUkucNwP0P419hC8v78PEM25pW5mBho94HRCgO3Q@mail.gmail.com/
+		// At first we checked only for a writable overlay
+		//  (which is specified as an "upperdir"), but there
+		//  were also problems seen when the overlay was
+		//  squashfuse, so we changed this to also check
+		//  non-writable overlays.  See
+		//  https://github.com/apptainer/apptainer/issues/1459
+		//  Unfortunately this also affects read-only fuse2fs
+		//  overlays even though no problems had been seen with
+		//  those using the kernel overlayfs.
 
-			for _, ldir := range strings.Split(lowerdirs, ":") {
-				err = fsoverlay.CheckFuse(ldir)
-				if err != nil {
-					break
-				}
+		for _, ldir := range strings.Split(lowerdirs, ":") {
+			err = fsoverlay.CheckFuse(ldir)
+			if err != nil {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
This changes the behavior to use the image driver overlay (i.e. fuse-overlayfs) if one of the lower directories is of type FUSE, even when the overlay layer is not writable.

- Fixes #1459 