### PR TITLE
Add libnvidia-gpucomp to the list of NVIDIA driver libraries (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   information was not copied in to the container when there was a
   parent root-mapped user namespace (as is the case for example in
   [cvmfsexec](https://github.com/cvmfs/cvmfsexec)).
+- Added the upcoming NVIDIA driver library `libnvidia-gpucomp.so` to the
+  list of libraries to add to NVIDIA GPU-enabled containers.
 - Fixed missing error handling during the creation of an encrypted
   image that lead to the generation of corrupted images.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@
 - Christian Goll <cgoll@suse.com>
 - Chris Hollowell <hollowec@bnl.gov>
 - Christian Neyers <foss@neyers.org>
+- Daniel Dadap <ddadap@nvidia.com>
 - Daniele Tamino <daniele.tamino@gmail.com>
 - Dave Godlove <d@sylabs.io>, <davidgodlove@gmail.com>
 - Dave Love <d.love@liverpool.ac.uk>

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -40,6 +40,7 @@ libnvidia-fbc.so
 libnvidia-glcore.so
 libnvidia-glsi.so
 libnvidia-glvkspirv.so
+libnvidia-gpucomp.so
 libnvidia-gtk2.so
 libnvidia-gtk3.so
 libnvidia-ifr.so


### PR DESCRIPTION
Upcoming versions of the NVIDIA driver will include a new component:

https://forums.developer.nvidia.com/t/new-driver-component-libnvidia-gpucomp/267060

Update the list of NVIDIA driver libraries so that it can be included in the runtime environment along with the others.

## Description of the Pull Request (PR):

cherry-pick PR#1716 to release-1.2 branch


### This fixes or addresses the following GitHub issues:

 - Fixes # N/A


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
