### PR TITLE
Allow containers using `--nv` and `--rocm` GPU binds simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - The `--vm` and related flags to start apptainer inside a VM have been
   removed. This functionality was related to the retired Singularity Desktop /
   SyOS projects.
+- The `--nv` and `--rocm` flags can now be used simultaneously.
 
 ### New Features & Functionality
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -96,6 +96,7 @@
 - Thomas Hamel <hmlth@t-hamel.fr>
 - Tim Wright <7im.Wright@protonmail.com>
 - Tobias Poschwatta <poschwatta@zib.de>
+- Tobias Ribizel <mail@ribizel.de>
 - Tru Huynh <tru@pasteur.fr>
 - Tyson Whitehead <twhitehead@gmail.com>
 - Vanessa Sochat <vsoch@users.noreply.github.com>

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -660,21 +660,19 @@ func (e *EngineConfig) GetTargetGID() []int {
 	return e.JSON.TargetGID
 }
 
-// Appends all entries that are not already present in the slice.
-func AppendSliceNonduplicate(slice []string, newElements []string) []string {
-	newSlice := make([]string, 0, len(slice)+len(newElements))
-	exists := make(map[string]bool)
-	for _, element := range slice {
-		newSlice = append(newSlice, element)
-		exists[element] = true
-	}
-	for _, element := range newElements {
-		if !exists[element] {
-			newSlice = append(newSlice, element)
-			exists[element] = true
+// ConcatenateSliceDeduplicate concatenates two string slices and returns a string slice without duplicated entries.
+func ConcatenateSliceDeduplicate(first []string, second []string) []string {
+	dedup := make(map[string]struct{})
+	for _, slice := range [][]string{first, second} {
+		for _, elem := range slice {
+			dedup[elem] = struct{}{}
 		}
 	}
-	return newSlice
+	slice := make([]string, 0, len(dedup))
+	for elem := range dedup {
+		slice = append(slice, elem)
+	}
+	return slice
 }
 
 // SetLibrariesPath sets libraries to bind in container
@@ -686,7 +684,7 @@ func (e *EngineConfig) SetLibrariesPath(libraries []string) {
 // AppendLibrariesPath adds libraries to bind in container
 // /.singularity.d/libs directory.
 func (e *EngineConfig) AppendLibrariesPath(libraries ...string) {
-	e.JSON.LibrariesPath = AppendSliceNonduplicate(e.JSON.LibrariesPath, libraries)
+	e.JSON.LibrariesPath = ConcatenateSliceDeduplicate(e.JSON.LibrariesPath, libraries)
 }
 
 // GetLibrariesPath returns libraries to bind in container
@@ -702,7 +700,7 @@ func (e *EngineConfig) SetFilesPath(files []string) {
 
 // AppendFilesPath adds files to bind in container (eg: --nv)
 func (e *EngineConfig) AppendFilesPath(files ...string) {
-	e.JSON.FilesPath = AppendSliceNonduplicate(e.JSON.FilesPath, files)
+	e.JSON.FilesPath = ConcatenateSliceDeduplicate(e.JSON.FilesPath, files)
 }
 
 // GetFilesPath returns files to bind in container (eg: --nv).

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -660,6 +660,23 @@ func (e *EngineConfig) GetTargetGID() []int {
 	return e.JSON.TargetGID
 }
 
+// Appends all entries that are not already present in the slice.
+func AppendSliceNonduplicate(slice []string, newElements []string) []string {
+	newSlice := make([]string, 0, len(slice)+len(newElements))
+	exists := make(map[string]bool)
+	for _, element := range slice {
+		newSlice = append(newSlice, element)
+		exists[element] = true
+	}
+	for _, element := range newElements {
+		if !exists[element] {
+			newSlice = append(newSlice, element)
+			exists[element] = true
+		}
+	}
+	return newSlice
+}
+
 // SetLibrariesPath sets libraries to bind in container
 // /.singularity.d/libs directory.
 func (e *EngineConfig) SetLibrariesPath(libraries []string) {
@@ -669,7 +686,7 @@ func (e *EngineConfig) SetLibrariesPath(libraries []string) {
 // AppendLibrariesPath adds libraries to bind in container
 // /.singularity.d/libs directory.
 func (e *EngineConfig) AppendLibrariesPath(libraries ...string) {
-	e.JSON.LibrariesPath = append(e.JSON.LibrariesPath, libraries...)
+	e.JSON.LibrariesPath = AppendSliceNonduplicate(e.JSON.LibrariesPath, libraries)
 }
 
 // GetLibrariesPath returns libraries to bind in container
@@ -685,7 +702,7 @@ func (e *EngineConfig) SetFilesPath(files []string) {
 
 // AppendFilesPath adds files to bind in container (eg: --nv)
 func (e *EngineConfig) AppendFilesPath(files ...string) {
-	e.JSON.FilesPath = append(e.JSON.FilesPath, files...)
+	e.JSON.FilesPath = AppendSliceNonduplicate(e.JSON.FilesPath, files)
 }
 
 // GetFilesPath returns files to bind in container (eg: --nv).


### PR DESCRIPTION
## Description of the Pull Request (PR):

For development and testing purposes, it may be necessary to run both ROCm and CUDA binaries in the same container. There is no obvious technical limitation that prevents this from working, so I created this PR to enable it.
Since both `--rocm` and `--nv` search for `libOpenCL.so`, I needed to remove the resulting duplicate from the bind mounts. This means that OpenCL binaries can only work on one backend, but this kind of frankenstein development environment is an obscure use case anyways, so it should not matter.

I tested the behavior locally with an image with both CUDA and ROCm installed, and it seems to work (after the usual [nvidia_uvm kernel module issues](https://apptainer.org/user-docs/3.5/gpu.html#cuda-error-unknown-when-everything-seems-to-be-correctly-configured) have been addressed)

### This fixes or addresses the following GitHub issues:

 - Fixes #1596 

