### PR TITLE
Remove non-runtime libraries from rocmliblist.conf

### DIFF
--- a/etc/rocmliblist.conf
+++ b/etc/rocmliblist.conf
@@ -16,9 +16,6 @@ libcomgr.so
 libCXLActivityLogger.so
 libelf.so
 libhc_am.so
-libhipblas.so
-libhip_hcc.so
-libhiprand.so
 libhsakmt.so
 libhsa-runtime64.so
 libmcwamp.so
@@ -30,11 +27,6 @@ libdrm.so
 libdrm_amdgpu.so
 libnuma.so
 libpci.so
-librccl.so
-librocblas.so
-librocfft-device.so
-librocfft.so
-librocrand.so
 librocr_debug_agent64.so
 
 libamdcomgr64.so


### PR DESCRIPTION
## Description of the Pull Request (PR):

The GPU integration should provide only the necessary runtime library components to execute kernels.
Additional libraries like rocBLAS etc. should be provided by the container.


### This fixes or addresses the following GitHub issues:

 - Fixes #1621


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
