### PR TITLE
Make missing rootless cgroups v2 variables be non-fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   [cvmfsexec](https://github.com/cvmfs/cvmfsexec)).
 - Added the upcoming NVIDIA driver library `libnvidia-gpucomp.so` to the
   list of libraries to add to NVIDIA GPU-enabled containers.
+- If rootless unified cgroups v2 is available when starting an image but
+  `XDG_RUNTIME_DIR` or `DBUS_SESSION_BUS_ADDRESS` is not set, print an
+  info message that stats will not be available instead of exiting with
+  a fatal error.
 
 ## v1.2.3 - \[2023-09-14\]
 

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -1051,6 +1051,11 @@ func (l *Launcher) setCgroups(instanceName string) error {
 	useCG := l.uid == 0
 	// non-root needs cgroups v2 unified mode + systemd as cgroups manager.
 	if l.uid != 0 && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups {
+		if os.Getenv("XDG_RUNTIME_DIR") == "" || os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
+			sylog.Infof("Instance stats will not be available because XDG_RUNTIME_DIR")
+			sylog.Infof("  or DBUS_SESSION_BUS_ADDRESS is not set")
+			return nil
+		}
 		useCG = true
 	}
 


### PR DESCRIPTION
When starting an instance, if rootless unified cgroups v2 is available but the required environment variables `XDG_RUNTIME_DIR` or `DBUS_SESSION_BUS_ADDRESS` are not, print an info message instead of causing a fatal error.

- Fixes #1731