### PR TITLE
Add discussion of TMPDIR and APPTAINER_TMPDIR in build help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Upgrade gocryptfs to version 2.4.0, removing the need for fusermount from
   the fuse package.
 - Upgraded squashfuse_ll to version 0.2.0, removing the need for applying
-  patches during compilation.
+  patches during compilation.  The new version includes a fix to prevent
+  it from triggering 'No data available errors' on overlays of SIF files that
+  were built on machines with SELinux enabled.
+- Add discussion of using TMPDIR or APPTAINER_TMPDIR in the build help.
 - Fix seccomp filters to allow mknod/mknodat syscalls to create pipe/socket
   and character devices with device number 0 for fakeroot builds.
 - Use fuse-overlayfs instead of the kernel overlayfs when a lower dir is
@@ -47,9 +50,6 @@ For older changes see the [archived Singularity change log](https://github.com/a
   always used to be done when the overlay layer was writable, but this
   fixes a problem seen when squashfuse (which is read-only) was used for
   the overlay layer.
-- Add another patch to the included squashfuse_ll to prevent it from
-  triggering 'No data available' errors on overlays of SIF files that
-  were built on machines with SELinux enabled.
 - Fix a minor regression in 1.2.0-rc.1 where starting up under `unshare -r`
   stopped mapping the user's home directory to the fake root's home directory.
 - Added ability to change log level through environment variables,

--- a/docs/content.go
+++ b/docs/content.go
@@ -65,7 +65,18 @@ Enterprise Performance Computing (EPC)`
       library://  an image library (no default)
       docker://   a Docker/OCI registry (default Docker Hub)
       shub://     an Apptainer registry (default Singularity Hub)
-      oras://     an OCI registry that holds SIF files using ORAS`
+      oras://     an OCI registry that holds SIF files using ORAS
+
+  Temporary files:
+  
+  The location used for temporary directories defaults to '/tmp' but
+  can be overridden by the TMPDIR environment variable, and that can be
+  overridden by the APPTAINER_TMPDIR environment variable.  The
+  temporary directory used during a build must be on a filesystem that
+  has enough space to hold the entire container image, uncompressed,
+  including any temporary files that are created and later removed
+  during the build. You may need to set APPTAINER_TMPDIR or TMPDIR when
+  building a large container on a system that has a small /tmp filesystem.`
 
 	BuildExample string = `
 


### PR DESCRIPTION
This imports some of the discussion of TMPDIR and APPTAINER_TMPDIR from the online documentation into the build help.

- Fixes #1380