### PR TITLE
Fix the use of APPTAINER_CONFIGDIR with instance start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 ### Bug fixes
 
 - Ignore undefined macros to fix yum bootstrap agent broken issue.
+- Fix the use of `APPTAINER_CONFIGDIR` with `apptainer instance start`.
 
 ## v1.2.2 - \[2023-07-27\]
 

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -91,19 +91,22 @@ func getPath(username string, subDir string) (string, error) {
 	}
 
 	var u *user.User
+	var configDir string
 	if username == "" {
 		u, err = user.CurrentOriginal()
+		if err != nil {
+			return "", err
+		}
+		configDir = syfs.ConfigDir()
 	} else {
 		u, err = user.GetPwNam(username)
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	configDir, err := syfs.ConfigDirForUsername(u.Name)
-	if err != nil {
-		return "", err
+		if err != nil {
+			return "", err
+		}
+		configDir, err = syfs.ConfigDirForUsername(u.Name)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	return filepath.Join(configDir, instancePath, subDir, hostname, u.Name), nil


### PR DESCRIPTION
This makes setting `$APPTAINER_CONFIGDIR` work with `apptainer instance start`.

- Fixes #1665 