### PR TITLE
Add 32-bit architectures compatiblity mode for 64-bit architectures to fakeroot seccomp filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   on a local unsigned SIF file.
 - Set real UID to zero when escalating privileges for CNI plugins to fix
   issue appeared with RHEL 9.X.
+- Add 32-bit architectures compatiblity mode for 64-bit architectures to
+  fakeroot seccomp filter
 
 ## v1.2.0-rc.1 - \[2023-06-07\]
 


### PR DESCRIPTION
### This fixes or addresses the following GitHub issues:

 - Fixes #809 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
