### PR TITLE
Change UnshareRootMapped to usually not unshare the mount namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.2.x
 
+- Fixed a problem with relocating an unprivileged installation of
+  apptainer on el8 and a mounted remote filesystem when using the
+  `--fakeroot` option without `/etc/subuid` mapping.  The fix was to
+  change the switch to an unprivileged root-mapped namespace to be the
+  equivalent of `unshare -r` instead of `unshare -rm`, to work around a
+  bug in the el8 kernel.
+
 ## v1.2.3 - \[2023-09-14\]
 
 - The `apptainer push/pull` commands now show a progress bar for the oras

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -91,7 +91,7 @@ func fakerootExec(isDeffile, unprivEncrypt bool) {
 		if buildArgs.ignoreUserns {
 			err = errors.New("could not start root-mapped namespace because --ignore-userns is set")
 		} else {
-			err = fakeroot.UnshareRootMapped(args)
+			err = fakeroot.UnshareRootMapped(args, unprivEncrypt)
 		}
 		if err == nil {
 			// All the work has been done by the child process

--- a/internal/app/apptainer/overlay_create.go
+++ b/internal/app/apptainer/overlay_create.go
@@ -232,7 +232,7 @@ func OverlayCreate(size int, imgPath string, overlaySparse bool, isFakeroot bool
 			//  the fakeroot command (in suid flow with no user
 			//  namespaces), using the --fakeroot option here
 			//  prevents overlay from working, most unfortunately.
-			err = fakeroot.UnshareRootMapped([]string{"/bin/true"})
+			err = fakeroot.UnshareRootMapped([]string{"/bin/true"}, false)
 			if err != nil {
 				sylog.Debugf("UnshareRootMapped failed: %v", err)
 				if isFakeroot {
@@ -248,7 +248,7 @@ func OverlayCreate(size int, imgPath string, overlaySparse bool, isFakeroot bool
 
 		if isFakeroot {
 			sylog.Debugf("Trying root-mapped namespace")
-			err = fakeroot.UnshareRootMapped(os.Args)
+			err = fakeroot.UnshareRootMapped(os.Args, false)
 			if err == nil {
 				// everything was done by the child
 				os.Exit(0)

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -25,14 +25,17 @@ import (
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
-// re-exec the command effectively under unshare -rm
-func UnshareRootMapped(args []string) error {
+// re-exec the command effectively under unshare -r or unshare -rm
+func UnshareRootMapped(args []string, includeMountNamespace bool) error {
 	cmd := osExec.Command(args[0], args[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS
+	cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWUSER
+	if includeMountNamespace {
+		cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNS
+	}
 	cmd.SysProcAttr.UidMappings = []syscall.SysProcIDMap{
 		{ContainerID: 0, HostID: syscall.Getuid(), Size: 1},
 	}

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -135,7 +135,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 			if l.cfg.IgnoreUserns {
 				err = errors.New("could not start root-mapped namespace because --ignore-userns is set")
 			} else {
-				err = fakeroot.UnshareRootMapped(os.Args)
+				err = fakeroot.UnshareRootMapped(os.Args, false)
 			}
 			if err == nil {
 				// All good


### PR DESCRIPTION
This changes the `UnshareRootMapped` function to usually be the equivalent of `unshare -r` instead of `unshare -rm`.  The mount namespace was unnecessary except when building an encrypted container unprivileged, and it works around a problem with relocating an unprivileged apptainer installation on a remote filesystem, which occurred only on el8.  (The problem does not happen when building an encrypted container unprivileged).

- Fixes #1683 