### PR TITLE
Configure temporary directory for cryptsetup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `XDG_RUNTIME_DIR` or `DBUS_SESSION_BUS_ADDRESS` is not set, print an
   info message that stats will not be available instead of exiting with
   a fatal error.
+- Use `APPTAINER_TMPDIR` for temporary files during privileged image
+  encryption.
 
 ## v1.2.3 - \[2023-09-14\]
 

--- a/internal/pkg/build/assemblers/sif.go
+++ b/internal/pkg/build/assemblers/sif.go
@@ -231,7 +231,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 			// Detach the following code from the squashfs creation. SIF can be
 			// created first and encrypted after. This gives the flexibility to
 			// encrypt an existing SIF
-			loopPath, err := cryptDev.EncryptFilesystem(fsPath, plaintext)
+			loopPath, err := cryptDev.EncryptFilesystem(fsPath, plaintext, b.TmpDir)
 			if err != nil {
 				return fmt.Errorf("unable to encrypt filesystem at %s: %+v", fsPath, err)
 			}

--- a/internal/pkg/util/crypt/crypt_dev.go
+++ b/internal/pkg/util/crypt/crypt_dev.go
@@ -115,7 +115,7 @@ func checkCryptsetupVersion(cryptsetup string) error {
 // a file that can be later used as an encrypted volume with cryptsetup.
 // NOTE: it is the callers responsibility to remove the returned file that
 // contains the crypt header.
-func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) {
+func (crypt *Device) EncryptFilesystem(path string, key []byte, tempdir string) (string, error) {
 	f, err := os.Stat(path)
 	if err != nil {
 		return "", fmt.Errorf("failed getting size of %s", path)
@@ -124,7 +124,7 @@ func (crypt *Device) EncryptFilesystem(path string, key []byte) (string, error) 
 	fSize := f.Size()
 
 	// Create a temporary file to format with crypt header
-	cryptF, err := os.CreateTemp("", "crypt-")
+	cryptF, err := os.CreateTemp(tempdir, "crypt-")
 	if err != nil {
 		sylog.Debugf("Error creating temporary crypt file")
 		return "", err

--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -102,7 +102,7 @@ func TestEncrypt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			devPath, err := dev.EncryptFilesystem(tt.path, tt.key)
+			devPath, err := dev.EncryptFilesystem(tt.path, tt.key, "")
 			if tt.shallPass && err != nil {
 				if err == ErrUnsupportedCryptsetupVersion {
 					t.Skip("installed version of cryptsetup is not supported, >=2.0.0 required")


### PR DESCRIPTION
Pass the bundle temporary directory to cryptDev.EncryptFilesystem for use in creating temporary files.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #1713 


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- [x] Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
