### PR TITLE
Extend timeout on golangci-lint

### DIFF
--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -294,7 +294,7 @@ var OciExecCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := apptainer.OciExec(args[0], args[1:]); err != nil {
+		if err := apptainer.OciExec(args[0], args[1:]); err != nil { //nolint:staticcheck
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/internal/app/apptainer/oci_exec_linux.go
+++ b/internal/app/apptainer/oci_exec_linux.go
@@ -20,7 +20,7 @@ import (
 )
 
 // OciExec executes a command in a container
-func OciExec(containerID string, cmdArgs []string) error {
+func OciExec(containerID string, cmdArgs []string) error { //nolint:staticcheck
 	commonConfig, err := getCommonConfig(containerID)
 	if err != nil {
 		return fmt.Errorf("%s doesn't exist", containerID)

--- a/mlocal/frags/Makefile.stub
+++ b/mlocal/frags/Makefile.stub
@@ -20,7 +20,7 @@ collect:
 check: codegen
 	@echo " CHECK golangci-lint"
 	$(V) cd $(SOURCEDIR) && \
-		golangci-lint run --verbose --build-tags "$(GO_TAGS)"
+		golangci-lint run --timeout 10m --verbose --build-tags "$(GO_TAGS)"
 	@echo "       PASS"
 
 .PHONY: dist


### PR DESCRIPTION
This extends the timeout on golangci-lint, because I have seen it time out a few times on github action ci checks.

It also stops staticcheck complaints about `apptainer.OciExec` never returning nil.  I haven't seen those on github but I saw them on my development machine when testing the longer timeout.