### PR TITLE
Restore old syscall setresuid behavior when escalating/dropping privileges.

### DIFF
--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2607,8 +2607,11 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 				}
 			}
 			if euid != 0 {
-				priv.Escalate()
-				defer priv.Drop()
+				dropPrivilege, err := priv.Escalate()
+				if err != nil {
+					return err
+				}
+				defer dropPrivilege()
 			}
 		}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Restore old syscall setresuid behavior when escalating/dropping privileges to only change UID for the locked thread

### This fixes or addresses the following GitHub issues:

 - Fixes #1576 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
