### PR TITLE
Fix gocryptfs build procedure for deb package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix memory usage calculation during apptainer compilation on RaspberryPi.
 - Fix misleading error when an overlay is requested by the root user while the
   overlay kernel module is not loaded.
+- Fix gocryptfs build procedures for deb package.
 
 ## v1.1.9 - \[2023-06-07\]
 

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -92,7 +92,9 @@ override_dh_auto_configure:
 	    set -x; \
 	    tar -C debian -xf $$GOCRYPTFSTGZ; \
 	    cd $${GOCRYPTFSTGZ%.tar.gz}; \
-	    PATH=$(GOROOT)/bin:$$PATH GOCACHE=$(GOCACHE) ./build-without-openssl.bash; \
+	    export GOCACHE=$(GOCACHE); \
+	    export GOPATH=$(GOROOT)/bin; \
+	    PATH=$(GOROOT)/bin:$$PATH ./build-without-openssl.bash; \
 	  fi
 ifneq ($(NEW_VERSION),)
 	$(warning "Setting new version in debian changelog: $(NEW_VERSION)")


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix gocryptfs build procedure for deb package.
export `GOCACHE` and `GOPATH`
For propagating those variables to nested bash scripts

### This fixes or addresses the following GitHub issues:

 - Fixes #1496 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
