### PR TITLE
Really fix the use of APPTAINER_CONFIGDIR with instance start

### DIFF
--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -402,6 +402,23 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 					for _, tt := range tests {
 						t.Run(tt.name, tt.function)
 					}
+					dir, err := os.MkdirTemp(c.env.TestDir, "MoveInstanceConfig")
+					if err != nil {
+						t.Fatalf("Failed to create temporary directory: %v", err)
+					}
+					defer os.RemoveAll(dir)
+					defer os.Unsetenv("APPTAINER_CONFIGDIR")
+					os.Setenv("APPTAINER_CONFIGDIR", dir)
+					for _, tt := range tests {
+						t.Run(tt.name+"Moved", tt.function)
+					}
+					t.Run("CheckInstanceDirMoved", func(t *testing.T) {
+						e2e.Privileged(func(t *testing.T) {
+							if _, err := os.Stat(dir + "/instances/app"); err != nil {
+								t.Fatalf("failed %v", err)
+							}
+						})(t)
+					})
 				})
 			}
 		},

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -665,6 +665,9 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 //
 //nolint:maintidx
 func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Config) error {
+	// import APPTAINER_CONFIGDIR from original environment if set
+	e.setEnvAppVar("CONFIGDIR")
+
 	name := instance.ExtractName(e.EngineConfig.GetImage())
 	file, err := instance.Get(name, instance.AppSubDir)
 	if err != nil {


### PR DESCRIPTION
This is a continuation of #1666 to fix the use of APPTAINER_CONFIGDIR with `apptainer instance start`.  Also includes e2e tests.
- Fixes #1665