### PR TITLE
Fix the use of APPTAINER_CONFIGDIR with instance start and run (release-1.2)

### DIFF
--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -45,6 +45,7 @@ func (c *ctx) stopInstance(t *testing.T, instance string, stopArgs ...string) (s
 		e2e.WithProfile(c.profile),
 		e2e.WithCommand("instance stop"),
 		e2e.WithArgs(args...),
+		e2e.WithEnv(c.withEnv),
 		e2e.PostRun(func(t *testing.T) {
 			success = !t.Failed()
 		}),
@@ -65,6 +66,7 @@ func (c *ctx) execInstance(t *testing.T, instance string, execArgs ...string) (s
 		e2e.WithProfile(c.profile),
 		e2e.WithCommand("exec"),
 		e2e.WithArgs(args...),
+		e2e.WithEnv(c.withEnv),
 		e2e.PostRun(func(t *testing.T) {
 			success = !t.Failed()
 		}),
@@ -92,6 +94,7 @@ func (c *ctx) expectInstance(t *testing.T, name string, nb int) {
 		e2e.WithProfile(c.profile),
 		e2e.WithCommand("instance list"),
 		e2e.WithArgs([]string{"--json", name}...),
+		e2e.WithEnv(c.withEnv),
 		e2e.ExpectExit(0, listInstancesFn),
 	)
 }

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -665,6 +665,8 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 //
 //nolint:maintidx
 func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Config) error {
+	os.Setenv("APPTAINER_CONFIGDIR", e.EngineConfig.GetConfigDir())
+
 	name := instance.ExtractName(e.EngineConfig.GetImage())
 	file, err := instance.Get(name, instance.AppSubDir)
 	if err != nil {

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -347,6 +347,8 @@ func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error 
 	}
 
 	if e.EngineConfig.GetInstance() {
+		os.Setenv("APPTAINER_CONFIGDIR", e.EngineConfig.GetConfigDir())
+
 		name := e.CommonConfig.ContainerID
 
 		if err := os.Chdir("/"); err != nil {

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -45,6 +45,7 @@ import (
 	apptainercallback "github.com/apptainer/apptainer/pkg/plugin/callback/runtime/engine/apptainer"
 	apptainerConfig "github.com/apptainer/apptainer/pkg/runtime/engine/apptainer/config"
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
+	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 	"github.com/apptainer/apptainer/pkg/util/capabilities"
@@ -267,6 +268,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	// Additional directory overrides.
 	l.engineConfig.SetScratchDir(l.cfg.ScratchDirs)
 	l.engineConfig.SetWorkdir(l.cfg.WorkDir)
+	l.engineConfig.SetConfigDir(syfs.ConfigDir())
 
 	// Container networking configuration.
 	l.engineConfig.SetNetwork(l.cfg.Network)

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -97,6 +97,7 @@ type JSONConfig struct {
 	Image                 string            `json:"image"`
 	ImageArg              string            `json:"imageArg"`
 	Workdir               string            `json:"workdir,omitempty"`
+	ConfigDir             string            `json:"configdir,omitempty"`
 	CgroupsJSON           string            `json:"cgroupsJSON,omitempty"`
 	HomeSource            string            `json:"homedir,omitempty"`
 	HomeDest              string            `json:"homeDest,omitempty"`
@@ -261,6 +262,17 @@ func (e *EngineConfig) SetWorkdir(name string) {
 // GetWorkdir retrieves the work directory path.
 func (e *EngineConfig) GetWorkdir() string {
 	return e.JSON.Workdir
+}
+
+// SetConfigDir sets a config directory path.
+func (e *EngineConfig) SetConfigDir(name string) {
+	e.JSON.ConfigDir = name
+}
+
+// GetConfigDir retrieves the config directory path if it is set, or
+// otherwise an empty string.
+func (e *EngineConfig) GetConfigDir() string {
+	return e.JSON.ConfigDir
 }
 
 // SetScratchDir set a scratch directory path.


### PR DESCRIPTION
This cherry-picks #1679 to the release-1.2 branch.