### PR TITLE
Restore using original user home directory under unshare -r

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Add another patch to the included squashfuse_ll to prevent it from
   triggering 'No data available' errors on overlays of SIF files that
   were built on machines with SELinux enabled.
+- Fix a minor regression in 1.2.0-rc.1 where starting up under `unshare -r`
+  stopped mapping the user's home directory to the fake root's home directory.
 
 ## v1.2.0-rc.1 - \[2023-06-07\]
 

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1494,7 +1494,10 @@ func (e *EngineOperations) loadImage(path string, writable bool, userNS bool) (*
 func (e *EngineOperations) setUserInfo(useTargetIDs bool) {
 	var gids []int
 
-	pw, err := user.Current()
+	// Use CurrentOriginal() here instead of Current() because that
+	// works better for mapping in the user's home directory when
+	// running in a root-mapped unprivileged user namespace (unshare -r)
+	pw, err := user.CurrentOriginal()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Use the `user.CurrentOriginal()` instead of `user.Current()` function to find the user's password file entry.  That works better for accessing the user's original home directory when running under unshare -r.  This is the fix used in sylabs/singularity#1756, fixing a minor regression introduced in #1368.

- Fixes #1450