### PR TITLE
Add 32-bit architectures compatiblity mode for 64-bit architectures to fakeroot seccomp filter. (release 1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   on a local unsigned SIF file.
 - Set real UID to zero when escalating privileges for CNI plugins to fix
   issue appeared with RHEL 9.X.
+- Add 32-bit architectures compatiblity mode for 64-bit architectures to
+  fakeroot seccomp filter
 
 ### New Features & Functionality
 

--- a/internal/pkg/security/seccomp/seccomp_supported.go
+++ b/internal/pkg/security/seccomp/seccomp_supported.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/oci/generate"
@@ -100,77 +101,122 @@ func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool, errNo int16)
 		sylog.Warningf("seccomp rule conditions are not supported with libseccomp under 2.2.1")
 	}
 
-	scmpAction, ok := scmpActionMap[config.DefaultAction]
+	scmpDefaultAction, ok := scmpActionMap[config.DefaultAction]
 	if !ok {
 		return fmt.Errorf("invalid action '%s' specified", config.DefaultAction)
 	}
-	if scmpAction == lseccomp.ActErrno {
-		scmpAction = scmpAction.SetReturnCode(errNo)
+	if scmpDefaultAction == lseccomp.ActErrno {
+		scmpDefaultAction = scmpDefaultAction.SetReturnCode(errNo)
 	}
 
-	filter, err := lseccomp.NewFilter(scmpAction)
+	scmpNativeArch, err := lseccomp.GetNativeArch()
 	if err != nil {
-		return fmt.Errorf("error creating new filter: %s", err)
+		return fmt.Errorf("failed to get seccomp native architecture: %s", err)
 	}
 
-	if err := filter.SetNoNewPrivsBit(noNewPrivs); err != nil {
-		return fmt.Errorf("failed to set no new priv flag: %s", err)
-	}
+	scmpArchitectures := []lseccomp.ScmpArch{scmpNativeArch}
 
 	for _, arch := range config.Architectures {
 		scmpArch, ok := scmpArchMap[arch]
 		if !ok {
 			return fmt.Errorf("invalid architecture '%s' specified", arch)
-		}
-
-		if err := filter.AddArch(scmpArch); err != nil {
-			return fmt.Errorf("error adding architecture: %s", err)
+		} else if scmpArch != scmpNativeArch {
+			scmpArchitectures = append(scmpArchitectures, scmpArch)
 		}
 	}
 
-	for _, syscall := range config.Syscalls {
-		if len(syscall.Names) == 0 {
-			return fmt.Errorf("no syscall specified for the rule")
+	var mergeFilter *lseccomp.ScmpFilter
+
+	for _, scmpArch := range scmpArchitectures {
+		filter, err := lseccomp.NewFilter(scmpDefaultAction)
+		if err != nil {
+			return fmt.Errorf("error creating new filter: %s", err)
 		}
 
-		scmpAction, ok = scmpActionMap[syscall.Action]
-		if !ok {
-			return fmt.Errorf("invalid action '%s' specified", syscall.Action)
-		}
-		if scmpAction == lseccomp.ActErrno {
-			scmpAction = scmpAction.SetReturnCode(errNo)
+		if err := filter.SetNoNewPrivsBit(noNewPrivs); err != nil {
+			return fmt.Errorf("failed to set no new priv flag: %s", err)
 		}
 
-		for _, sysName := range syscall.Names {
-			sysNr, err := lseccomp.GetSyscallFromName(sysName)
-			if err != nil {
-				continue
+		if scmpArch != scmpNativeArch {
+			if err := filter.AddArch(scmpArch); err != nil {
+				return fmt.Errorf("error adding architecture: %s", err)
 			}
 
-			if len(syscall.Args) == 0 || !supportCondition {
-				if err := filter.AddRule(sysNr, scmpAction); err != nil {
-					return fmt.Errorf("failed adding seccomp rule for syscall %s: %s", sysName, err)
-				}
-			} else {
-				conditions, err := addSyscallRuleContitions(syscall.Args)
+			if err := filter.RemoveArch(scmpNativeArch); err != nil {
+				return fmt.Errorf("error removing architecture: %s", err)
+			}
+		}
+
+		ignoreArchFilter := false
+
+		for _, syscall := range config.Syscalls {
+			if len(syscall.Names) == 0 {
+				return fmt.Errorf("no syscall specified for the rule")
+			}
+
+			scmpAction, ok := scmpActionMap[syscall.Action]
+			if !ok {
+				return fmt.Errorf("invalid action '%s' specified", syscall.Action)
+			}
+			if scmpAction == lseccomp.ActErrno {
+				scmpAction = scmpAction.SetReturnCode(errNo)
+			}
+
+			for _, sysName := range syscall.Names {
+				sysNr, err := lseccomp.GetSyscallFromNameByArch(sysName, scmpArch)
 				if err != nil {
-					return err
+					continue
 				}
-				if err := filter.AddRuleConditional(sysNr, scmpAction, conditions); err != nil {
-					return fmt.Errorf("failed adding rule condition for syscall %s: %s", sysName, err)
+
+				if len(syscall.Args) == 0 || !supportCondition {
+					if err := filter.AddRule(sysNr, scmpAction); err != nil {
+						if isUnrecognizedSyscall(err) {
+							ignoreArchFilter = true
+							break
+						}
+						return fmt.Errorf("failed adding seccomp rule for syscall %s: %s", sysName, err)
+					}
+				} else {
+					conditions, err := addSyscallRuleConditions(syscall.Args)
+					if err != nil {
+						return err
+					}
+					if err := filter.AddRuleConditional(sysNr, scmpAction, conditions); err != nil {
+						if isUnrecognizedSyscall(err) {
+							ignoreArchFilter = true
+							break
+						}
+						return fmt.Errorf("failed adding rule condition for syscall %s: %s", sysName, err)
+					}
+				}
+			}
+		}
+
+		if !ignoreArchFilter {
+			if mergeFilter == nil {
+				mergeFilter = filter
+			} else {
+				if err := mergeFilter.Merge(filter); err != nil {
+					return fmt.Errorf("failed to merge seccomp filter for architecture %s: %s", scmpArch, err)
 				}
 			}
 		}
 	}
 
-	if err = filter.Load(); err != nil {
+	if mergeFilter == nil {
+		return fmt.Errorf("seccomp filter not applied due to error")
+	} else if err := mergeFilter.Load(); err != nil {
 		return fmt.Errorf("failed loading seccomp filter: %s", err)
 	}
 
 	return nil
 }
 
-func addSyscallRuleContitions(args []specs.LinuxSeccompArg) ([]lseccomp.ScmpCondition, error) {
+func isUnrecognizedSyscall(err error) bool {
+	return strings.Contains(err.Error(), "unrecognized syscall")
+}
+
+func addSyscallRuleConditions(args []specs.LinuxSeccompArg) ([]lseccomp.ScmpCondition, error) {
 	var maxIndex uint = 6
 	conditions := make([]lseccomp.ScmpCondition, 0)
 


### PR DESCRIPTION
### This fixes or addresses the following GitHub issues:

 - Cherry-pick #1522 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
