### PR TITLE
chore: Move i/p/a/apptainer Sign/Verify functions to separate pkg, from sylabs 1892

### DIFF
--- a/cmd/internal/cli/pgp.go
+++ b/cmd/internal/cli/pgp.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
-	"github.com/apptainer/apptainer/internal/app/apptainer"
+	sifsignature "github.com/apptainer/apptainer/internal/pkg/signature"
 	"github.com/apptainer/apptainer/internal/pkg/util/interactive"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/sypgp"
@@ -224,8 +224,8 @@ type keyList struct {
 	SignerKeys []*key
 }
 
-// getJSONCallback returns an apptainer.VerifyCallback that appends to kl.
-func getJSONCallback(kl *keyList) apptainer.VerifyCallback {
+// getJSONCallback returns a signature.VerifyCallback that appends to kl.
+func getJSONCallback(kl *keyList) sifsignature.VerifyCallback {
 	return func(f *sif.FileImage, r integrity.VerifyResult) bool {
 		name, fp := "unknown", ""
 		var keyLocal, keyCheck bool

--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -13,7 +13,7 @@ import (
 	"crypto"
 
 	"github.com/apptainer/apptainer/docs"
-	"github.com/apptainer/apptainer/internal/app/apptainer"
+	sifsignature "github.com/apptainer/apptainer/internal/pkg/signature"
 	"github.com/apptainer/apptainer/pkg/cmdline"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/sypgp"
@@ -130,7 +130,7 @@ var SignCmd = &cobra.Command{
 }
 
 func doSignCmd(cmd *cobra.Command, cpath string) {
-	var opts []apptainer.SignOpt
+	var opts []sifsignature.SignOpt
 
 	// Set key material.
 	switch {
@@ -141,7 +141,7 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 		if err != nil {
 			sylog.Fatalf("Failed to load key material: %v", err)
 		}
-		opts = append(opts, apptainer.OptSignWithSigner(s))
+		opts = append(opts, sifsignature.OptSignWithSigner(s))
 
 	default:
 		sylog.Infof("Signing image with PGP key material")
@@ -154,21 +154,21 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 			f = selectEntityInteractive()
 		}
 		f = decryptSelectedEntityInteractive(f)
-		opts = append(opts, apptainer.OptSignEntitySelector(f))
+		opts = append(opts, sifsignature.OptSignEntitySelector(f))
 	}
 
 	// Set group option, if applicable.
 	if cmd.Flag(signSifGroupIDFlag.Name).Changed || cmd.Flag(signOldSifGroupIDFlag.Name).Changed {
-		opts = append(opts, apptainer.OptSignGroup(sifGroupID))
+		opts = append(opts, sifsignature.OptSignGroup(sifGroupID))
 	}
 
 	// Set object option, if applicable.
 	if cmd.Flag(signSifDescSifIDFlag.Name).Changed || cmd.Flag(signSifDescIDFlag.Name).Changed {
-		opts = append(opts, apptainer.OptSignObjects(sifDescID))
+		opts = append(opts, sifsignature.OptSignObjects(sifDescID))
 	}
 
 	// Sign the image.
-	if err := apptainer.Sign(cmd.Context(), cpath, opts...); err != nil {
+	if err := sifsignature.Sign(cmd.Context(), cpath, opts...); err != nil {
 		sylog.Fatalf("Failed to sign container: %v", err)
 	}
 	sylog.Infof("Signature created and applied to image '%v'", cpath)

--- a/internal/app/apptainer/push.go
+++ b/internal/app/apptainer/push.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apptainer/apptainer/internal/pkg/signature"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	keyClient "github.com/apptainer/container-key-client/client"
@@ -100,7 +101,7 @@ func LibraryPush(ctx context.Context, pushSpec LibraryPushSpec, libraryConfig *c
 
 	if !pushSpec.AllowUnsigned {
 		// Check if the container has a valid signature.
-		if err := Verify(ctx, pushSpec.SourceFile, OptVerifyWithPGP(co...)); err != nil {
+		if err := signature.Verify(ctx, pushSpec.SourceFile, signature.OptVerifyWithPGP(co...)); err != nil {
 			sylog.Warningf("%v", err)
 			return ErrLibraryUnsigned
 		}

--- a/internal/pkg/build/sources/verify_sif.go
+++ b/internal/pkg/build/sources/verify_sif.go
@@ -12,7 +12,7 @@ package sources
 import (
 	"context"
 
-	"github.com/apptainer/apptainer/internal/app/apptainer"
+	"github.com/apptainer/apptainer/internal/pkg/signature"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	keyClient "github.com/apptainer/container-key-client/client"
 )
@@ -20,11 +20,11 @@ import (
 // checkSIFFingerprint checks whether a bootstrap SIF image verifies, and was signed with a specified fingerprint
 func checkSIFFingerprint(ctx context.Context, imagePath string, fingerprints []string, co ...keyClient.Option) error {
 	sylog.Infof("Checking bootstrap image verifies with fingerprint(s): %v", fingerprints)
-	return apptainer.VerifyFingerprints(ctx, imagePath, fingerprints, apptainer.OptVerifyWithPGP(co...))
+	return signature.VerifyFingerprints(ctx, imagePath, fingerprints, signature.OptVerifyWithPGP(co...))
 }
 
 // verifySIF checks whether a bootstrap SIF image verifies
 func verifySIF(ctx context.Context, imagePath string, co ...keyClient.Option) error {
 	sylog.Infof("Verifying bootstrap image %s", imagePath)
-	return apptainer.Verify(ctx, imagePath, apptainer.OptVerifyWithPGP(co...))
+	return signature.Verify(ctx, imagePath, signature.OptVerifyWithPGP(co...))
 }

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -17,9 +17,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/apptainer/apptainer/internal/app/apptainer"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/client"
+	"github.com/apptainer/apptainer/internal/pkg/signature"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	keyClient "github.com/apptainer/container-key-client/client"
@@ -143,7 +143,7 @@ func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo string, pull
 		}
 	}
 
-	if err := apptainer.Verify(ctx, pullTo, apptainer.OptVerifyWithPGP(co...)); err != nil {
+	if err := signature.Verify(ctx, pullTo, signature.OptVerifyWithPGP(co...)); err != nil {
 		sylog.Warningf("%v", err)
 		return pullTo, ErrLibraryPullUnsigned
 	}

--- a/internal/pkg/signature/sign.go
+++ b/internal/pkg/signature/sign.go
@@ -7,7 +7,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package apptainer
+package signature
 
 import (
 	"context"

--- a/internal/pkg/signature/sign_test.go
+++ b/internal/pkg/signature/sign_test.go
@@ -7,7 +7,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package apptainer
+package signature
 
 import (
 	"context"

--- a/internal/pkg/signature/verify.go
+++ b/internal/pkg/signature/verify.go
@@ -8,7 +8,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package apptainer
+package signature
 
 import (
 	"context"

--- a/internal/pkg/signature/verify_ocsp.go
+++ b/internal/pkg/signature/verify_ocsp.go
@@ -8,7 +8,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package apptainer
+package signature
 
 import (
 	"bytes"

--- a/internal/pkg/signature/verify_test.go
+++ b/internal/pkg/signature/verify_test.go
@@ -7,7 +7,7 @@
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
 
-package apptainer
+package signature
 
 import (
 	"bytes"


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1892

The original PR description was:
> Implementation of SIF signing and verification was previously part of the large internal/pkg/app/singularity package.
> 
> This situation is problematic, as verification may need to be performed in builds, client pulls etc. Consequently internal/pkg/app/singularity had to be imported in lower level code.
> 
> Work on the OCI mode has exposed situations where this can result in import loops.
> 
> After recent re-writes, the Sign / Verify functions are not tied to other portions of internal/pkg/app/singularity. Therefore this PR moves them to a separate package to avoid import loops etc.
> 
> As a result, internal/pkg/app/singularity is now only imported by cmd/.



