### PR TITLE
Change install-unprivileged.sh to default to oldest available dist 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,14 @@ jobs:
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 
+      - name: Install and test unprivileged for rocky 9 with rocky 8 container
+        env:
+          OS_TYPE: rockylinux
+          OS_VERSION: 9
+          CONTAINER_VERS: rockylinux:8
+          TEST_TYPE: unpriv
+        run: ./scripts/ci-docker-run
+
       - name: Install and test unprivileged for ubuntu 20.04
         env:
           OS_TYPE: ubuntu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           OS_TYPE: centos
           OS_VERSION: 7
+          HIDE_DIST: true
           GO_ARCH: linux-amd64
         run: |
           # Move the source directory down a level to separate it

--- a/scripts/ci-docker-run
+++ b/scripts/ci-docker-run
@@ -22,8 +22,10 @@ if [ "$OS_TYPE" = "debian" ] || [ "$OS_TYPE" = "ubuntu" ]; then
     PKGTYPE=deb
 fi
 
+CONTAINER_VERS="${CONTAINER_VERS:-$DOCKER_HUB_URI}"
+
 docker run --privileged --network=host -v "$(pwd):/build:rw" \
-  -e OS_TYPE=$OS_TYPE -e GO_ARCH=$GO_ARCH -e DOCKER_HUB_URI="$DOCKER_HUB_URI" \
+  -e OS_TYPE=$OS_TYPE -e GO_ARCH=$GO_ARCH -e CONTAINER_VERS="$CONTAINER_VERS" \
   --name "$DOCKER_CONTAINER_NAME" "$DOCKER_HUB_URI" /bin/bash -exc \
 	"cd /build && scripts/ci-${TEST_TYPE:-$PKGTYPE-build}-test"
 

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -59,8 +59,10 @@ su testuser -c '
       curl -f -L -sS -O $URL
       DOWNLOADEDFILES="$DOWNLOADEDFILES $(basename $URL)"
   done
-  # eliminate the "dist" part in the rpm name, for the release_assets
-  echo "%dist %{nil}" >$HOME/.rpmmacros
+  if [ "$HIDE_DIST" = true ]; then
+    # eliminate the "dist" part in the rpm name, for the release_assets
+    echo "%dist %{nil}" >$HOME/.rpmmacros
+  fi
   make -C builddir rpm
   sudo yum install -y $HOME/rpmbuild/RPMS/*/*.rpm
   BLD="$(echo $HOME/rpmbuild/BUILD/apptainer-*)"

--- a/scripts/ci-unpriv-test
+++ b/scripts/ci-unpriv-test
@@ -27,12 +27,17 @@ su testuser -c '
   set -e
   rm -rf ins image*.sif overlay.img
   tools/install-unprivileged.sh -v apptainer-[1-9]*.$(arch).rpm ins
-
-  ins/bin/apptainer build image.sif docker://'$DOCKER_HUB_URI'
+  (
+  echo Bootstrap: docker
+  echo From: '"$CONTAINER_VERS"'
+  echo %post
+  echo "  id"
+  ) >image.def
+  ins/bin/apptainer build image.sif image.def
   truncate -s 1G overlay.img
   mkfs.ext3 -F -O ^has_journal overlay.img
   ins/bin/apptainer exec --overlay overlay.img -f image.sif touch /bin/newfile
-  ins/bin/apptainer exec -B $PWD -f image.sif ins/bin/apptainer exec --overlay overlay.img image.sif cat /bin/newfile
+  ins/bin/apptainer exec -f image.sif ins/bin/apptainer exec --overlay overlay.img image.sif cat /bin/newfile
   ins/bin/apptainer exec --unsquash image.sif true
   echo testphrase|ins/bin/apptainer build --encrypt --passphrase image-e.sif image.sif
   echo testphrase|ins/bin/apptainer exec --passphrase image-e.sif true


### PR DESCRIPTION
This changes install-unprivileged.sh to default to always install the oldest supported distribution for the architecture, and to prefer the tools downloaded to any that might be on the system. That is primarily because glibc versions are upward compatible, so for the widest support of target container OS distributions when binding in fakeroot command files from the host we want to have the oldest library version available.

When installing from a local apptainer rpm file, the seccomp library has to match the rpm distribution, so that is downloaded separately.  An additional check in the CI after building the rocky8 rpm is added using rocky9 under docker but rocky8 again in the container, to demonstrate that a newer OS is able to build an older container with the fakeroot command.  It isn't possible to do the full check to an older OS than the rpm because of the seccomp library restriction.

- Fixes #1338