### PR TITLE
fix the build failure when unprivileged user namespaces is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 ### Bug fixes
 
 - Fix `$APPTAINER_MESSAGELEVEL` to correctly set the logging level.
+- Fix build failures when in setuid mode and unprivileged user namespaces
+  are unavailable and the `--fakeroot` option is not selected.
 
 ## v1.2.1 - \[2023-07-24\]
 

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -384,7 +384,7 @@ func preRun(cmd *cobra.Command, args []string) {
 		if os.Getuid() != 0 {
 			if isDeffile {
 				sylog.Verbosef("Implying --fakeroot because building from definition file unprivileged")
-				fakerootExec(isDeffile, true)
+				fakerootExec(isDeffile, buildArgs.encrypt)
 			} else if buildArgs.encrypt {
 				sylog.Verbosef("Implying --fakeroot because using unprivileged encryption")
 				fakerootExec(isDeffile, true)

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -2001,7 +2001,7 @@ func (c *imgBuildTests) testContainerBuildUnderFakerootModes(t *testing.T) {
 	// running under the mode 2(https://apptainer.org/docs/user/main/fakeroot.html)
 	c.env.RunApptainer(
 		t,
-		e2e.WithProfile(e2e.UserNamespaceProfile),
+		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--force", "--userns", "--ignore-subuid", "--ignore-fakeroot-command", fmt.Sprintf("%s/openssh-mode2a.sif", tmpDir), "testdata/unprivileged_build.def"),
 		e2e.ExpectExit(255), // because chown will fail
@@ -2010,7 +2010,7 @@ func (c *imgBuildTests) testContainerBuildUnderFakerootModes(t *testing.T) {
 	// running under the mode 2(https://apptainer.org/docs/user/main/fakeroot.html)
 	c.env.RunApptainer(
 		t,
-		e2e.WithProfile(e2e.UserNamespaceProfile),
+		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--force", "--userns", "--ignore-subuid", "--ignore-fakeroot-command", fmt.Sprintf("%s/openssh-mode2b.sif", tmpDir), "testdata/unprivileged_build_2.def"),
 		e2e.ExpectExit(0),
@@ -2019,7 +2019,7 @@ func (c *imgBuildTests) testContainerBuildUnderFakerootModes(t *testing.T) {
 	// running under the mode 3(https://apptainer.org/docs/user/main/fakeroot.html)
 	c.env.RunApptainer(
 		t,
-		e2e.WithProfile(e2e.FakerootProfile),
+		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--force", "--userns", "--ignore-subuid", fmt.Sprintf("%s/openssh-mode3.sif", tmpDir), "testdata/unprivileged_build.def"),
 		e2e.ExpectExit(0),
@@ -2028,7 +2028,7 @@ func (c *imgBuildTests) testContainerBuildUnderFakerootModes(t *testing.T) {
 	// running under the mode 4(https://apptainer.org/docs/user/main/fakeroot.html)
 	c.env.RunApptainer(
 		t,
-		e2e.WithProfile(e2e.FakerootProfile),
+		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("--force", "--ignore-userns", "--ignore-subuid", fmt.Sprintf("%s/openssh-mode4.sif", tmpDir), "testdata/unprivileged_build_4.def"),
 		e2e.ExpectExit(0),


### PR DESCRIPTION
## Description of the Pull Request (PR):

when calling the `fakerootExec` we should use `buildArgs.encrypt` as a parameter rather than constant `true` when `isDeffine` is true. 


### This fixes or addresses the following GitHub issues:

 - Fixes #1582 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
