### PR TITLE
Update bash completion build dir, from sylabs 1790

### DIFF
--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -42,8 +42,8 @@ ALL += $(apptainer)
 
 
 # bash_completion files
-bash_completion1 :=  $(BUILDDIR)/etc/bash_completion.d/apptainer
-bash_completion2 :=  $(BUILDDIR)/etc/bash_completion.d/singularity
+bash_completion1 :=  $(BUILDDIR)/bash-completion/completions/apptainer
+bash_completion2 :=  $(BUILDDIR)/bash-completion/completions/singularity
 bash_completions := $(bash_completion1) $(bash_completion2)
 $(bash_completions): $(apptainer_build_config)
 	@echo " GEN" $@


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1790
 which fixed
- sylabs/singularity#1137

The original PR description was:
> The appropriate location for bash completion files is now `share/bash-completion/completions/` - verified against the RPM and Deb packaging guides.
> 
> Also remove unnecessary `.dirs` entries in the Debian packaging. Our `make install` creates almost everything, and there were some outdated directories in `.dirs`.