### PR TITLE
Only map the HostUID when in a root-mapped user namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   change the switch to an unprivileged root-mapped namespace to be the
   equivalent of `unshare -r` instead of `unshare -rm` on action commands,
   to work around a bug in the el8 kernel.
+- Fixed a regression introduced in 1.2.0 where the user's password
+  information was not copied in to the container when there was a
+  parent root-mapped user namespace (as is the case for example in
+  [cvmfsexec](https://github.com/cvmfs/cvmfsexec)).
 
 ## v1.2.3 - \[2023-09-14\]
 

--- a/pkg/util/namespaces/user_linux.go
+++ b/pkg/util/namespaces/user_linux.go
@@ -63,7 +63,7 @@ func IsInsideUserNamespace(pid int) (bool, bool) {
 }
 
 // HostUID attempts to find the original host UID if the current
-// process is running inside a user namespace, if it doesn't it
+// process is root running inside a user namespace, and if not it
 // simply returns the current UID
 func HostUID() (int, error) {
 	return getHostID("uid", os.Getuid())
@@ -75,6 +75,10 @@ func HostGID() (int, error) {
 }
 
 func getHostID(typ string, currentID int) (int, error) {
+	if currentID != 0 {
+		return currentID, nil
+	}
+
 	idMap := fmt.Sprintf("/proc/self/%s_map", typ)
 
 	f, err := os.Open(idMap)


### PR DESCRIPTION
This changes the `namespaces.HostUID()` function to only try to find the real host UID when the current uid is 0.  This avoids problems when running in a user namespace mapped from root back to a user, where the parent is a root-mapped user namespace.

- Fixes #1703