### PR TITLE
fix rel. path --workdir with --scratch, add native e2e tests, from sylabs 1694

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Added ability to change log level through environment variables,
   `APPTAINER_SILENT`, `APPTAINER_QUIET`, and `APPTAINER_VERBOSE`. Added
   `APPTAINER_NOCOLOR` environment variable for `--nocolor` option.
+- Fix interaction between `--workdir` when given relative path and `--scratch`.
 
 ## v1.2.0-rc.1 - \[2023-06-07\]
 

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2819,6 +2819,48 @@ func (c actionTests) actionFakerootHome(t *testing.T) {
 	}
 }
 
+// Make sure --workdir and --scratch work together nicely even when workdir is a
+// relative path. Test needs to be run in non-parallel mode, because it changes
+// the current working directory of the host.
+func (c actionTests) relWorkdirScratch(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	testdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "persistent-overlay-", "")
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup(t)
+		}
+	})
+
+	const subdirName string = "mysubdir"
+	if err := os.Mkdir(filepath.Join(testdir, subdirName), 0o777); err != nil {
+		t.Fatalf("could not create subdirectory %q in %q: %s", subdirName, testdir, err)
+	}
+
+	// Change current working directory, with deferred undoing of change.
+	prevCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("could not get current working directory: %s", err)
+	}
+	defer os.Chdir(prevCwd)
+	if err = os.Chdir(testdir); err != nil {
+		t.Fatalf("could not change cwd to %q: %s", testdir, err)
+	}
+
+	profiles := []e2e.Profile{e2e.UserProfile, e2e.RootProfile, e2e.FakerootProfile, e2e.UserNamespaceProfile}
+
+	for _, p := range profiles {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(p.String()),
+			e2e.WithProfile(p),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs("--contain", "--workdir", "./"+subdirName, "--scratch", "/myscratch", c.env.ImagePath, "true"),
+			e2e.ExpectExit(0),
+		)
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := actionTests{
@@ -2866,5 +2908,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"umask":                     np(c.actionUmask),         // test umask propagation
 		"invalidRemote":             np(c.invalidRemote),       // GHSA-5mv9-q7fq-9394
 		"fakeroot home":             c.actionFakerootHome,      // test home dir in fakeroot
+		"relWorkdirScratch":         np(c.relWorkdirScratch),   // test relative --workdir with --scratch
 	}
 }

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -2828,7 +2828,7 @@ func (c actionTests) relWorkdirScratch(t *testing.T) {
 	testdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "persistent-overlay-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			cleanup(t)
+			e2e.Privileged(cleanup)
 		}
 	})
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2035,9 +2035,12 @@ func (c *container) addScratchMount(system *mount.System) error {
 
 	workdir := c.engine.EngineConfig.GetWorkdir()
 	hasWorkdir := workdir != ""
-
+	var err error
 	if hasWorkdir {
-		workdir = filepath.Clean(workdir)
+		workdir, err = filepath.Abs(filepath.Clean(workdir))
+		if err != nil {
+			sylog.Warningf("Can't determine absolute path of workdir %s", workdir)
+		}
 		sourceDir := filepath.Join(workdir, scratchSessionDir)
 		if err := fs.MkdirAll(sourceDir, 0o750); err != nil {
 			return fmt.Errorf("could not create scratch working directory %s: %s", sourceDir, err)

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -1963,7 +1963,7 @@ func (c *container) addTmpMount(system *mount.System) error {
 
 			workdir, err := filepath.Abs(filepath.Clean(workdir))
 			if err != nil {
-				sylog.Warningf("Can't determine absolute path of workdir %s", workdir)
+				return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 			}
 
 			tmpSource = filepath.Join(workdir, tmpSource)
@@ -2039,7 +2039,7 @@ func (c *container) addScratchMount(system *mount.System) error {
 	if hasWorkdir {
 		workdir, err = filepath.Abs(filepath.Clean(workdir))
 		if err != nil {
-			sylog.Warningf("Can't determine absolute path of workdir %s", workdir)
+			return fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
 		}
 		sourceDir := filepath.Join(workdir, scratchSessionDir)
 		if err := fs.MkdirAll(sourceDir, 0o750); err != nil {


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1694
 which fixed
- sylabs/singularity#1693

The original PR description was:
> Fixes a bug where `--scratch` failed when used in conjunction with `--workdir` if the latter was given a relative (rather than absolute) path.
> 
> Also changes the behavior of `--workdir` code so that an error (rather than a warning) is generated if specified workdir cannot be converted to an absolute path.
> 
> Lastly, adds e2e tests for this behavior (`--scratch` in conjunction with relative `--workdir`), in both native and OCI modes.