### PR TITLE
Clean up format of `remote list` output, from sylabs1919

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - The commands related to OCI/Docker registries that were under `remote` have
   been moved to their own, dedicated `registry` command. Run
   `apptainer help registry` for more information.
+- The the `remote list` subcommand now outputs only remote endpoints (with
+  keyservers and OCI/Docker registries having been moved to separate commands),
+  and the output has been streamlined.
 
 ### New Features & Functionality
 

--- a/internal/app/apptainer/remote_list.go
+++ b/internal/app/apptainer/remote_list.go
@@ -63,31 +63,28 @@ func RemoteList(usrConfigFile string) (err error) {
 	})
 	sort.Strings(names)
 
-	fmt.Println("Cloud Services Endpoints")
-	fmt.Println("========================")
 	fmt.Println()
-
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, listLine, "NAME", "URI", "ACTIVE", "GLOBAL", "EXCLUSIVE", "INSECURE")
+	fmt.Fprintf(tw, listLine, "NAME", "URI", "DEFAULT?", "GLOBAL?", "EXCLUSIVE?", "SECURE?")
 	for _, n := range names {
-		sys := "NO"
+		sys := ""
 		if c.Remotes[n].System {
-			sys = "YES"
+			sys = "✓"
 		}
-		excl := "NO"
+		excl := ""
 		if c.Remotes[n].Exclusive {
-			excl = "YES"
+			excl = "✓"
 		}
-		insec := "NO"
+		secure := "✓"
 		if c.Remotes[n].Insecure {
-			insec = "YES"
+			secure = "✗!"
+		}
+		isDefault := ""
+		if c.DefaultRemote != "" && c.DefaultRemote == n {
+			isDefault = "✓"
 		}
 
-		active := "NO"
-		if c.DefaultRemote != "" && c.DefaultRemote == n {
-			active = "YES"
-		}
-		fmt.Fprintf(tw, listLine, n, c.Remotes[n].URI, active, sys, excl, insec)
+		fmt.Fprintf(tw, listLine, n, c.Remotes[n].URI, isDefault, sys, excl, secure)
 	}
 	tw.Flush()
 


### PR DESCRIPTION
This pulls in
- sylabs/singularity#1919
which fixed
- sylabs/singularity#1896

The original PR description was
> Changes the format of the output of `singularity remote list` in accordance with option (a) outlined in sylabs/singularity#1639
> 
> Note that the output now includes _only_ the configured remote endpoints, to the exclusion of keyservers (see sylabs/singularity#1905) and OCI/Docker registries (see sylabs/singularity#1908).