### PR TITLE
Unshare mount namespace for all non-subuid fakeroot builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   apptainer on el8 and a mounted remote filesystem when using the
   `--fakeroot` option without `/etc/subuid` mapping.  The fix was to
   change the switch to an unprivileged root-mapped namespace to be the
-  equivalent of `unshare -r` instead of `unshare -rm`, to work around a
-  bug in the el8 kernel.
+  equivalent of `unshare -r` instead of `unshare -rm` on action commands,
+  to work around a bug in the el8 kernel.
 
 ## v1.2.3 - \[2023-09-14\]
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -91,7 +91,7 @@ func fakerootExec(isDeffile, unprivEncrypt bool) {
 		if buildArgs.ignoreUserns {
 			err = errors.New("could not start root-mapped namespace because --ignore-userns is set")
 		} else {
-			err = fakeroot.UnshareRootMapped(args, unprivEncrypt)
+			err = fakeroot.UnshareRootMapped(args, true)
 		}
 		if err == nil {
 			// All the work has been done by the child process

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -105,19 +105,6 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 			l.cfg.Namespaces.User = true
 			sylog.Debugf("running root-mapped unprivileged")
 			var err error
-			// Try to bind-mount the original user's home directory to /root.
-			// This may be overridden later by custom home directory settings,
-			// but this makes it available later as a source for the what it
-			// thinks of as the "original" user's home directory, if needed.
-			homedir := os.Getenv("HOME")
-			if homedir != "" {
-				err = syscall.Mount(homedir, "/root", "", syscall.MS_BIND, "")
-				if err != nil {
-					sylog.Debugf("Failure bind-mounting %s to /root: %v, skipping", homedir, err)
-				} else {
-					sylog.Debugf("Bind-mounting %s to /root", homedir)
-				}
-			}
 			if l.cfg.IgnoreFakerootCmd {
 				err = errors.New("fakeroot command is ignored because of --ignore-fakeroot-command")
 			} else {


### PR DESCRIPTION
This changes the `UnshareRootMapped` calls in non-subuid fakeroot builds to always unshare the mount namespace, not just when encrypting the container, because it was also being used to mount the user's home directory at `/root`.  This also removes the similar code mounting the user's home directory from fakeroot action commands because it isn't succeeding after #1687.  Build commands are not subject to the relocation problem that #1687 fixed, reported in #1683.

- Fixes #1689