### PR TITLE
Include squashfuse patch that corrects xattr types, especially affecting images built on SELinux (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   always used to be done when the overlay layer was writable, but this
   fixes a problem seen when squashfuse (which is read-only) was used for
   the overlay layer.
+- Add another patch to the included squashfuse_ll to prevent it from
+  triggering 'No data available' errors on overlays of SIF files that
+  were built on machines with SELinux enabled.
 
 ### New Features & Functionality
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -199,7 +199,7 @@ To download the source code do this:
 
 ```sh
 SQUASHFUSEVERSION=0.1.105
-SQUASHFUSEPRS="70 77 81"
+SQUASHFUSEPRS="70 77 81 83"
 curl -L -O https://github.com/vasi/squashfuse/archive/$SQUASHFUSEVERSION/squashfuse-$SQUASHFUSEVERSION.tar.gz
 for PR in $SQUASHFUSEPRS; do
     curl -L -O https://github.com/vasi/squashfuse/pull/$PR.patch

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -65,6 +65,7 @@ Source11: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squas
 Patch10: https://github.com/vasi/squashfuse/pull/70.patch
 Patch11: https://github.com/vasi/squashfuse/pull/77.patch
 Patch12: https://github.com/vasi/squashfuse/pull/81.patch
+Patch13: https://github.com/vasi/squashfuse/pull/83.patch
 %endif
 
 # This Conflicts is in case someone tries to install the main apptainer
@@ -153,6 +154,7 @@ Provides the optional setuid-root portion of Apptainer.
 %patch -P 10 -p1
 %patch -P 11 -p1
 %patch -P 12 -p1
+%patch -P 13 -p1
 %setup -n %{name}-%{package_version}
 %else
 %autosetup -n %{name}-%{package_version}


### PR DESCRIPTION
This cherry-picks #1478 to the release-1.2 branch.