### PR TITLE
Fix checking for rootless overlay so it works on ubuntu 22.04 (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes since last pre-release
+
+- Fix the check for rootless overlay on Ubuntu 22.04 so it will use overlay
+  instead of underlay by default like all other tested operating systems.
+
 ## v1.2.0-rc.2 - \[2023-07-05\]
 
 ## Changes since last pre-release

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -157,7 +157,7 @@ func CheckRootless() error {
 
 	args := []string{
 		"-t", "overlay",
-		"-o", "lowerdir=/tmp:/etc",
+		"-o", "lowerdir=/mnt:/etc",
 		"none",
 		"/tmp",
 	}


### PR DESCRIPTION
This cherry-picks #1550 to the release-1.2 branch.