### PR TITLE
move keyserver-related cmds from remote to their own cmd, from sylabs 1905

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   removed. This functionality was related to the retired Singularity Desktop /
   SyOS projects.
 - The `--nv` and `--rocm` flags can now be used simultaneously.
+- The keyserver-related commands that were under `remote` have been moved to
+  their own, dedicated `keyserver` command. Run `apptainer help keyserver` for
+  more information.
 
 ### New Features & Functionality
 

--- a/cmd/internal/cli/keyserver.go
+++ b/cmd/internal/cli/keyserver.go
@@ -1,0 +1,249 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/apptainer/apptainer/docs"
+	"github.com/apptainer/apptainer/internal/app/apptainer"
+	"github.com/apptainer/apptainer/pkg/cmdline"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyserverInsecure bool
+	keyserverOrder    uint32
+)
+
+// -i|--insecure
+var keyserverInsecureFlag = cmdline.Flag{
+	ID:           "keyserverInsecureFlag",
+	Value:        &keyserverInsecure,
+	DefaultValue: false,
+	Name:         "insecure",
+	ShortHand:    "i",
+	Usage:        "allow insecure connection to keyserver",
+}
+
+// -o|--order
+var keyserverOrderFlag = cmdline.Flag{
+	ID:           "keyserverOrderFlag",
+	Value:        &keyserverOrder,
+	DefaultValue: uint32(0),
+	Name:         "order",
+	ShortHand:    "o",
+	Usage:        "define the keyserver order",
+}
+
+// -u|--username
+var keyserverLoginUsernameFlag = cmdline.Flag{
+	ID:           "keyserverLoginUsernameFlag",
+	Value:        &loginUsername,
+	DefaultValue: "",
+	Name:         "username",
+	ShortHand:    "u",
+	Usage:        "username to authenticate with (required for Docker/OCI registry login)",
+	EnvKeys:      []string{"LOGIN_USERNAME"},
+}
+
+// -p|--password
+var keyserverLoginPasswordFlag = cmdline.Flag{
+	ID:           "keyserverLoginPasswordFlag",
+	Value:        &loginPassword,
+	DefaultValue: "",
+	Name:         "password",
+	ShortHand:    "p",
+	Usage:        "password / token to authenticate with",
+	EnvKeys:      []string{"LOGIN_PASSWORD"},
+}
+
+// --password-stdin
+var keyserverLoginPasswordStdinFlag = cmdline.Flag{
+	ID:           "keyserverLoginPasswordStdinFlag",
+	Value:        &loginPasswordStdin,
+	DefaultValue: false,
+	Name:         "password-stdin",
+	Usage:        "take password from standard input",
+}
+
+func init() {
+	addCmdInit(func(cmdManager *cmdline.CommandManager) {
+		cmdManager.RegisterCmd(KeyserverCmd)
+		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverAddCmd)
+		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverRemoveCmd)
+		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverLoginCmd)
+		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverLogoutCmd)
+		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverListCmd)
+
+		cmdManager.RegisterFlagForCmd(&keyserverOrderFlag, KeyserverAddCmd)
+		cmdManager.RegisterFlagForCmd(&keyserverInsecureFlag, KeyserverAddCmd)
+
+		cmdManager.RegisterFlagForCmd(&keyserverLoginUsernameFlag, KeyserverLoginCmd)
+		cmdManager.RegisterFlagForCmd(&keyserverLoginPasswordFlag, KeyserverLoginCmd)
+		cmdManager.RegisterFlagForCmd(&keyserverLoginPasswordStdinFlag, KeyserverLoginCmd)
+	})
+}
+
+// KeyserverCmd apptainer keyserver [...]
+var KeyserverCmd = &cobra.Command{
+	Run: nil,
+
+	Use:     docs.KeyserverUse,
+	Short:   docs.KeyserverShort,
+	Long:    docs.KeyserverLong,
+	Example: docs.KeyserverExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// KeyserverAddCmd apptainer keyserver add [option] <keyserver_url>
+var KeyserverAddCmd = &cobra.Command{
+	Args:   cobra.RangeArgs(1, 2),
+	PreRun: setKeyserver,
+	Run: func(cmd *cobra.Command, args []string) {
+		uri := args[0]
+		name := ""
+		if len(args) > 1 {
+			name = args[0]
+			uri = args[1]
+		}
+
+		if cmd.Flag(keyserverOrderFlag.Name).Changed && keyserverOrder == 0 {
+			sylog.Fatalf("order must be > 0")
+		}
+
+		if err := apptainer.KeyserverAdd(name, uri, keyserverOrder, keyserverInsecure); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use:     docs.KeyserverAddUse,
+	Short:   docs.KeyserverAddShort,
+	Long:    docs.KeyserverAddLong,
+	Example: docs.KeyserverAddExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// KeyserverRemoveCmd apptainer remote remove-keyserver [remoteName] <keyserver_url>
+var KeyserverRemoveCmd = &cobra.Command{
+	Args:   cobra.RangeArgs(1, 2),
+	PreRun: setKeyserver,
+	Run: func(cmd *cobra.Command, args []string) {
+		uri := args[0]
+		name := ""
+		if len(args) > 1 {
+			name = args[0]
+			uri = args[1]
+		}
+
+		if err := apptainer.KeyserverRemove(name, uri); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use:     docs.KeyserverRemoveUse,
+	Short:   docs.KeyserverRemoveShort,
+	Long:    docs.KeyserverRemoveLong,
+	Example: docs.KeyserverRemoveExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+func setKeyserver(_ *cobra.Command, _ []string) {
+	if uint32(os.Getuid()) != 0 {
+		sylog.Fatalf("Unable to modify keyserver configuration: not root user")
+	}
+}
+
+// KeyserverLoginCmd apptainer registry login [option] <registry_url>
+var KeyserverLoginCmd = &cobra.Command{
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		loginArgs := new(apptainer.LoginArgs)
+
+		loginArgs.Name = args[0]
+
+		loginArgs.Username = loginUsername
+		loginArgs.Password = loginPassword
+		loginArgs.Tokenfile = loginTokenFile
+		loginArgs.Insecure = loginInsecure
+
+		if loginPasswordStdin {
+			p, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				sylog.Fatalf("Failed to read password from stdin: %s", err)
+			}
+			loginArgs.Password = strings.TrimSuffix(string(p), "\n")
+			loginArgs.Password = strings.TrimSuffix(loginArgs.Password, "\r")
+		}
+
+		if err := apptainer.KeyserverLogin(remoteConfig, loginArgs); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use:     docs.KeyserverLoginUse,
+	Short:   docs.KeyserverLoginShort,
+	Long:    docs.KeyserverLoginLong,
+	Example: docs.KeyserverLoginExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// KeyserverLogoutCmd apptainer remote logout [remoteName|serviceURI]
+var KeyserverLogoutCmd = &cobra.Command{
+	Args: cobra.RangeArgs(0, 1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// default to empty string to signal to KeyserverLogin to use default remote
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		}
+
+		if err := apptainer.KeyserverLogout(remoteConfig, name); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+		sylog.Infof("Logout succeeded")
+	},
+
+	Use:     docs.KeyserverLogoutUse,
+	Short:   docs.KeyserverLogoutShort,
+	Long:    docs.KeyserverLogoutLong,
+	Example: docs.KeyserverLogoutExample,
+
+	DisableFlagsInUseLine: true,
+}
+
+// KeyserverListCmd apptainer remote list
+var KeyserverListCmd = &cobra.Command{
+	Args: cobra.RangeArgs(0, 1),
+	Run: func(cmd *cobra.Command, args []string) {
+		remoteName := ""
+		if len(args) > 0 {
+			remoteName = args[0]
+		}
+		if err := apptainer.KeyserverList(remoteName, remoteConfig); err != nil {
+			sylog.Fatalf("%s", err)
+		}
+	},
+
+	Use:     docs.KeyserverListUse,
+	Short:   docs.KeyserverListShort,
+	Long:    docs.KeyserverListLong,
+	Example: docs.KeyserverListExample,
+
+	DisableFlagsInUseLine: true,
+}

--- a/cmd/internal/cli/keyserver.go
+++ b/cmd/internal/cli/keyserver.go
@@ -137,7 +137,7 @@ var KeyserverAddCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 }
 
-// KeyserverRemoveCmd apptainer remote remove-keyserver [remoteName] <keyserver_url>
+// KeyserverRemoveCmd apptainer keyserver remove [remoteName] <keyserver_url>
 var KeyserverRemoveCmd = &cobra.Command{
 	Args:   cobra.RangeArgs(1, 2),
 	PreRun: setKeyserver,
@@ -168,7 +168,7 @@ func setKeyserver(_ *cobra.Command, _ []string) {
 	}
 }
 
-// KeyserverLoginCmd apptainer registry login [option] <registry_url>
+// KeyserverLoginCmd apptainer keyserver login [option] <registry_url>
 var KeyserverLoginCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -203,7 +203,7 @@ var KeyserverLoginCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 }
 
-// KeyserverLogoutCmd apptainer remote logout [remoteName|serviceURI]
+// KeyserverLogoutCmd apptainer keyserver logout [remoteName|serviceURI]
 var KeyserverLogoutCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -227,7 +227,7 @@ var KeyserverLogoutCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 }
 
-// KeyserverListCmd apptainer remote list
+// KeyserverListCmd apptainer keyserver list
 var KeyserverListCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -144,8 +144,7 @@ var remoteKeyserverOrderFlag = cmdline.Flag{
 	DefaultValue: uint32(0),
 	Name:         "order",
 	ShortHand:    "o",
-	Usage:        "define the keyserver order",
-	Deprecated:   "use 'keyserver' subcommand instead of 'remote', see the output of 'apptainer help keyserver' for more information",
+	Hidden:       true,
 }
 
 // -i|--insecure (deprecated)
@@ -155,8 +154,7 @@ var remoteKeyserverInsecureFlag = cmdline.Flag{
 	DefaultValue: false,
 	Name:         "insecure",
 	ShortHand:    "i",
-	Usage:        "allow insecure connection to keyserver",
-	Deprecated:   "use 'keyserver' subcommand instead of 'remote', see the output of 'apptainer help keyserver' for more information",
+	Hidden:       true,
 }
 
 // -i|--insecure
@@ -450,28 +448,28 @@ var RemoteStatusCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 }
 
-// RemoteAddKeyserverCmd apptainer remote add-keyserver [option] [remoteName] <keyserver_url>
+// RemoteAddKeyserverCmd apptainer remote add-keyserver (deprecated)
 var RemoteAddKeyserverCmd = &cobra.Command{
-	Args:   cobra.RangeArgs(1, 2),
-	PreRun: setKeyserver,
+	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
-		if cmd.Flag(remoteKeyserverOrderFlag.Name).Changed {
-			sylog.Fatalf("use 'keyserver' subcommand instead of 'remote', see the output of 'apptainer help keyserver' for more information")
-		}
+		sylog.Warningf("'remote add-keyserver' is deprecated and will be removed in a future release; running 'keyserver add'")
+		keyserverInsecure = remoteKeyserverInsecure
+		keyserverOrder = remoteKeyserverOrder
+		KeyserverAddCmd.Run(cmd, args)
 	},
 
-	DisableFlagsInUseLine: true,
+	Use:    "add-keyserver",
+	Hidden: true,
 }
 
-// RemoteRemoveKeyserverCmd apptainer remote remove-keyserver [remoteName] <keyserver_url>
+// RemoteAddKeyserverCmd apptainer remote remove-keyserver (deprecated)
 var RemoteRemoveKeyserverCmd = &cobra.Command{
-	Args:   cobra.RangeArgs(1, 2),
-	PreRun: setKeyserver,
+	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
-		if cmd.Flag(remoteKeyserverOrderFlag.Name).Changed {
-			sylog.Fatalf("use 'keyserver' subcommand instead of 'remote', see the output of 'apptainer help keyserver' for more information")
-		}
+		sylog.Warningf("'remote remove-keyserver' is deprecated and will be removed in a future release; running 'keyserver remove'")
+		KeyserverRemoveCmd.Run(cmd, args)
 	},
 
-	DisableFlagsInUseLine: true,
+	Use:    "remove-keyserver",
+	Hidden: true,
 }

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -2,8 +2,8 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -137,7 +137,7 @@ var remoteUseExclusiveFlag = cmdline.Flag{
 	Usage:        "set the endpoint as exclusive (root user only, imply --global)",
 }
 
-// -o|--order
+// -o|--order (deprecated)
 var remoteKeyserverOrderFlag = cmdline.Flag{
 	ID:           "remoteKeyserverOrderFlag",
 	Value:        &remoteKeyserverOrder,
@@ -145,9 +145,10 @@ var remoteKeyserverOrderFlag = cmdline.Flag{
 	Name:         "order",
 	ShortHand:    "o",
 	Usage:        "define the keyserver order",
+	Deprecated:   "use 'keyserver' subcommand instead of 'remote', see the output of 'apptainer help keyserver' for more information",
 }
 
-// -i|--insecure
+// -i|--insecure (deprecated)
 var remoteKeyserverInsecureFlag = cmdline.Flag{
 	ID:           "remoteKeyserverInsecureFlag",
 	Value:        &remoteKeyserverInsecure,
@@ -155,6 +156,7 @@ var remoteKeyserverInsecureFlag = cmdline.Flag{
 	Name:         "insecure",
 	ShortHand:    "i",
 	Usage:        "allow insecure connection to keyserver",
+	Deprecated:   "use 'keyserver' subcommand instead of 'remote', see the output of 'apptainer help keyserver' for more information",
 }
 
 // -i|--insecure
@@ -230,12 +232,6 @@ func setGlobalRemoteConfig(_ *cobra.Command, _ []string) {
 
 	// set remoteConfig value to the location of the global remote.yaml file
 	remoteConfig = remote.SystemConfigPath
-}
-
-func setKeyserver(_ *cobra.Command, _ []string) {
-	if uint32(os.Getuid()) != 0 {
-		sylog.Fatalf("Unable to modify keyserver configuration: not root user")
-	}
 }
 
 // RemoteGetLoginPasswordCmd singularity remote get-login-password
@@ -459,26 +455,10 @@ var RemoteAddKeyserverCmd = &cobra.Command{
 	Args:   cobra.RangeArgs(1, 2),
 	PreRun: setKeyserver,
 	Run: func(cmd *cobra.Command, args []string) {
-		uri := args[0]
-		name := ""
-		if len(args) > 1 {
-			name = args[0]
-			uri = args[1]
-		}
-
-		if cmd.Flag(remoteKeyserverOrderFlag.Name).Changed && remoteKeyserverOrder == 0 {
-			sylog.Fatalf("order must be > 0")
-		}
-
-		if err := apptainer.RemoteAddKeyserver(name, uri, remoteKeyserverOrder, remoteKeyserverInsecure); err != nil {
-			sylog.Fatalf("%s", err)
+		if cmd.Flag(remoteKeyserverOrderFlag.Name).Changed {
+			sylog.Fatalf("use 'keyserver' subcommand instead of 'remote', see the output of 'apptainer help keyserver' for more information")
 		}
 	},
-
-	Use:     docs.RemoteAddKeyserverUse,
-	Short:   docs.RemoteAddKeyserverShort,
-	Long:    docs.RemoteAddKeyserverLong,
-	Example: docs.RemoteAddKeyserverExample,
 
 	DisableFlagsInUseLine: true,
 }
@@ -488,22 +468,10 @@ var RemoteRemoveKeyserverCmd = &cobra.Command{
 	Args:   cobra.RangeArgs(1, 2),
 	PreRun: setKeyserver,
 	Run: func(cmd *cobra.Command, args []string) {
-		uri := args[0]
-		name := ""
-		if len(args) > 1 {
-			name = args[0]
-			uri = args[1]
-		}
-
-		if err := apptainer.RemoteRemoveKeyserver(name, uri); err != nil {
-			sylog.Fatalf("%s", err)
+		if cmd.Flag(remoteKeyserverOrderFlag.Name).Changed {
+			sylog.Fatalf("use 'keyserver' subcommand instead of 'remote', see the output of 'apptainer help keyserver' for more information")
 		}
 	},
-
-	Use:     docs.RemoteRemoveKeyserverUse,
-	Short:   docs.RemoteRemoveKeyserverShort,
-	Long:    docs.RemoteRemoveKeyserverLong,
-	Example: docs.RemoteRemoveKeyserverExample,
 
 	DisableFlagsInUseLine: true,
 }

--- a/docs/keyserver.go
+++ b/docs/keyserver.go
@@ -1,0 +1,89 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package docs
+
+// Global content for help and man pages
+const (
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// keyserver command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	KeyserverUse   string = `keyserver [subcommand options...]`
+	KeyserverShort string = `Manage apptainer keyservers`
+	KeyserverLong  string = `
+  The 'keyserver' command allows you to manage standalone keyservers that will 
+  be used for retrieving cryptographic keys.`
+	KeyserverExample string = `
+  All group commands have their own help output:
+
+    $ apptainer help keyserver add
+    $ apptainer keyserver add`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// keyserver add command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	KeyserverAddUse   string = `add [options] [remoteName] <keyserver_url>`
+	KeyserverAddShort string = `Add a keyserver (root user only)`
+	KeyserverAddLong  string = `
+  The 'keyserver add' command lets the user specify an additional keyserver.
+  The --order specifies the order of the new keyserver relative to the 
+  keyservers that have already been specified. Therefore, when specifying
+  '--order 1', the new keyserver will become the primary one. If no endpoint is
+  specified, the new keyserver will be associated with the default remote
+  endpoint.`
+	KeyserverAddExample string = `
+  $ apptainer keyserver add https://keys.example.com
+
+  To add a keyserver to be used as the primary keyserver for the current
+  endpoint:
+  $ apptainer keyserver add --order 1 https://keys.example.com`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// keyserver remove command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	KeyserverRemoveUse   string = `remove [remoteName] <keyserver_url>`
+	KeyserverRemoveShort string = `Remove a keyserver (root user only)`
+	KeyserverRemoveLong  string = `
+  The 'keyserver remove' command lets the user remove a previously specified
+  keyserver from a specific endpoint. If no endpoint is specified, the default
+  remote endpoint will be assumed.`
+	KeyserverRemoveExample string = `
+  $ apptainer keyserver remove https://keys.example.com`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// keyserver login command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	KeyserverLoginUse   string = `login [login options...] <keyserver>`
+	KeyserverLoginShort string = `Login to a keyserver`
+	KeyserverLoginLong  string = `
+  The 'keyserver login' command allows you to login to a specific keyserver.`
+	KeyserverLoginExample string = `
+  To login in to a keyserver:
+  $ apptainer keyserver login --username foo https://mykeyserver.example.com`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// keyserver logout command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	KeyserverLogoutUse   string = `logout <keyserver>`
+	KeyserverLogoutShort string = `Logout from a keyserver`
+	KeyserverLogoutLong  string = `
+  The 'keyserver logout' command allows you to log out from a keyserver.`
+	KeyserverLogoutExample string = `
+  To log out from a keyserver:
+  $ apptainer keyserver logout https://mykeyserver.example.com`
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// keyserver list command
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	KeyserverListUse   string = `list [remoteName]`
+	KeyserverListShort string = `List all keyservers that are configured`
+	KeyserverListLong  string = `
+  The 'keyserver list' command lists all keyservers configured for use with a
+  given remote endpoint. If no endpoint is specified, the default
+  remote endpoint will be assumed.`
+	KeyserverListExample string = `
+  $ apptainer keyserver list`
+)

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -2,8 +2,8 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -16,11 +16,10 @@ const (
 	// remote command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteUse   string = `remote [remote options...]`
-	RemoteShort string = `Manage apptainer remote endpoints, keyservers and OCI/Docker registry credentials`
+	RemoteShort string = `Manage apptainer remote endpoints and OCI/Docker registry credentials`
 	RemoteLong  string = `
-  The 'remote' command allows you to manage Apptainer remote endpoints,
-  standalone keyservers and OCI/Docker registry credentials through its
-  subcommands.
+  The 'remote' command allows you to manage Apptainer remote endpoints and
+  OCI/Docker registry credentials through its subcommands.
 
   A 'remote endpoint' is a group of services that is compatible with the
   container library API.  The remote endpoint is a single address,
@@ -88,9 +87,9 @@ const (
 	// remote list command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteListUse   string = `list`
-	RemoteListShort string = `List all apptainer remote endpoints, keyservers, and OCI credentials that are configured`
+	RemoteListShort string = `List all apptainer remote endpoints and OCI credentials that are configured`
 	RemoteListLong  string = `
-  The 'remote list' command lists all remote endpoints, keyservers, and OCI registry
+  The 'remote list' command lists all remote endpoints and OCI registry
   credentials configured for use.
 
   The current remote is indicated by 'YES' in the 'ACTIVE' column and can be changed
@@ -101,10 +100,10 @@ const (
 	// remote login command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteLoginUse   string = `login [login options...] <remote_name|registry_uri>`
-	RemoteLoginShort string = `Login to an Apptainer remote endpoint, an OCI/Docker registry or a keyserver using credentials`
+	RemoteLoginShort string = `Login to an Apptainer remote endpoint or an OCI/Docker registry using credentials`
 	RemoteLoginLong  string = `
-  The 'remote login' command allows you to set credentials for a specific endpoint,
-  an OCI/Docker registry or a keyserver.
+  The 'remote login' command allows you to set credentials for a specific endpoint or
+  an OCI/Docker registry.
 
   If no endpoint or registry is specified, the command will login to the currently
   active remote endpoint.`
@@ -125,11 +124,11 @@ const (
 	// remote logout command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	RemoteLogoutUse   string = `logout <remote_name|registry_uri>`
-	RemoteLogoutShort string = `Log out from an Apptainer remote endpoint, an OCI/Docker registry or a keyserver`
+	RemoteLogoutShort string = `Log out from an Apptainer remote endpoint or an OCI/Docker registry`
 	RemoteLogoutLong  string = `
-  The 'remote logout' command allows you to log out from an Apptainer specific endpoint,
-  an OCI/Docker registry or a keyserver. If no endpoint or service is specified, it will
-  logout from the current active remote endpoint.
+  The 'remote logout' command allows you to log out from an Apptainer specific
+  endpoint or an OCI/Docker registry. If no endpoint or service is specified, it
+  will logout from the current active remote endpoint.
   `
 	RemoteLogoutExample string = `
   To log out from an endpoint
@@ -151,29 +150,4 @@ const (
   will be checked.`
 	RemoteStatusExample string = `
   $ apptainer remote status`
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// remote add-keyserver command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	RemoteAddKeyserverUse   string = `add-keyserver [options] [remoteName] <keyserver_url>`
-	RemoteAddKeyserverShort string = `Add a keyserver (root user only)`
-	RemoteAddKeyserverLong  string = `
-  The 'remote add-keyserver' command allows to define additional keyserver. The --order
-  option can define the order of the keyserver for all related key operations, therefore
-  when specifying '--order 1' the keyserver is becoming the primary keyserver. If no endpoint
-  is specified, it will use the default remote endpoint.`
-	RemoteAddKeyserverExample string = `
-  $ apptainer remote add-keyserver https://keys.example.com
-
-  To add a keyserver to be used as the primary keyserver for the current endpoint
-  $ apptainer remote add-keyserver --order 1 https://keys.example.com`
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// remote remove-keyserver command
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	RemoteRemoveKeyserverUse   string = `remove-keyserver [remoteName] <keyserver_url>`
-	RemoteRemoveKeyserverShort string = `Remove a keyserver (root user only)`
-	RemoteRemoveKeyserverLong  string = `
-  The 'remote remove-keyserver' command allows to remove a defined keyserver from a specific
-  endpoint. If no endpoint is specified, it will use the default remote endpoint.`
-	RemoteRemoveKeyserverExample string = `
-  $ apptainer remote remove-keyserver https://keys.example.com`
 )

--- a/e2e/keyserver/keyserver.go
+++ b/e2e/keyserver/keyserver.go
@@ -1,0 +1,190 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package keyserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apptainer/apptainer/e2e/internal/e2e"
+	"github.com/apptainer/apptainer/e2e/internal/testhelper"
+)
+
+type ctx struct {
+	env e2e.TestEnv
+}
+
+func (c ctx) keyserver(t *testing.T) {
+	var (
+		apptainerKeyserver = "https://keys.openpgp.org"
+		testKeyserver      = "http://localhost:11371"
+		addKeyserver       = "keyserver add"
+		removeKeyserver    = "keyserver remove"
+	)
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		listLines  []string
+		expectExit int
+		profile    e2e.Profile
+	}{
+		{
+			name:       "add non privileged",
+			command:    addKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 255,
+			profile:    e2e.UserProfile,
+		},
+		{
+			name:    "add without order",
+			command: addKeyserver,
+			args:    []string{"--insecure", testKeyserver},
+			listLines: []string{
+				"DefaultRemote*",
+				"   #1  https://keys.openpgp.org  🔒",
+				"   #2  http://localhost:11371",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "remove previous",
+			command:    removeKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "remove non-existent",
+			command:    removeKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "add with order 0",
+			command:    addKeyserver,
+			args:       []string{"--order", "0", testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:    "add with order 1",
+			command: addKeyserver,
+			args:    []string{"--order", "1", testKeyserver},
+			listLines: []string{
+				"DefaultRemote*",
+				"   #1  http://localhost:11371    🔒",
+				"   #2  https://keys.openpgp.org  🔒",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "add duplicate",
+			command:    addKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:    "remove apptainer",
+			command: removeKeyserver,
+			args:    []string{apptainerKeyserver},
+			listLines: []string{
+				"DefaultRemote*",
+				"   #1  http://localhost:11371  🔒",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "remove primary KO",
+			command:    removeKeyserver,
+			args:       []string{testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:    "add restore apptainer",
+			command: addKeyserver,
+			args:    []string{apptainerKeyserver},
+			listLines: []string{
+				"DefaultRemote*",
+				"   #1  http://localhost:11371    🔒",
+				"   #2  https://keys.openpgp.org  🔒",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:    "remove primary OK",
+			command: removeKeyserver,
+			args:    []string{testKeyserver},
+			listLines: []string{
+				"DefaultRemote*",
+				"   #1  https://keys.openpgp.org  🔒",
+			},
+			expectExit: 0,
+			profile:    e2e.RootProfile,
+		},
+		{
+			name:       "add out of order",
+			command:    addKeyserver,
+			args:       []string{"--order", "100", testKeyserver},
+			expectExit: 255,
+			profile:    e2e.RootProfile,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(tt.profile),
+			e2e.WithCommand(tt.command),
+			e2e.WithArgs(tt.args...),
+			e2e.PostRun(func(t *testing.T) {
+				if t.Failed() || len(tt.listLines) == 0 {
+					return
+				}
+				c.env.RunApptainer(
+					t,
+					e2e.WithProfile(e2e.UserProfile),
+					e2e.WithCommand("keyserver list"),
+					e2e.ExpectExit(
+						0,
+						e2e.ExpectOutput(
+							e2e.ContainMatch,
+							strings.Join(tt.listLines, "\n"),
+						),
+					),
+				)
+			}),
+			e2e.ExpectExit(tt.expectExit),
+		)
+	}
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+	c := ctx{
+		env: env,
+	}
+
+	np := testhelper.NoParallel
+
+	return testhelper.Tests{
+		"keyserver": np(c.keyserver),
+	}
+}

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -40,6 +40,7 @@ import (
 	"github.com/apptainer/apptainer/e2e/inspect"
 	"github.com/apptainer/apptainer/e2e/instance"
 	"github.com/apptainer/apptainer/e2e/key"
+	"github.com/apptainer/apptainer/e2e/keyserver"
 	"github.com/apptainer/apptainer/e2e/legacy"
 	"github.com/apptainer/apptainer/e2e/oci"
 	"github.com/apptainer/apptainer/e2e/overlay"
@@ -213,6 +214,7 @@ func Run(t *testing.T) {
 	suite.AddGroup("INSPECT", inspect.E2ETests)
 	suite.AddGroup("INSTANCE", instance.E2ETests)
 	suite.AddGroup("KEY", key.E2ETests)
+	suite.AddGroup("KEYSERVER", keyserver.E2ETests)
 	suite.AddGroup("LEGACY", legacy.E2ETests)
 	suite.AddGroup("OCI", oci.E2ETests)
 	suite.AddGroup("OVERLAY", overlay.E2ETests)

--- a/internal/app/apptainer/keyserver_add.go
+++ b/internal/app/apptainer/keyserver_add.go
@@ -20,7 +20,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 )
 
-func RemoteRemoveKeyserver(name, uri string) error {
+func KeyserverAdd(name, uri string, order uint32, insecure bool) error {
 	// Explicit handling of corner cases: name and uri must be valid strings
 	if strings.TrimSpace(uri) == "" {
 		return fmt.Errorf("invalid URI: cannot have empty URI")
@@ -53,7 +53,7 @@ func RemoteRemoveKeyserver(name, uri string) error {
 		return fmt.Errorf("current endpoint is not a system defined endpoint")
 	}
 
-	if err := ep.RemoveKeyserver(uri); err != nil {
+	if err := ep.AddKeyserver(uri, order, insecure); err != nil {
 		return err
 	}
 

--- a/internal/app/apptainer/keyserver_list.go
+++ b/internal/app/apptainer/keyserver_list.go
@@ -1,0 +1,77 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package apptainer
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/apptainer/apptainer/internal/pkg/remote"
+)
+
+// KeyserverList prints information about remote configurations
+func KeyserverList(remoteName string, usrConfigFile string) (err error) {
+	c := &remote.Config{}
+
+	// opening config file
+	file, err := os.OpenFile(usrConfigFile, os.O_RDONLY|os.O_CREATE, 0o600)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no remote configurations")
+		}
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	// read file contents to config struct
+	c, err = remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing remote config data: %s", err)
+	}
+
+	if err := syncSysConfig(c); err != nil {
+		return err
+	}
+
+	for epName, ep := range c.Remotes {
+		fmt.Println()
+		isSystem := ""
+		if ep.System {
+			isSystem = "*"
+		}
+		fmt.Printf("%s%s\n", epName, isSystem)
+
+		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		if err := ep.UpdateKeyserversConfig(); err != nil {
+			fmt.Fprintln(tw, " \t(unable to fetch associated keyserver info for this endpoint)")
+		}
+
+		order := 1
+		for _, kc := range ep.Keyservers {
+			if kc.Skip {
+				continue
+			}
+			secure := "🔒"
+			if kc.Insecure {
+				secure = ""
+			}
+			fmt.Fprintf(tw, " \t#%d\t%s\t%s\n", order, kc.URI, secure)
+			order++
+		}
+		tw.Flush()
+	}
+
+	fmt.Println()
+	fmt.Println("(* = system endpoint)")
+
+	return nil
+}

--- a/internal/app/apptainer/keyserver_logout.go
+++ b/internal/app/apptainer/keyserver_logout.go
@@ -1,0 +1,63 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package apptainer
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/apptainer/apptainer/internal/pkg/remote"
+)
+
+// KeyserverLogout logs out from a keyserver.
+func KeyserverLogout(usrConfigFile, name string) (err error) {
+	// opening config file
+	file, err := os.OpenFile(usrConfigFile, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	// read file contents to config struct
+	c, err := remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing remote config data: %s", err)
+	}
+
+	if err := syncSysConfig(c); err != nil {
+		return err
+	}
+
+	// services
+	if err := c.Logout(name); err != nil {
+		return fmt.Errorf("while verifying token: %v", err)
+	}
+
+	// truncating file before writing new contents and syncing to commit file
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("while truncating remote config file: %s", err)
+	}
+
+	if n, err := file.Seek(0, io.SeekStart); err != nil || n != 0 {
+		return fmt.Errorf("failed to reset %s cursor: %s", file.Name(), err)
+	}
+
+	if _, err := c.WriteTo(file); err != nil {
+		return fmt.Errorf("while writing remote config to file: %s", err)
+	}
+
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
+	}
+
+	return nil
+}

--- a/internal/app/apptainer/keyserver_remove.go
+++ b/internal/app/apptainer/keyserver_remove.go
@@ -1,0 +1,78 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package apptainer
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/apptainer/apptainer/internal/pkg/remote"
+	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
+)
+
+func KeyserverRemove(name, uri string) error {
+	// Explicit handling of corner cases: name and uri must be valid strings
+	if strings.TrimSpace(uri) == "" {
+		return fmt.Errorf("invalid URI: cannot have empty URI")
+	}
+
+	// opening config file
+	file, err := os.OpenFile(remote.SystemConfigPath, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("while opening remote config file: %s", err)
+	}
+	defer file.Close()
+
+	// read file contents to config struct
+	c, err := remote.ReadFrom(file)
+	if err != nil {
+		return fmt.Errorf("while parsing remote config data: %s", err)
+	}
+
+	var ep *endpoint.Config
+
+	if name == "" {
+		ep, err = c.GetDefault()
+	} else {
+		ep, err = c.GetRemote(name)
+	}
+
+	if err != nil {
+		return fmt.Errorf("no endpoint found: %s", err)
+	} else if !ep.System {
+		return fmt.Errorf("current endpoint is not a system defined endpoint")
+	}
+
+	if err := ep.RemoveKeyserver(uri); err != nil {
+		return err
+	}
+
+	// truncating file before writing new contents and syncing to commit file
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("while truncating remote config file: %s", err)
+	}
+
+	if n, err := file.Seek(0, io.SeekStart); err != nil || n != 0 {
+		return fmt.Errorf("failed to reset %s cursor: %s", file.Name(), err)
+	}
+
+	if _, err := c.WriteTo(file); err != nil {
+		return fmt.Errorf("while writing remote config to file: %s", err)
+	}
+
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("failed to flush remote config file %s: %s", file.Name(), err)
+	}
+
+	return nil
+}

--- a/internal/app/apptainer/remote_list.go
+++ b/internal/app/apptainer/remote_list.go
@@ -2,8 +2,8 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -90,39 +90,6 @@ func RemoteList(usrConfigFile string) (err error) {
 		fmt.Fprintf(tw, listLine, n, c.Remotes[n].URI, active, sys, excl, insec)
 	}
 	tw.Flush()
-
-	if ep, err := c.GetDefault(); err == nil {
-		if err := ep.UpdateKeyserversConfig(); err == nil {
-			fmt.Println()
-			fmt.Println("Keyservers")
-			fmt.Println("==========")
-			fmt.Println()
-
-			tw = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", "URI", "GLOBAL", "INSECURE", "ORDER")
-			order := 1
-			for _, kc := range ep.Keyservers {
-				if kc.Skip {
-					continue
-				}
-				insecure := "NO"
-				if kc.Insecure {
-					insecure = "YES"
-				}
-				fmt.Fprintf(tw, "%s\tYES\t%s\t%d", kc.URI, insecure, order)
-				if !kc.External {
-					fmt.Fprintf(tw, "*\n")
-				} else {
-					fmt.Fprintf(tw, "\n")
-				}
-				order++
-			}
-			tw.Flush()
-
-			fmt.Println()
-			fmt.Println("* Active cloud services keyserver")
-		}
-	}
 
 	if len(c.Credentials) > 0 {
 		fmt.Println()


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1905
    which fixed
- sylabs/singularity#1893

The original PR description was:

>   Moves the operations relating to keyservers - adding them, listing them, and removing them - from subcommands of the remote command (singularity remote add-keyserver, singularity remote remove-keyserver, etc.) to their own dedicated command, keyserver (singularity keyserver add, singularity keyserver remove, etc.). See the output of singularity help keyserver for more information.
>
> Also changes the format of the keyserver list output (now generated via singularity keyserver list) in accordance with option (a) outlined in sylabs/singularity#1639

