### PR TITLE
Enhancement to debug log to show source docker image hash

### DIFF
--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -245,6 +245,7 @@ func getDockerRefDigest(ctx context.Context, ref types.ImageReference, sys *type
 		return "", err
 	}
 	digest = d.Encoded()
+	sylog.Debugf("docker.GetDigest source image digest for %s is %s", transports.ImageName(ref), digest)
 	digest = fmt.Sprintf("%x", sha256.Sum256([]byte(digest+sys.ArchitectureChoice+sys.VariantChoice)))
 	sylog.Debugf("docker.GetDigest digest for %s is %s", transports.ImageName(ref), digest)
 	return digest, nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Print out the source docker image hash to maintain a paper trail of the input image that was used.

This allows us to prove the provenance of the output container.

### This fixes or addresses the following GitHub issues:

 - Fixes #1748 
