### PR TITLE
Fix typos found by codespell

### DIFF
--- a/cmd/starter/c/include/securebits.h
+++ b/cmd/starter/c/include/securebits.h
@@ -28,7 +28,7 @@
 #define SECBIT_NOROOT_LOCKED    (issecure_mask(SECURE_NOROOT_LOCKED))
 
 /* When set, setuid to/from uid 0 does not trigger capability-"fixup".
-   When unset, to provide compatiblility with old programs relying on
+   When unset, to provide compatibility with old programs relying on
    set*uid to gain/lose privilege, transitions to/from uid 0 cause
    capabilities to be gained/lost. */
 #define SECURE_NO_SETUID_FIXUP          2

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -382,7 +382,7 @@ func TestNewImageSource(t *testing.T) {
 		shallPass bool
 	}{
 		{
-			name:      "valid ctx, undefained sys",
+			name:      "valid ctx, undefined sys",
 			ctx:       validCtx,
 			sys:       nil,
 			shallPass: false,

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -26,7 +26,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-var ErrUnitialized = errors.New("cgroups manager is not initialized")
+var ErrUninitialized = errors.New("cgroups manager is not initialized")
 
 // Manager provides functions to modify, freeze, thaw, and destroy a cgroup.
 // Apptainer's cgroups.Manager is a wrapper around runc/libcontainer/cgroups.
@@ -45,7 +45,7 @@ type Manager struct {
 // GetCgroupRootPath returns the cgroups mount root path, for the managed cgroup
 func (m *Manager) GetCgroupRootPath() (rootPath string, err error) {
 	if m.group == "" || m.cgroup == nil {
-		return "", ErrUnitialized
+		return "", ErrUninitialized
 	}
 
 	// v2 - has a single fixed mountpoint for the root cgroup
@@ -78,7 +78,7 @@ func (m *Manager) GetCgroupRootPath() (rootPath string, err error) {
 // GetCgroupRelPath returns the relative path of the cgroup under the mount point
 func (m *Manager) GetCgroupRelPath() (relPath string, err error) {
 	if m.group == "" || m.cgroup == nil {
-		return "", ErrUnitialized
+		return "", ErrUninitialized
 	}
 
 	// v2 - has a single fixed mountpoint for the root cgroup
@@ -122,7 +122,7 @@ func (m *Manager) GetStats() (*lccgroups.Stats, error) {
 // an OCI LinuxResources spec struct.
 func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {
 	if m.group == "" || m.cgroup == nil {
-		return ErrUnitialized
+		return ErrUninitialized
 	}
 
 	spec := &specs.Spec{
@@ -178,7 +178,7 @@ func (m *Manager) UpdateFromFile(path string) error {
 // nolint:contextcheck
 func (m *Manager) AddProc(pid int) (err error) {
 	if m.group == "" || m.cgroup == nil {
-		return ErrUnitialized
+		return ErrUninitialized
 	}
 	if pid == 0 {
 		return fmt.Errorf("cannot add a zero pid to cgroup")
@@ -210,7 +210,7 @@ func (m *Manager) AddProc(pid int) (err error) {
 // Freeze freezes processes in the managed cgroup.
 func (m *Manager) Freeze() (err error) {
 	if m.group == "" || m.cgroup == nil {
-		return ErrUnitialized
+		return ErrUninitialized
 	}
 	return m.cgroup.Freeze(lcconfigs.Frozen)
 }
@@ -218,7 +218,7 @@ func (m *Manager) Freeze() (err error) {
 // Thaw unfreezes process in the managed cgroup.
 func (m *Manager) Thaw() (err error) {
 	if m.group == "" || m.cgroup == nil {
-		return ErrUnitialized
+		return ErrUninitialized
 	}
 	return m.cgroup.Freeze(lcconfigs.Thawed)
 }
@@ -226,7 +226,7 @@ func (m *Manager) Thaw() (err error) {
 // Destroy deletes the managed cgroup.
 func (m *Manager) Destroy() (err error) {
 	if m.group == "" || m.cgroup == nil {
-		return ErrUnitialized
+		return ErrUninitialized
 	}
 	return m.cgroup.Destroy()
 }

--- a/internal/pkg/client/library/user.go
+++ b/internal/pkg/client/library/user.go
@@ -34,7 +34,7 @@ type userData struct {
 	Username string       `json:"username"`
 }
 
-// getUserData retrives auth service user information from the current remote.
+// getUserData retrieves auth service user information from the current remote.
 func getUserData(config *containerclient.Config) (*userData, error) {
 	client := http.Client{Timeout: 5 * time.Second}
 	path := userServicePath

--- a/internal/pkg/util/bin/bin_apptainer.go
+++ b/internal/pkg/util/bin/bin_apptainer.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// findOnPath performs a search on the configurated binary path for the
+// findOnPath performs a search on the configured binary path for the
 // named executable, returning its full path.
 func findOnPath(name string, useSuidPath bool) (path string, err error) {
 	cfg := apptainerconf.GetCurrentConfig()


### PR DESCRIPTION
## Description of the Pull Request (PR):

Minor change, just fix a handful misspellings.

While `configurate` can be [found in OED](https://www.oed.com/search/dictionary/?q=configurate), it is missing from the open-source spell checking reference [SCOWL (and Friends)](http://app.aspell.net/lookup?dict=en_GB-large;words=configurate).
 
#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
