### PR TITLE
Update to squashfuse 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Upgrade gocryptfs to version 2.4.0, removing the need for fusermount from
   the fuse package.
+- Upgraded squashfuse_ll to version 0.2.0, removing the need for applying
+  patches during compilation.
 - Fix seccomp filters to allow mknod/mknodat syscalls to create pipe/socket
   and character devices with device number 0 for fakeroot builds.
 - Use fuse-overlayfs instead of the kernel overlayfs when a lower dir is

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,14 +174,10 @@ See the output of `./mconfig -h` for available options.
 
 If you want to have the best performance for unprivileged mounts of SIF
 files for multi-core applications, you can optionally install an improved
-performance version of `squashfuse_ll`.
-
-As of this writing there is a patch pending to the squashfuse project to
-add multithreading support that significantly improves performance for
-applications that access a lot of small files from many cores at once.
-There's also another `squashfuse_ll` patch for supporting options to make
-files appear to be owned by the user
-(the same options that exist in `squashfuse`).
+performance version of `squashfuse_ll`.  That version has been released as
+version 0.2.0 but as of this writing it is not yet very widely distributed,
+and it does not have multithreading enabled in the default compilation options.
+Instructions for installing it from source follow here.
 
 First, make sure that additional required packages are installed.  On Debian:
 
@@ -198,12 +194,8 @@ yum install -y autoconf automake libtool pkgconfig fuse3-devel zlib-devel
 To download the source code do this:
 
 ```sh
-SQUASHFUSEVERSION=0.1.105
-SQUASHFUSEPRS="70 77 81 83"
+SQUASHFUSEVERSION=0.2.0
 curl -L -O https://github.com/vasi/squashfuse/archive/$SQUASHFUSEVERSION/squashfuse-$SQUASHFUSEVERSION.tar.gz
-for PR in $SQUASHFUSEPRS; do
-    curl -L -O https://github.com/vasi/squashfuse/pull/$PR.patch
-done
 ```
 
 Then to compile and install do this:
@@ -211,9 +203,6 @@ Then to compile and install do this:
 ```sh
 tar xzf squashfuse-$SQUASHFUSEVERSION.tar.gz
 cd squashfuse-$SQUASHFUSEVERSION
-for PR in $SQUASHFUSEPRS; do
-    patch -p1 <../$PR.patch
-done
 ./autogen.sh
 CFLAGS=-std=c99 ./configure --enable-multithreading
 make squashfuse_ll

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -42,7 +42,7 @@ wget -O debian/$TARBALL https://dl.google.com/go/$TARBALL
 
 Finally, install the additional dependencies in the section on the
 [improved performance squashfuse](../../INSTALL.md##installing-improved-performance-squashfuse_ll)
-and download the additional files listed there into the debian directory.
+and download the additional file listed there into the debian directory.
 Also install the additional file from the section on
 [installing gocryptfs)(../../INSTALL.md##installing-gocryptfs)
 into the debian directory.

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -69,9 +69,6 @@ override_dh_auto_configure:
 	    set -x; \
 	    tar -C debian -xf $$SQUASHFUSETGZ; \
 	    cd $${SQUASHFUSETGZ%.tar.gz}; \
-	    for PATCH in ../*.patch; do \
-	      patch -p1 <$$PATCH; \
-	    done; \
 	    ./autogen.sh; \
 	    FLAGS=-std=c99 ./configure --enable-multithreading; \
 	    make squashfuse_ll; \

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -36,7 +36,7 @@
 # Uncomment this to include gocryptfs
 # %%global gocryptfs_version 2.4.0
 # Uncomment this to include a multithreaded version of squashfuse_ll
-# %%global squashfuse_version 0.1.105
+# %%global squashfuse_version 0.2.0
 
 # The last singularity version number in EPEL/Fedora
 %global last_singularity_version 3.8.7-3
@@ -62,10 +62,6 @@ Source10: https://github.com/rfjakob/gocryptfs/archive/v%{gocryptfs_version}/goc
 %endif
 %if "%{?squashfuse_version}" != ""
 Source11: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squashfuse-%{squashfuse_version}.tar.gz
-Patch10: https://github.com/vasi/squashfuse/pull/70.patch
-Patch11: https://github.com/vasi/squashfuse/pull/77.patch
-Patch12: https://github.com/vasi/squashfuse/pull/81.patch
-Patch13: https://github.com/vasi/squashfuse/pull/83.patch
 %endif
 
 # This Conflicts is in case someone tries to install the main apptainer
@@ -151,10 +147,6 @@ Provides the optional setuid-root portion of Apptainer.
 # the default directory for other steps is where the %%prep section ends
 # so do main package last
 %setup -b 11 -n squashfuse-%{squashfuse_version}
-%patch -P 10 -p1
-%patch -P 11 -p1
-%patch -P 12 -p1
-%patch -P 13 -p1
 %setup -n %{name}-%{package_version}
 %else
 %autosetup -n %{name}-%{package_version}

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -66,10 +66,9 @@ su testuser -c '
     fi
   fi
   go version
-  # download additional source & patch urls listed in rpm
+  # download additional source urls listed in rpm
   SPEC=dist/rpm/apptainer.spec.in
   DOWNLOADURL="$(sed -n "s/^Source[1-9][0-9]*: //p" $SPEC)"
-  DOWNLOADURL="$DOWNLOADURL $(sed -n "s/^Patch[1-9][0-9]*: //p" $SPEC)"
   SUBS="$(sed -n "s/.*%global //p" $SPEC)"
   for URL in $DOWNLOADURL; do
       if [[ "$URL" != http* ]]; then

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -44,9 +44,8 @@ su testuser -c '
   # enable the multithreading squashfuse and gocryptfs
   sed -i "s/^# %\(%global squashfuse_version\)/\1/" apptainer.spec
   sed -i "s/^# %\(%global gocryptfs_version\)/\1/" apptainer.spec
-  # download any additional source & patch urls
+  # download any additional source urls
   DOWNLOADURL="$(sed -n "s/^Source[1-9][0-9]*: //p" apptainer.spec)"
-  DOWNLOADURL="$DOWNLOADURL $(sed -n "s/^Patch[1-9][0-9]*: //p" apptainer.spec)"
   SUBS="$(sed -n "s/^%global //p" apptainer.spec)"
   DOWNLOADEDFILES=""
   for URL in $DOWNLOADURL; do


### PR DESCRIPTION
This updates the squashfuse version to 0.2.0.  It also removes references to applying patches since I don't anticipate needing those again.

- Fixes #1504 