### PR TITLE
remote: Make registryUri available for library, from sylabs 1929

### DIFF
--- a/internal/pkg/remote/endpoint/client.go
+++ b/internal/pkg/remote/endpoint/client.go
@@ -2,6 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -130,4 +131,16 @@ func (config *Config) LibraryClientConfig(uri string) (*libClient.Config, error)
 	}
 
 	return libraryConfig, nil
+}
+
+// RegistryURI returns the URI of the backing OCI registry for the library service, associated with ep.
+func (config *Config) RegistryURI() (string, error) {
+	registryURI, err := config.getServiceConfigVal(Library, RegistryURIConfigKey)
+	if err != nil {
+		return "", err
+	}
+	if registryURI == "" {
+		return "", fmt.Errorf("library does not provide an OCI registry")
+	}
+	return registryURI, nil
 }

--- a/internal/pkg/remote/endpoint/client_test.go
+++ b/internal/pkg/remote/endpoint/client_test.go
@@ -10,6 +10,8 @@
 package endpoint
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
@@ -234,5 +236,27 @@ func TestLibraryClientConfig(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestConfig_RegistryURI(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "../../../../test/remote/config.example.json")
+	}))
+	t.Cleanup(srv.Close)
+
+	ep := Config{
+		URI:      srv.URL,
+		Insecure: true,
+	}
+
+	expectRegistry := "https://registry.example.com"
+	rURI, err := ep.RegistryURI()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if rURI != expectRegistry {
+		t.Errorf("expected %q, got %q", expectRegistry, rURI)
 	}
 }

--- a/test/remote/config.example.json
+++ b/test/remote/config.example.json
@@ -1,0 +1,20 @@
+{
+    "libraryAPI": {
+      "uri": "https://library.example.com",
+      "registryUri": "https://registry.example.com"
+    },
+    "keystoreAPI": {
+      "uri": "https://keys.example.com"
+    },
+    "builderAPI": {
+      "uri": "https://build.example.com",
+      "managerUri": "https://build.example.com"
+    },
+    "consentAPI": {
+      "uri": "https://auth.example.com/consent"
+    },
+    "tokenAPI": {
+      "uri": "https://auth.example.com/token"
+    }
+  }
+  


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity#1929 

The original PR description was 
> ## Description of the Pull Request (PR):
> 
> Retrieve the `registryUri` value from the library service config for SCS/Enterprise remotes.
> 
> The concept of a service in the remote code is rather overloaded and inflexible. Add an internal use map that we can pull the `registryUri` into and out of. Hide it behind a single `RegistryURI` public fn.
> 
> Not the tidiest, but it works pending major overhaul of the remote / endpoint code.
