### PR TITLE
Set real UID to zero when escalating privileges for CNI plugins to fix issue appeared with RHEL 9.X (release 1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix interaction between `--workdir` when given relative path and `--scratch`.
 - Remove the warning about a missing signature when building an image based
   on a local unsigned SIF file.
+- Set real UID to zero when escalating privileges for CNI plugins to fix
+  issue appeared with RHEL 9.X.
 
 ### New Features & Functionality
 

--- a/internal/pkg/util/priv/priv_linux.go
+++ b/internal/pkg/util/priv/priv_linux.go
@@ -21,7 +21,7 @@ import (
 func Escalate() error {
 	runtime.LockOSThread()
 	uid := os.Getuid()
-	return syscall.Setresuid(uid, 0, uid)
+	return syscall.Setresuid(0, 0, uid)
 }
 
 // Drop drops privileges of the thread or process.

--- a/pkg/network/network_linux.go
+++ b/pkg/network/network_linux.go
@@ -461,7 +461,7 @@ func (m *Setup) command(ctx context.Context, command string) error {
 		defer env.SetFromList(backupEnv)
 	}
 
-	config := &libcni.CNIConfig{Path: []string{m.cniPath.Plugin}}
+	config := libcni.NewCNIConfig([]string{m.cniPath.Plugin}, nil)
 
 	// set a timeout context for the execution of the CNI plugin
 	// to interrupt its execution if it takes more than 5 seconds


### PR DESCRIPTION
### This fixes or addresses the following GitHub issues:

 - Cherry-pick #1520 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
