### PR TITLE
Restore old syscall setresuid behavior when escalating/dropping privileges. (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## v1.2.1 - \[2023-07-25\]
+
+Changes since v1.2.0
+
+### Security fix
+
+- Included fix for [security advisory](https://github.com/apptainer/apptainer/security/advisories/GHSA-mmx5-32m4-wxvx),
+  an ineffective privilege drop when requesting container network allows an
+  attacker to delete any directory on the host filesystems with a crafted
+  starter config.
+
 ## v1.2.0 - \[2023-07-18\]
 
 Changes since v1.1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
-## v1.2.1 - \[2023-07-25\]
-
-Changes since v1.2.0
+## v1.2.1 - \[2023-07-24\]
 
 ### Security fix
 
-- Included fix for [security advisory](https://github.com/apptainer/apptainer/security/advisories/GHSA-mmx5-32m4-wxvx),
-  an ineffective privilege drop when requesting container network allows an
-  attacker to delete any directory on the host filesystems with a crafted
-  starter config.
+- Included a fix for
+  [security advisory GHSA-mmx5-32m4-wxvx](https://github.com/apptainer/apptainer/security/advisories/GHSA-mmx5-32m4-wxvx)
+  which describes an ineffective privilege drop when requesting a
+  container network with a setuid installation of Apptainer.
+  The vulnerability allows an attacker to delete any directory on the
+  host filesystems with a crafted starter config.
+  Only affects v1.2.0-rc.2 and v1.2.0.
 
 ## v1.2.0 - \[2023-07-18\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,7 +137,7 @@ To build a specific version of Apptainer, check out a
 for example:
 
 ```sh
-git checkout v1.2.0
+git checkout v1.2.1
 ```
 
 ## Compiling Apptainer
@@ -272,7 +272,7 @@ like this:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-VERSION=1.2.0  # this is the apptainer version, change as you need
+VERSION=1.2.1  # this is the apptainer version, change as you need
 # Fetch the source
 wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/apptainer-${VERSION}.tar.gz
 ```
@@ -324,7 +324,7 @@ in your PATH:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-VERSION=1.2.0 # this is the latest apptainer version, change as you need
+VERSION=1.2.1 # this is the latest apptainer version, change as you need
 ./mconfig
 make -C builddir rpm
 sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/apptainer-$(echo $VERSION|tr - \~)*.x86_64.rpm 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2604,8 +2604,11 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 				}
 			}
 			if euid != 0 {
-				priv.Escalate()
-				defer priv.Drop()
+				dropPrivilege, err := priv.Escalate()
+				if err != nil {
+					return err
+				}
+				defer dropPrivilege()
 			}
 		}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cherry-pick #1578 into the release-1.2 branch.  Also make everything ready for 1.2.1 release.


