### PR TITLE
Parse digest from canonical docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Adding a new remote endpoint using the `apptainer remote add` command will
   now set the new endpoint as default. This behavior can be suppressed by
   supplying the `--no-default` (or `-n`) flag to `remote add`.
+- When fetching a Docker image that has a digest but no tag Apptainer will
+  now resolve the digest from the URI instead of making a request to the
+  container registry.
 
 ### New Features & Functionality
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -115,4 +115,5 @@
 - Charles Vejnar <charles.vejnar@gmail.com>
 - Carmelo Piccione <carmelo.piccione@gmail.com>
 - Filip Gorczyca <filip.gorczyca141@gmail.com>
+- Jesse Farebrother <jessefarebro@gmail.com>
 ```

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -14,6 +14,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,6 +30,7 @@ import (
 const (
 	invalidOCIURI = "library://valid_uri_but_not_real_image"
 	invalidHash   = "1n2o3t4e5x6i7s9t0i1n2g3h4a5s6h"
+	validHash     = "0000000000000000000000000000000000000000000000000000000000000000"
 )
 
 // getInvalidRef enerate an invalid reference.
@@ -44,6 +46,10 @@ func getInvalidRef(cacheRootPath string) string {
 // getTestCacheInfo(). This abstracts the syntax of an OCI URI
 func getValidOCIURI(ref string) string {
 	return filepath.Join("oci://", ref)
+}
+
+func getDockerDigestURI(ref string) string {
+	return fmt.Sprintf("docker://%s@%s", ref, validHash)
 }
 
 // createIndexFile creates the index.json file of the dummy OCI cache.
@@ -266,6 +272,18 @@ func TestConvertReference(t *testing.T) {
 		{
 			name:       "invalid image ref; valid context",
 			ref:        createInvalidImageRef(t, getInvalidRef(cacheDir)),
+			ctx:        createValidSysCtx(),
+			shouldPass: false,
+		},
+		{
+			name:       "invalid image domain, valid digest; valid context",
+			ref:        createValidImageRef(t, getDockerDigestURI("invalid.domain.com:5000/image")),
+			ctx:        createValidSysCtx(),
+			shouldPass: true,
+		},
+		{
+			name:       "invalid image domain, with tag, valid digest; valid context",
+			ref:        createValidImageRef(t, getDockerDigestURI("invalid.domain.com:5000/image:latest")),
 			ctx:        createValidSysCtx(),
 			shouldPass: false,
 		},


### PR DESCRIPTION
## Description of the Pull Request (PR):

When given a Docker image with a digest and no tag, Apptainer should parse the digest directly from the URI instead of requesting it from the container registry. This is an attempt at fixing this problem. My Go knowledge is limited at best, so this might require some iteration.

### This fixes or addresses the following GitHub issues:

 - Fixes #1104
