### PR TITLE
Fix 'enable overlay = driver' to always force using image driver (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   always used to be done when the overlay layer was writable, but this
   fixes a problem seen when squashfuse (which is read-only) was used for
   the overlay layer.
+- Fix the `enable overlay = driver` configuration option to always use
+  the overlay image driver (that is, fuse-overlayfs) even when the kernel
+  overlayfs is usable.
 - Add another patch to the included squashfuse_ll to prevent it from
   triggering 'No data available' errors on overlays of SIF files that
   were built on machines with SELinux enabled.

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -666,34 +666,40 @@ mount:
 	err = nil
 	if !bindMount && !remount && mnt.Type == "overlay" && tag == mount.LayerTag &&
 		imageDriver != nil && imageDriver.Features()&image.OverlayFeature != 0 {
-		lowerdirs := ""
-		for _, opt := range opts {
-			if strings.HasPrefix(opt, "lowerdir=") {
-				lowerdirs = opt[len("lowerdir="):]
+		if c.engine.EngineConfig.File.EnableOverlay == "driver" {
+			// Set an error to switch to the overlay image driver
+			// below during the mount error check
+			err = fmt.Errorf("overlay image driver selected by configuration")
+		} else {
+			lowerdirs := ""
+			for _, opt := range opts {
+				if strings.HasPrefix(opt, "lowerdir=") {
+					lowerdirs = opt[len("lowerdir="):]
+				}
 			}
-		}
-		// This is an overlay and there is an overlay image
-		//  driver.  When a lower layer is of type FUSE
-		//  we want to skip trying the kernel overlayfs. That's
-		//  because sometimes the mount succeeds but the
-		//  operation doesn't work, due to a kernel regression
-		//  related to fuse under overlayfs that first showed up
-		//  in kernel version 5.15, as discussed at
-		//   https://lore.kernel.org/lkml/CAJfpegvaUyCUkucNwP0P419hC8v78PEM25pW5mBho94HRCgO3Q@mail.gmail.com/
-		// At first we checked only for a writable overlay
-		//  (which is specified as an "upperdir"), but there
-		//  were also problems seen when the overlay was
-		//  squashfuse, so we changed this to also check
-		//  non-writable overlays.  See
-		//  https://github.com/apptainer/apptainer/issues/1459
-		//  Unfortunately this also affects read-only fuse2fs
-		//  overlays even though no problems had been seen with
-		//  those using the kernel overlayfs.
+			// This is an overlay and there is an overlay image
+			//  driver.  When a lower layer is of type FUSE
+			//  we want to skip trying the kernel overlayfs. That's
+			//  because sometimes the mount succeeds but the
+			//  operation doesn't work, due to a kernel regression
+			//  related to fuse under overlayfs that first showed up
+			//  in kernel version 5.15, as discussed at
+			//   https://lore.kernel.org/lkml/CAJfpegvaUyCUkucNwP0P419hC8v78PEM25pW5mBho94HRCgO3Q@mail.gmail.com/
+			// At first we checked only for a writable overlay
+			//  (which is specified as an "upperdir"), but there
+			//  were also problems seen when the overlay was
+			//  squashfuse, so we changed this to also check
+			//  non-writable overlays.  See
+			//  https://github.com/apptainer/apptainer/issues/1459
+			//  Unfortunately this also affects read-only fuse2fs
+			//  overlays even though no problems had been seen with
+			//  those using the kernel overlayfs.
 
-		for _, ldir := range strings.Split(lowerdirs, ":") {
-			err = fsoverlay.CheckFuse(ldir)
-			if err != nil {
-				break
+			for _, ldir := range strings.Split(lowerdirs, ":") {
+				err = fsoverlay.CheckFuse(ldir)
+				if err != nil {
+					break
+				}
 			}
 		}
 	}

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -498,9 +498,11 @@ shared loop devices = {{ if eq .SharedLoopDevices true }}yes{{ else }}no{{ end }
 # IMAGE DRIVER: [STRING]
 # DEFAULT: Undefined
 # This option specifies the name of an image driver provided by a plugin that
-# will be used to handle image mounts. If the 'enable overlay' option is set
-# to 'driver' the driver name specified here will also be used to handle
-# overlay mounts.
+# will be used to handle image mounts. This will override the builtin image
+# driver which provides unprivileged image mounts for squashfs, extfs, 
+# overlayfs, and gocryptfs.  The overlayfs image driver will only be used
+# if the kernel overlayfs is not usable, but if the 'enable overlay' option
+# above is set to 'driver', the image driver will always be used for overlay.
 # If the driver name specified has not been registered via a plugin installation
 # the run-time will abort.
 image driver = {{ .ImageDriver }}


### PR DESCRIPTION
This cherry-picks #1494 to the release-1.2 branch.