### PR TITLE
Show docker hash

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -115,4 +115,5 @@
 - Charles Vejnar <charles.vejnar@gmail.com>
 - Carmelo Piccione <carmelo.piccione@gmail.com>
 - Filip Gorczyca <filip.gorczyca141@gmail.com>
+- Nicholas Yue <yue.nicholas@gmail.com>
 ```

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -245,6 +245,7 @@ func getDockerRefDigest(ctx context.Context, ref types.ImageReference, sys *type
 		return "", err
 	}
 	digest = d.Encoded()
+	sylog.Debugf("docker.GetDigest source image digest for %s is %s", transports.ImageName(ref), digest)
 	digest = fmt.Sprintf("%x", sha256.Sum256([]byte(digest+sys.ArchitectureChoice+sys.VariantChoice)))
 	sylog.Debugf("docker.GetDigest digest for %s is %s", transports.ImageName(ref), digest)
 	return digest, nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Enhancement to debug log to show source docker image hash
    
Print out the source docker image hash to maintain a paper trail of the input
image that was used.
    
This allows us to prove the provenance of the output container.
    
Signed-off-by: Nicholas Yue <yue.nicholas@gmail.com>


### This fixes or addresses the following GitHub issues:

 - Fixes #1748
