### PR TITLE
Fix the issue that APPTAINER_MESSAGELEVEL does not have effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
   pkg/build/types/parser.All(), `.Raw` contains the raw content of a single
   build stage. Otherwise, it is equal to `.FullRaw`.
 
+## Changes since last release
+
+### Bug fixes
+
+- Fix `$APPTAINER_MESSAGELEVEL` to correctly set the logging level.
+
 ## v1.2.0 - \[2023-07-18\]
 
 Changes since v1.1.9

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -15,11 +15,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"os/signal"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -271,18 +273,26 @@ func addCmdInit(cmdInit func(*cmdline.CommandManager)) {
 func setSylogMessageLevel() {
 	var level int
 
+	l, err := strconv.Atoi(env.GetenvLegacy("MESSAGELEVEL", "MESSAGELEVEL"))
+	if err == nil {
+		level = l
+	}
+
 	if debug {
 		level = 5
 		// Propagate debug flag to nested `apptainer` calls.
 		os.Setenv("APPTAINER_DEBUG", "1")
 	} else if verbose {
 		level = 4
+		os.Setenv("APPTAINER_VERBOSE", "1")
 	} else if quiet {
 		level = -1
+		os.Setenv("APPTAINER_QUIET", "1")
 	} else if silent {
 		level = -3
+		os.Setenv("APPTAINER_SILENT", "1")
 	} else {
-		level = 1
+		level = int(math.Max(float64(level), 1))
 	}
 
 	color := true

--- a/internal/pkg/image/unpacker/squashfs_apptainer.go
+++ b/internal/pkg/image/unpacker/squashfs_apptainer.go
@@ -364,6 +364,10 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 		fmt.Sprintf("LD_LIBRARY_PATH=%s", strings.Join(libraryPath, string(os.PathListSeparator))),
 		fmt.Sprintf("APPTAINERENV_LD_LIBRARY_PATH=%s", strings.Join(libraryPath, string(os.PathListSeparator))),
 		fmt.Sprintf("APPTAINER_DEBUG=%s", os.Getenv("APPTAINER_DEBUG")),
+		fmt.Sprintf("APPTAINER_VERBOSE=%s", os.Getenv("APPTAINER_VERBOSE")),
+		fmt.Sprintf("APPTAINER_QUIET=%s", os.Getenv("APPTAINER_QUIET")),
+		fmt.Sprintf("APPTAINER_SILENT=%s", os.Getenv("APPTAINER_SILENT")),
+		fmt.Sprintf("APPTAINER_MESSAGELEVEL=%s", os.Getenv("APPTAINER_MESSAGELEVEL")),
 	}
 
 	return cmd, nil

--- a/pkg/sylog/sylog.go
+++ b/pkg/sylog/sylog.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 )
 
-const messageLevelEnv = "APPTAINER_MESSAGELEVEL"
-
 var messageColors = map[messageLevel]string{
 	FatalLevel: "\x1b[31m",
 	ErrorLevel: "\x1b[31m",
@@ -37,9 +35,9 @@ var (
 var logWriter = (io.Writer)(os.Stderr)
 
 func init() {
-	level, err := strconv.Atoi(os.Getenv(messageLevelEnv))
+	l, err := strconv.Atoi(os.Getenv("APPTAINER_MESSAGELEVEL"))
 	if err == nil {
-		loggerLevel = messageLevel(level)
+		loggerLevel = messageLevel(l)
 	}
 }
 
@@ -150,7 +148,7 @@ func GetLevel() int {
 // GetEnvVar returns a formatted environment variable string which
 // can later be interpreted by init() in a child proc
 func GetEnvVar() string {
-	return fmt.Sprintf("%s=%d", messageLevelEnv, loggerLevel)
+	return fmt.Sprintf("APPTAINER_MESSAGELEVEL=%d", loggerLevel)
 }
 
 // Writer returns an io.Writer to pass to an external packages logging utility.

--- a/pkg/sylog/sylog_dummy.go
+++ b/pkg/sylog/sylog_dummy.go
@@ -14,12 +14,20 @@ package sylog
 import (
 	"io"
 	"os"
+	"strconv"
 )
 
 var (
 	noColorLevel messageLevel = 90
 	loggerLevel               = InfoLevel
 )
+
+func init() {
+	l, err := strconv.Atoi(os.Getenv("APPTAINER_MESSAGELEVEL"))
+	if err == nil {
+		loggerLevel = messageLevel(l)
+	}
+}
 
 func getLoggerLevel() messageLevel {
 	if loggerLevel <= -noColorLevel {


### PR DESCRIPTION
## Description of the Pull Request (PR):

This `APPTAINER_MESSAGELEVEL` is only used when sylog is initialized, so we need to do some calculation between log level envs and message level env. 
https://github.com/JasonYangShadow/apptainer/blob/issue%2F1556/cmd/internal/cli/apptainer.go#L275
https://github.com/JasonYangShadow/apptainer/blob/issue%2F1556/cmd/internal/cli/apptainer.go#L291

### This fixes or addresses the following GitHub issues:

 - Fixes #1556 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
