### PR TITLE
Fix the use of APPTAINER_CONFIGDIR with instance start (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - The `apptainer push/pull` command will show a progress bar for oras protocol.
 - The `--nv` and `--rocm` flags can now be used simultaneously.
+- Fix the use of `APPTAINER_CONFIGDIR` with `apptainer instance start`.
 
 ## v1.2.2 - \[2023-07-27\]
 

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -91,19 +91,22 @@ func getPath(username string, subDir string) (string, error) {
 	}
 
 	var u *user.User
+	var configDir string
 	if username == "" {
 		u, err = user.CurrentOriginal()
+		if err != nil {
+			return "", err
+		}
+		configDir = syfs.ConfigDir()
 	} else {
 		u, err = user.GetPwNam(username)
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	configDir, err := syfs.ConfigDirForUsername(u.Name)
-	if err != nil {
-		return "", err
+		if err != nil {
+			return "", err
+		}
+		configDir, err = syfs.ConfigDirForUsername(u.Name)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	return filepath.Join(configDir, instancePath, subDir, hostname, u.Name), nil


### PR DESCRIPTION
This cherry-picks #1666 to the release-1.2 branch.