### PR TITLE
Fix typos found by codespell

### DIFF
--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -792,7 +792,7 @@ func apptainerExec(image string, args []string) (string, error) {
 		return "", fmt.Errorf("while determining absolute path for %s: %v", image, err)
 	}
 
-	// re-use apptainer exec to grab image file content,
+	// reuse apptainer exec to grab image file content,
 	// we reduce binds to the bare minimum with options below
 	cmdArgs := []string{"exec", "--contain", "--no-home", "--no-nv", "--no-rocm", abspath}
 	cmdArgs = append(cmdArgs, args...)

--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -226,7 +226,7 @@ static struct capabilities *get_process_capabilities() {
     header.pid = 0;
 
     if ( capget(&header, data) < 0 ) {
-        fatalf("Failed to get processus capabilities\n");
+        fatalf("Failed to get process capabilities\n");
     }
 
     current->permitted = ((unsigned long long)data[1].permitted << 32) | data[0].permitted;

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -93,7 +93,7 @@ func (c actionTests) actionRun(t *testing.T) {
 	}
 }
 
-// actionExec tests min fuctionality for apptainer exec
+// actionExec tests min functionality for apptainer exec
 func (c actionTests) actionExec(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
@@ -206,7 +206,7 @@ func (c actionTests) actionExec(t *testing.T) {
 	}
 }
 
-// actionExecMultiProfile tests fuctionality using apptainer exec under all native profiles that do not involve user namespaces.
+// actionExecMultiProfile tests functionality using apptainer exec under all native profiles that do not involve user namespaces.
 func (c actionTests) actionExecMultiProfile(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
@@ -423,7 +423,7 @@ func (c actionTests) STDPipe(t *testing.T) {
 			input:   "false",
 			exit:    1,
 		},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:    "TrueShub",
 		// 	command: "shell",
@@ -431,7 +431,7 @@ func (c actionTests) STDPipe(t *testing.T) {
 		// 	input:   "true",
 		// 	exit:    0,
 		// },
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:    "FalseShub",
 		// 	command: "shell",
@@ -546,7 +546,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			exit:    0,
 			profile: e2e.UserProfile,
 		},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:    "RunFromShubOK",
 		// 	command: "run",
@@ -568,7 +568,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			exit:    1,
 			profile: e2e.UserProfile,
 		},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:    "RunFromShubKO",
 		// 	command: "run",
@@ -583,7 +583,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			exit:    1,
 			profile: e2e.UserProfile,
 		},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:    "ExecTrueShub",
 		// 	command: "exec",
@@ -605,7 +605,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			exit:    1,
 			profile: e2e.UserProfile,
 		},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:    "ExecFalseShub",
 		// 	command: "exec",
@@ -629,7 +629,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			exit:    0,
 			profile: e2e.UserNamespaceProfile,
 		},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:    "ExecTrueShubUserns",
 		// 	command: "exec",
@@ -651,7 +651,7 @@ func (c actionTests) RunFromURI(t *testing.T) {
 			exit:    1,
 			profile: e2e.UserNamespaceProfile,
 		},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:    "ExecFalseShubUserns",
 		// 	command: "exec",

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -82,12 +82,12 @@ func (c imgBuildTests) buildFrom(t *testing.T) {
 				require.Command(t, "debootstrap")
 			},
 		},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:       "ShubURI",
 		// 	buildSpec:  "shub://GodloveD/busybox",
 		// },
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {
 		// 	name:       "ShubDefFile",
 		// 	buildSpec:  "../examples/shub/Apptainer",

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -288,7 +288,7 @@ func (c ctx) testPullCmd(t *testing.T) {
 			unauthenticated:  false,
 			expectedExitCode: 0,
 		},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		{
 			desc:             "image from shub",
 			srcURI:           "shub://GodloveD/busybox",

--- a/e2e/testdata/Apptainer
+++ b/e2e/testdata/Apptainer
@@ -12,7 +12,7 @@ from: ghcr.io/apptainer/alpine:3.15.0
     GOPATH=/go
     PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
     CGO_ENABLED=0
-    AVENGERS=asemble
+    AVENGERS=assemble
     export GOPATH PATH CGO_ENABLED AVENGERS
 
 %setup

--- a/internal/pkg/build/assemblers/sandbox_test.go
+++ b/internal/pkg/build/assemblers/sandbox_test.go
@@ -80,7 +80,7 @@ func TestSandboxAssemblerShub(t *testing.T) {
 		t.SkipNow()
 	}
 
-	// TODO(mem): reenable this; disabled while shub is down
+	// TODO(mem): re-enable this; disabled while shub is down
 	t.Skip("Skipping tests that access singularity hub")
 
 	b, err := types.NewBundle(filepath.Join(os.TempDir(), "sbuild-sandboxAssembler"), os.TempDir())

--- a/internal/pkg/build/assemblers/sif_test.go
+++ b/internal/pkg/build/assemblers/sif_test.go
@@ -97,7 +97,7 @@ func TestSIFAssemblerShub(t *testing.T) {
 		t.SkipNow()
 	}
 
-	// TODO(mem): reenable this; disabled while shub is down
+	// TODO(mem): re-enable this; disabled while shub is down
 	t.Skip("Skipping tests that access singularity hub")
 
 	mksquashfsPath, err := exec.LookPath("mksquashfs")

--- a/internal/pkg/build/sources/conveyorPacker_shub_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub_test.go
@@ -26,7 +26,7 @@ const (
 
 // TestShubConveyor tests if we can pull an image from singularity hub
 func TestShubConveyor(t *testing.T) {
-	// TODO(mem): reenable this; disabled while shub is down
+	// TODO(mem): re-enable this; disabled while shub is down
 	t.Skip("Skipping tests that access singularity hub")
 
 	if testing.Short() {
@@ -58,7 +58,7 @@ func TestShubConveyor(t *testing.T) {
 
 // TestShubPacker checks if we can create a Bundle from the pulled image
 func TestShubPacker(t *testing.T) {
-	// TODO(mem): reenable this; disabled while shub is down
+	// TODO(mem): re-enable this; disabled while shub is down
 	t.Skip("Skipping tests that access singularity hub")
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/internal/pkg/client/shub/pull_test.go
+++ b/internal/pkg/client/shub/pull_test.go
@@ -24,7 +24,7 @@ const (
 
 // TestDownloadImage tests if we can pull an image from Singularity Hub
 func TestDownloadImage(t *testing.T) {
-	// TODO(mem): reenable this; disabled while shub is down
+	// TODO(mem): re-enable this; disabled while shub is down
 	t.Skip("Skipping tests that access singularity hub")
 
 	if testing.Short() {

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -57,14 +57,14 @@ type File struct {
 	Checkpoint string `json:"checkpoint"`
 }
 
-// ProcName returns processus name based on instance name
+// ProcName returns process name based on instance name
 // and username
 func ProcName(name string, username string) (string, error) {
 	if err := CheckName(name); err != nil {
 		return "", fmt.Errorf("while checking instance name: %s", err)
 	}
 	if username == "" {
-		return "", fmt.Errorf("while getting instance processus name: empty username")
+		return "", fmt.Errorf("while getting instance process name: empty username")
 	}
 	return fmt.Sprintf(prognameFormat, ProgPrefix, username, name), nil
 }

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -867,7 +867,7 @@ func (c *container) mountImage(mnt *mount.Point) error {
 	sylog.Debugf("Mounting loop device %s to %s of type %s\n", path, mnt.Destination, mnt.Type)
 
 	if mountType == "encryptfs" {
-		// pass the master processus ID only if a container IPC
+		// pass the master process ID only if a container IPC
 		// namespace was requested because cryptsetup requires
 		// to run in the host IPC namespace
 		masterPid := 0
@@ -2138,7 +2138,7 @@ func (c *container) addCwdMount(system *mount.System) error {
 		sylog.Verbosef("Not mounting CWD (already mounted in container): %s", cwdHost)
 		return nil
 	} else if cwdHostSymlink && cwdContainerSymlink && cwdContainerResolved != cwdHostResolved {
-		// symlink case when both destination exists on host and in container but are differents
+		// symlink case when both destinations exist on host and in container but are different
 		sylog.Verbosef("Not mounting CWD, detected symlinks with different destination between host/container")
 		return nil
 	}

--- a/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
@@ -111,7 +111,7 @@ func (t *Methods) Decrypt(arguments *args.CryptArgs, reply *string) (err error) 
 
 		// cryptsetup requires to run in the host IPC namespace
 		// so we enter temporarily in the host IPC namespace
-		// via the master processus ID if its greater than zero
+		// via the master process ID if its greater than zero
 		// which means that a container IPC namespace was requested
 		if err := namespaces.Enter(arguments.MasterPid, "ipc"); err != nil {
 			return fmt.Errorf("while joining host IPC namespace: %s", err)

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -1277,7 +1277,7 @@ func convertImage(filename string, unsquashfsPath string, tmpDir string) (rootfs
 	// Nice message if we have been given an older ext3 image, which cannot be extracted due to lack of privilege
 	// to loopback mount.
 	if part.Type == imgutil.EXT3 {
-		sylog.Errorf("File %q is an ext3 format continer image.", filename)
+		sylog.Errorf("File %q is an ext3 format container image.", filename)
 		sylog.Errorf("Only SIF and squashfs images can be extracted in unprivileged mode.")
 		sylog.Errorf("Use `apptainer build` to convert this image to a SIF file using a setuid install of Apptainer.")
 	}

--- a/internal/pkg/util/env/create_test.go
+++ b/internal/pkg/util/env/create_test.go
@@ -654,7 +654,7 @@ func TestSetContainerEnv(t *testing.T) {
 			},
 		},
 		{
-			name:     "suppress the info message when both legecy and new env coexist",
+			name:     "suppress the info message when both legacy and new env coexist",
 			cleanEnv: false,
 			homeDest: "/home/tester",
 			env: []string{
@@ -670,7 +670,7 @@ func TestSetContainerEnv(t *testing.T) {
 			},
 		},
 		{
-			name:     "should print info message if only legecy env exists",
+			name:     "should print info message if only legacy env exists",
 			cleanEnv: false,
 			homeDest: "/home/tester",
 			env: []string{

--- a/internal/pkg/util/paths/resolve.go
+++ b/internal/pkg/util/paths/resolve.go
@@ -47,7 +47,7 @@ func soLinks(libPath string) (paths []string, err error) {
 		if resolvedLib, err := filepath.EvalSymlinks(lPath); err == nil {
 			if resolvedLib == libPath {
 				// symlinkCandidate resolves (eventually) to required lib
-				sylog.Debugf("Idenfified %s as a symlink for %s", lPath, libPath)
+				sylog.Debugf("Identified %s as a symlink for %s", lPath, libPath)
 				paths = append(paths, lPath)
 			}
 		} else {

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -36,7 +36,7 @@ func TestScanDefinitionFile(t *testing.T) {
 		{"Fingerprint", "testdata_good/fingerprint/fingerprint", "testdata_good/fingerprint/fingerprint_sections.json"},
 		{"LocalImage", "testdata_good/localimage/localimage", "testdata_good/localimage/localimage_sections.json"},
 		{"Scratch", "testdata_good/scratch/scratch", "testdata_good/scratch/scratch_sections.json"},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
 		{"Yum", "testdata_good/yum/yum", "testdata_good/yum/yum_sections.json"},
 		{"Zypper", "testdata_good/zypper/zypper", "testdata_good/zypper/zypper_sections.json"},
@@ -179,7 +179,7 @@ func TestParseDefinitionFile(t *testing.T) {
 		{"Fingerprint", "testdata_good/fingerprint/fingerprint", "testdata_good/fingerprint/fingerprint.json"},
 		{"LocalImage", "testdata_good/localimage/localimage", "testdata_good/localimage/localimage.json"},
 		{"Scratch", "testdata_good/scratch/scratch", "testdata_good/scratch/scratch.json"},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub.json"},
 		{"Yum", "testdata_good/yum/yum", "testdata_good/yum/yum.json"},
 		{"Zypper", "testdata_good/zypper/zypper", "testdata_good/zypper/zypper.json"},
@@ -344,7 +344,7 @@ func TestIsValidDefinition(t *testing.T) {
 		{"Docker", "testdata_good/docker/docker", "testdata_good/docker/docker_sections.json"},
 		{"LocalImage", "testdata_good/localimage/localimage", "testdata_good/localimage/localimage_sections.json"},
 		{"Scratch", "testdata_good/scratch/scratch", "testdata_good/scratch/scratch_sections.json"},
-		// TODO(mem): reenable this; disabled while shub is down
+		// TODO(mem): re-enable this; disabled while shub is down
 		// {"Shub", "testdata_good/shub/shub", "testdata_good/shub/shub_sections.json"},
 		{"Yum", "testdata_good/yum/yum", "testdata_good/yum/yum_sections.json"},
 		{"Zypper", "testdata_good/zypper/zypper", "testdata_good/zypper/zypper_sections.json"},

--- a/pkg/image/ext3_test.go
+++ b/pkg/image/ext3_test.go
@@ -21,8 +21,8 @@ import (
 // createVirtualBlockDevice creates a virtual block device
 // in a file using the dd command. The test is skipped if
 // the command is not available.
-// @parma[in] test handle to control the test, i.e., stop it in case of fatal error
-// @parma[in] path to the virtual block device to be created
+// @param[in] test handle to control the test, i.e., stop it in case of fatal error
+// @param[in] path to the virtual block device to be created
 func createVirtualBlockDevice(t *testing.T, path string) {
 	cmdBin, err := exec.LookPath("dd")
 	if err != nil {

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -201,7 +201,7 @@ latesturl()
 		URL="$URL/${2:0:1}"
 	fi
 	if [ "$URL" != "$LASTURL" ]; then
-		# optimization: re-use last list if it hasn't changed
+		# optimization: reuse last list if it hasn't changed
 		LASTURL="$URL"
 		LASTPKGS="$(curl -Ls "$URL")"
 	elif [ $RETRY -gt 0 ]; then


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix typos found by codespell.

If `splitted->split` is too intrusive, I can revert or defer to a later merge request.

Not sure about `asemble`, is this misspelling on purpose?
https://github.com/apptainer/apptainer/blob/d4ef5cb491a84573fa7faa8fb7e8ae11bfbe28d5/e2e/testdata/Apptainer#L15

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
