### PR TITLE
Remove Requires: fuse (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix `$APPTAINER_MESSAGELEVEL` to correctly set the logging level.
 - Fix build failures when in setuid mode and unprivileged user namespaces
   are unavailable and the `--fakeroot` option is not selected.
+- Remove `Requires: fuse` from rpm packaging.
 
 ## v1.2.1 - \[2023-07-24\]
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -113,8 +113,6 @@ Requires: squashfuse
 Requires: fakeroot
 Requires: fuse-overlayfs
 Requires: e2fsprogs
-# only gocryptfs requires fuse
-Requires: fuse
 # Uncomment this for the epel build, but we don't want it for the Apptainer
 #  release build because there the same rpm is shared across OS versions
 #%%if 0%{?el7}


### PR DESCRIPTION
This cherry-picks #1619 into the release-1.2 branch.