### PR TITLE
add skipping comment line in templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Adding a new remote endpoint using the `apptainer remote add` command will
   now set the new endpoint as default. This behavior can be suppressed by
   supplying the `--no-default` (or `-n`) flag to `remote add`.
+- Skip parsing build definition file template variables after comments
+  beginning with a hash symbol.
 
 ### New Features & Functionality
 

--- a/internal/pkg/build/args/args_test.go
+++ b/internal/pkg/build/args/args_test.go
@@ -219,6 +219,37 @@ func TestReader(t *testing.T) {
 			defaultArgsMap: map[string]string{},
 			err:            "is not defined through either --build-arg (--build-arg-file) or 'arguments' section",
 		},
+		{
+			name: "ok case with variables defined in comment lines",
+			input: `
+			%argument
+				OS_VER=1 #  comment line {{ OS_VER }}
+			%post
+			    	# comment
+				#an
+				#!/bin/{{ BASH }}
+				apt install {{ OS_VER }}#comment {{ OS_VER }}
+				#some other comment {{ OS_VER }}
+				#should not be replaced as well 
+			`,
+			output: `
+			%argument
+				OS_VER=1 #  comment line {{ OS_VER }}
+			%post
+			    	# comment
+				#an
+				#!/bin/csh
+				apt install 1#comment {{ OS_VER }}
+				#some other comment {{ OS_VER }}
+				#should not be replaced as well 
+			`,
+			argsMap: map[string]string{
+				"OS_VER": "1",
+				"BASH":   "csh",
+			},
+			defaultArgsMap: map[string]string{},
+			err:            "",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description of the Pull Request (PR):

add the ability to handle comment line starting with `# ` in template feature 

### This fixes or addresses the following GitHub issues:

 - Fixes #1719


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
