### PR TITLE
Unshare mount namespace for all non-subuid fakeroot builds (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   apptainer on el8 and a mounted remote filesystem when using the
   `--fakeroot` option without `/etc/subuid` mapping.  The fix was to
   change the switch to an unprivileged root-mapped namespace to be the
-  equivalent of `unshare -r` instead of `unshare -rm`, to work around a
-  bug in the el8 kernel.
+  equivalent of `unshare -r` instead of `unshare -rm` on action commands,
+  to work around a bug in the el8 kernel.
 
 ## v1.2.3 - \[2023-09-14\]
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -95,7 +95,7 @@ func fakerootExec(isDeffile, unprivEncrypt bool) {
 		if buildArgs.ignoreUserns {
 			err = errors.New("could not start root-mapped namespace because --ignore-userns is set")
 		} else {
-			err = fakeroot.UnshareRootMapped(args, unprivEncrypt)
+			err = fakeroot.UnshareRootMapped(args, true)
 		}
 		if err == nil {
 			// All the work has been done by the child process

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -105,19 +105,6 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 			l.cfg.Namespaces.User = true
 			sylog.Debugf("running root-mapped unprivileged")
 			var err error
-			// Try to bind-mount the original user's home directory to /root.
-			// This may be overridden later by custom home directory settings,
-			// but this makes it available later as a source for the what it
-			// thinks of as the "original" user's home directory, if needed.
-			homedir := os.Getenv("HOME")
-			if homedir != "" {
-				err = syscall.Mount(homedir, "/root", "", syscall.MS_BIND, "")
-				if err != nil {
-					sylog.Debugf("Failure bind-mounting %s to /root: %v, skipping", homedir, err)
-				} else {
-					sylog.Debugf("Bind-mounting %s to /root", homedir)
-				}
-			}
 			if l.cfg.IgnoreFakerootCmd {
 				err = errors.New("fakeroot command is ignored because of --ignore-fakeroot-command")
 			} else {


### PR DESCRIPTION
This cherry-picks #1690 to the release-1.2 branch.