### PR TITLE
Restore using original user home directory under unshare -r (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Add another patch to the included squashfuse_ll to prevent it from
   triggering 'No data available' errors on overlays of SIF files that
   were built on machines with SELinux enabled.
+- Fix a minor regression in 1.2.0-rc.1 where starting up under `unshare -r`
+  stopped mapping the user's home directory to the fake root's home directory.
 
 ### New Features & Functionality
 

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1494,7 +1494,10 @@ func (e *EngineOperations) loadImage(path string, writable bool, userNS bool) (*
 func (e *EngineOperations) setUserInfo(useTargetIDs bool) {
 	var gids []int
 
-	pw, err := user.Current()
+	// Use CurrentOriginal() here instead of Current() because that
+	// works better for mapping in the user's home directory when
+	// running in a root-mapped unprivileged user namespace (unshare -r)
+	pw, err := user.CurrentOriginal()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This cherry-picks #1481 to the release-1.2 branch.