### PR TITLE
Add ability to change log level via environment variables & Update the fatal error message in starter.c (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   were built on machines with SELinux enabled.
 - Fix a minor regression in 1.2.0-rc.1 where starting up under `unshare -r`
   stopped mapping the user's home directory to the fake root's home directory.
+- Added ability to change log level through environment variables,
+  `APPTAINER_SILENT`, `APPTAINER_QUIET`, and `APPTAINER_VERBOSE`. Added
+  `APPTAINER_NOCOLOR` environment variable for `--nocolor` option.
 
 ### New Features & Functionality
 

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -95,6 +95,7 @@ var singNoColorFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "nocolor",
 	Usage:        "print without color output (default False)",
+	EnvKeys:      []string{"NOCOLOR"},
 }
 
 // -s|--silent
@@ -105,6 +106,7 @@ var singSilentFlag = cmdline.Flag{
 	Name:         "silent",
 	ShortHand:    "s",
 	Usage:        "only print errors",
+	EnvKeys:      []string{"SILENT"},
 }
 
 // -q|--quiet
@@ -115,6 +117,7 @@ var singQuietFlag = cmdline.Flag{
 	Name:         "quiet",
 	ShortHand:    "q",
 	Usage:        "suppress normal output",
+	EnvKeys:      []string{"QUIET"},
 }
 
 // -v|--verbose
@@ -125,6 +128,7 @@ var singVerboseFlag = cmdline.Flag{
 	Name:         "verbose",
 	ShortHand:    "v",
 	Usage:        "print additional information",
+	EnvKeys:      []string{"VERBOSE"},
 }
 
 // --docker-username
@@ -468,6 +472,7 @@ func migrateGPGPrivate(sypgpDir, legacySypgpDir string) {
 }
 
 func persistentPreRun(cmd *cobra.Command, args []string) error {
+	setSylogMessageLevel()
 	sylog.Debugf("Apptainer version: %s", buildcfg.PACKAGE_VERSION)
 
 	if cmd.CalledAs() == "confgen" {

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -1398,10 +1398,10 @@ __attribute__((constructor)) static void init(void) {
      * the host libc library used by this starter binary.
      */
     if (getpwuid(0) == NULL) {
-        fatalf("Failed to retrieve root user information: %s\n", strerror(errno));
+        fatalf("Failed to retrieve root user information: %s\n", errno == 0 ? "root user not found" : strerror(errno));
     }
     if (getgrgid(0) == NULL) {
-        fatalf("Failed to retrieve root group information: %s\n", strerror(errno));
+        fatalf("Failed to retrieve root group information: %s\n", errno == 0 ? "root group not found" : strerror(errno));
     }
 
     userns = user_namespace_init(&sconfig->container.namespace);
@@ -1463,7 +1463,7 @@ __attribute__((constructor)) static void init(void) {
 
             /* wait parent write user namespace mappings */
             if ( wait_event(master_socket[1]) < 0 ) {
-                fatalf("Error while waiting event for user namespace mappings: %s\n", strerror(errno));
+                fatalf("Error while waiting event for user namespace mappings: %s\n", errno == 0 ? "no event received" : strerror(errno));
             }
         }
 

--- a/pkg/sylog/sylog_dummy.go
+++ b/pkg/sylog/sylog_dummy.go
@@ -16,6 +16,20 @@ import (
 	"os"
 )
 
+var (
+	noColorLevel messageLevel = 90
+	loggerLevel               = InfoLevel
+)
+
+func getLoggerLevel() messageLevel {
+	if loggerLevel <= -noColorLevel {
+		return loggerLevel + noColorLevel
+	} else if loggerLevel >= noColorLevel {
+		return loggerLevel - noColorLevel
+	}
+	return loggerLevel
+}
+
 // Fatalf is a dummy function exiting with code 255. This
 // function must not be used in public packages.
 func Fatalf(format string, a ...interface{}) {
@@ -38,14 +52,24 @@ func Verbosef(format string, a ...interface{}) {}
 func Debugf(format string, a ...interface{}) {}
 
 // SetLevel is a dummy function doing nothing.
-func SetLevel(l int, color bool) {}
+func SetLevel(l int, color bool) {
+	// Here we do not check term.IsTerminal to explicitly control the color
+	loggerLevel = messageLevel(l)
+	if !color {
+		if loggerLevel >= InfoLevel {
+			loggerLevel = loggerLevel + noColorLevel
+		} else if loggerLevel <= LogLevel {
+			loggerLevel = loggerLevel - noColorLevel
+		}
+	}
+}
 
 // DisableColor for the logger
 func DisableColor() {}
 
 // GetLevel is a dummy function returning lowest message level.
 func GetLevel() int {
-	return int(-1)
+	return int(getLoggerLevel())
 }
 
 // GetEnvVar is a dummy function returning environment variable

--- a/pkg/sylog/sylog_dummy_test.go
+++ b/pkg/sylog/sylog_dummy_test.go
@@ -25,8 +25,8 @@ func TestGetLevel(t *testing.T) {
 	defer test.ResetPrivilege(t)
 
 	l := GetLevel()
-	if l != -1 {
-		t.Fatalf("%d was returned instead of -1", l)
+	if l != 1 {
+		t.Fatalf("%d was returned instead of 1", l)
 	}
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cherry picks these PRs to the 1.2 branch:
 - #1472
 - #1483

### This fixes or addresses the following GitHub issues:

 - Fixes #1171 
 - Fixes #1446 

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
