### PR TITLE
Stop using random build-ids

### DIFF
--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -185,7 +185,7 @@ fi
 # GOPROXY=off makes sure we fail instead of making network requests
 # the -B ldflags prevent rpm complaints about "No build ID note found"
 CGO_ENABLED=0 GOPROXY=off ./build.bash -mod=vendor -tags without_openssl \
-    -ldflags="-X main.GitVersion=%{gocryptfs_version} -B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`" 
+    -ldflags="-X main.GitVersion=%{gocryptfs_version} -B 0x12345678"
 popd
 %endif
 

--- a/mlocal/frags/go_normal_opts.mk
+++ b/mlocal/frags/go_normal_opts.mk
@@ -1,3 +1,3 @@
 # This tells go's link command to add a GNU Build Id, needed for later
 #   symbol stripping for example as is done by rpmbuild.
-GO_LDFLAGS += -ldflags="-B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`"
+GO_LDFLAGS += -ldflags="-B 0x12345678"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Stop using random build-ids
to use the default deterministic build-ids instead. This allows for reproducible builds.


### This fixes or addresses the following GitHub issues:

 - Fixes: #1623

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)

#### other

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).
