### PR TITLE
Limit install-unprivileged.sh -o option to suse distributions

### DIFF
--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -98,6 +98,10 @@ if [ -z "$DIST" ]; then
 	fi
 fi
 
+if ! $NOOPENSUSE && [[ "$DIST" != *suse* ]]; then
+	fatal "The -o option is only relevant to suse-based distributions"
+fi
+
 if [ -z "$ARCH" ]; then
 	ARCH="$(arch)"
 fi


### PR DESCRIPTION
As mentioned in #1338, this prevents the`-o` option from interfering with non-suse distributions.