### PR TITLE
Update the fatal error message in starter.c

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -1398,10 +1398,10 @@ __attribute__((constructor)) static void init(void) {
      * the host libc library used by this starter binary.
      */
     if (getpwuid(0) == NULL) {
-        fatalf("Failed to retrieve root user information: %s\n", strerror(errno));
+        fatalf("Failed to retrieve root user information: %s\n", errno == 0 ? "root user not found" : strerror(errno));
     }
     if (getgrgid(0) == NULL) {
-        fatalf("Failed to retrieve root group information: %s\n", strerror(errno));
+        fatalf("Failed to retrieve root group information: %s\n", errno == 0 ? "root group not found" : strerror(errno));
     }
 
     userns = user_namespace_init(&sconfig->container.namespace);
@@ -1463,7 +1463,7 @@ __attribute__((constructor)) static void init(void) {
 
             /* wait parent write user namespace mappings */
             if ( wait_event(master_socket[1]) < 0 ) {
-                fatalf("Error while waiting event for user namespace mappings: %s\n", strerror(errno));
+                fatalf("Error while waiting event for user namespace mappings: %s\n", errno == 0 ? "no event received" : strerror(errno));
             }
         }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

when errno = 0 (strerror(errno) will show SUCCESS), it'll add custom fatal message. otherwise use the errno. 


### This fixes or addresses the following GitHub issues:

 - Fixes #1171 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
