### PR TITLE
fix issue apptainer will not read credentials from fallback path (release-1.2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - The `--nv` and `--rocm` flags can now be used simultaneously.
 - Fix the use of `APPTAINER_CONFIGDIR` with `apptainer instance start`.
 - Ignore undefined macros to fix yum bootstrap agent broken issue.
+- Fix the issue that apptainer will not read credentials from Docker fallback path.
 
 ## v1.2.2 - \[2023-07-27\]
 

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -92,7 +92,7 @@ func getResolver(ctx context.Context, ociAuth *ocitypes.DockerAuthConfig, noHTTP
 		return docker.NewResolver(opts), nil
 	}
 
-	cli, err := oras_docker.NewClient(syfs.DockerConf())
+	cli, err := oras_docker.NewClientWithDockerFallback(syfs.DockerConf())
 	if err != nil {
 		sylog.Warningf("Couldn't load auth credential file: %s", err)
 		return docker.NewResolver(opts), nil

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -75,7 +75,7 @@ func (h *ociHandler) login(u *url.URL, username, password string, insecure bool)
 	if err != nil {
 		return nil, err
 	}
-	cli, err := docker.NewClient(syfs.DockerConf())
+	cli, err := docker.NewClientWithDockerFallback(syfs.DockerConf())
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (h *ociHandler) login(u *url.URL, username, password string, insecure bool)
 }
 
 func (h *ociHandler) logout(u *url.URL) error {
-	cli, err := docker.NewClient(syfs.DockerConf())
+	cli, err := docker.NewClientWithDockerFallback(syfs.DockerConf())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry pick PR
https://github.com/apptainer/apptainer/pull/1664

### This fixes or addresses the following GitHub issues:

 - Fixes #1616 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
