### PR TITLE
restore the option `--warn-unused-build-args`

### DIFF
--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -306,6 +306,7 @@ var buildVarArgFileFlag = cmdline.Flag{
 	Usage:        "specifies a file containing variable=value lines to replace '{{ variable }}' with value in build definition files",
 }
 
+// --warn-unused-build-args
 var buildArgUnusedWarn = cmdline.Flag{
 	ID:           "buildArgUnusedWarnFlag",
 	Value:        &buildArgs.buildArgsUnusedWarn,

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -267,9 +267,17 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 	if err != nil {
 		sylog.Fatalf("While processing the definition file: %v", err)
 	}
-	defs, err := build.MakeAllDefs(spec, buildArgsMap)
+	defs, unusedArgs, err := build.MakeAllDefs(spec, buildArgsMap)
 	if err != nil {
 		sylog.Fatalf("Unable to build from %s: %v", spec, err)
+	}
+
+	if len(unusedArgs) > 0 {
+		if buildArgs.buildArgsUnusedWarn {
+			sylog.Warningf("Unused build args: %s", strings.Join(unusedArgs, " "))
+		} else {
+			sylog.Fatalf("unused build args: %s. Use option --warn-unused-build-args to show a warning instead of a fatal message", strings.Join(unusedArgs, " "))
+		}
 	}
 
 	authToken := ""

--- a/internal/pkg/build/build_test.go
+++ b/internal/pkg/build/build_test.go
@@ -200,7 +200,7 @@ func TestTransformer(t *testing.T) {
 }
 
 func TestProcessDefsSingleDef(t *testing.T) {
-	d, err := MakeAllDefs(
+	d, _, err := MakeAllDefs(
 		filepath.Join("..", "..", "..", "test", "build-args", "single-stage-unit-test.def"),
 		map[string]string{
 			"OS_VER": "1",
@@ -216,7 +216,7 @@ func TestProcessDefsSingleDef(t *testing.T) {
 }
 
 func TestProcessDefsMultipleDef(t *testing.T) {
-	d, err := MakeAllDefs(
+	d, _, err := MakeAllDefs(
 		filepath.Join("..", "..", "..", "test", "build-args", "multiple-stage-unit-test.def"),
 		map[string]string{
 			"DEVEL_IMAGE": "golang:1.12.3-alpine3.9",
@@ -275,4 +275,18 @@ func TestReadDefaultArgs(t *testing.T) {
 		"FINAL_IMAGE": "alpine:3.17",
 		"HOME":        "/root",
 	})
+}
+
+func TestProcessWithAdditionalArgs(t *testing.T) {
+	_, unusedArgs, err := MakeAllDefs(
+		filepath.Join("..", "..", "..", "test", "build-args", "single-stage-unit-test.def"),
+		map[string]string{
+			"OS_VER":   "1",
+			"AUTHOR":   "jason",
+			"ADDITION": "1",
+		},
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, len(unusedArgs), 1)
+	assert.Equal(t, "ADDITION", unusedArgs[0])
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):
restore the option `--warn-unused-build-args`

### This fixes or addresses the following GitHub issues:

 - Fixes #1534 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
