### PR TITLE
Add sharens mode for apptainer exec/run/shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   inferred by `--containall` and `--compat`.
 - Added `--config` option to`keyserver` commands.
 - Honor an optional remoteName argument to the `keyserver list` command.
+- Adding `--sharens` mode for `apptainer exec/run/shell`, which enables to run multiple
+  apptainer instances in the same user namespace.
 
 ### Developer / API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Added `--config` option to`keyserver` commands.
 - Honor an optional remoteName argument to the `keyserver list` command.
 - Adding `--sharens` mode for `apptainer exec/run/shell`, which enables to run multiple
-  apptainer instances in the same user namespace.
+  apptainer instances created by the same parent using the same image in the same
+  user namespace.
 
 ### Developer / API
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -824,7 +824,7 @@ var actionShareNSFlag = cmdline.Flag{
 	Value:        &shareNS,
 	DefaultValue: false,
 	Name:         "sharens",
-	Usage:        "mode for launching containers in the same namespace",
+	Usage:        "share the namespace and image with other containers launched from the same parent process",
 	EnvKeys:      []string{"SHARENS"},
 	Hidden:       false,
 }

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -90,6 +90,8 @@ var (
 	ignoreUserns      bool
 
 	underlay bool // whether using underlay instead of overlay
+
+	shareNS bool // mode for launching container using shared namespace
 )
 
 // --app
@@ -816,6 +818,17 @@ var actionUnderlayFlag = cmdline.Flag{
 	Hidden:       false,
 }
 
+// --sharens
+var actionShareNSFlag = cmdline.Flag{
+	ID:           "shareNSFlag",
+	Value:        &shareNS,
+	DefaultValue: false,
+	Name:         "sharens",
+	Usage:        "mode for launching containers in the same namespace",
+	EnvKeys:      []string{"SHARENS"},
+	Hidden:       false,
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -908,5 +921,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionIgnoreFakerootCommand, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionIgnoreUsernsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionUnderlayFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionShareNSFlag, actionsCmd...)
 	})
 }

--- a/cmd/internal/cli/checkpoint.go
+++ b/cmd/internal/cli/checkpoint.go
@@ -167,7 +167,7 @@ var CheckpointInstanceCmd = &cobra.Command{
 		sylog.Infof("Using checkpoint %q", e.Name())
 
 		a := append([]string{"/.singularity.d/actions/exec"}, dmtcp.CheckpointArgs(port)...)
-		if err := launchContainer(cmd, "instance://"+args[0], a, ""); err != nil {
+		if err := launchContainer(cmd, "instance://"+args[0], a, "", -1); err != nil {
 			sylog.Fatalf("%s", err)
 		}
 	},

--- a/cmd/internal/cli/instance_actions_linux.go
+++ b/cmd/internal/cli/instance_actions_linux.go
@@ -50,7 +50,7 @@ func instanceAction(cmd *cobra.Command, args []string) {
 		killCont = "kill -CONT 1; "
 	}
 	a := append([]string{killCont + "/.singularity.d/actions/" + script}, args[2:]...)
-	if err := launchContainer(cmd, image, a, name); err != nil {
+	if err := launchContainer(cmd, image, a, name, -1); err != nil {
 		sylog.Fatalf("%s", err)
 	}
 

--- a/cmd/internal/cli/instance_list_linux.go
+++ b/cmd/internal/cli/instance_list_linux.go
@@ -24,6 +24,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&instanceListUserFlag, instanceListCmd)
 		cmdManager.RegisterFlagForCmd(&instanceListJSONFlag, instanceListCmd)
 		cmdManager.RegisterFlagForCmd(&instanceListLogsFlag, instanceListCmd)
+		cmdManager.RegisterFlagForCmd(&instanceListAllFlag, instanceListCmd)
 	})
 }
 
@@ -67,6 +68,19 @@ var instanceListLogsFlag = cmdline.Flag{
 	EnvKeys:      []string{"LOGS"},
 }
 
+// -a|--all
+var instanceListAll bool
+
+var instanceListAllFlag = cmdline.Flag{
+	ID:           "instanceListAllFlag",
+	Value:        &instanceListAll,
+	DefaultValue: false,
+	Name:         "all",
+	ShortHand:    "a",
+	Usage:        "display all instances (include --sharens instances)",
+	EnvKeys:      []string{"ALL"},
+}
+
 // apptainer instance list
 var instanceListCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
@@ -81,7 +95,7 @@ var instanceListCmd = &cobra.Command{
 			sylog.Fatalf("Only root user can list user's instances")
 		}
 
-		err := apptainer.PrintInstanceList(os.Stdout, name, instanceListUser, instanceListJSON, instanceListLogs)
+		err := apptainer.PrintInstanceList(os.Stdout, name, instanceListUser, instanceListJSON, instanceListLogs, instanceListAll)
 		if err != nil {
 			sylog.Fatalf("Could not list instances: %v", err)
 		}

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -134,7 +134,7 @@ func (c *ctx) testCreateManyInstances(t *testing.T) {
 			e2e.ExpectExit(0),
 		)
 
-		c.expectInstance(t, instanceName, 1)
+		c.expectInstance(t, instanceName, 1, false)
 	}
 }
 
@@ -383,7 +383,7 @@ func (c *ctx) testInstanceWithConfigDir(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
-	c.expectInstance(t, name, 1)
+	c.expectInstance(t, name, 1, false)
 	c.execInstance(t, name, "id")
 	c.stopInstance(t, name)
 
@@ -392,6 +392,17 @@ func (c *ctx) testInstanceWithConfigDir(t *testing.T) {
 			t.Fatalf("failed %v", err)
 		}
 	})(t)
+}
+
+// testShareNSMopde will test --sharens flag
+func (c *ctx) testShareNSMode(t *testing.T) {
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(c.profile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--sharens", c.env.ImagePath, "true"),
+		e2e.ExpectExit(0),
+	)
 }
 
 // E2ETests is the main func to trigger the test suite
@@ -424,6 +435,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 				{"GhostInstance", c.testGhostInstance},
 				{"CheckpointInstance", c.testCheckpointInstance},
 				{"InstanceWithConfigDir", c.testInstanceWithConfigDir},
+				{"ShareNSMode", c.testShareNSMode},
 			}
 
 			profiles := []e2e.Profile{

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -52,7 +52,7 @@ func (c *ctx) stopInstance(t *testing.T, instance string, stopArgs ...string) (s
 		e2e.ExpectExit(0, e2e.GetStreams(&stdout, &stderr)),
 	)
 
-	c.expectInstance(t, instance, 0)
+	c.expectInstance(t, instance, 0, true)
 
 	return
 }
@@ -77,7 +77,7 @@ func (c *ctx) execInstance(t *testing.T, instance string, execArgs ...string) (s
 }
 
 // Check if there is the number of expected instances with the provided name.
-func (c *ctx) expectInstance(t *testing.T, name string, nb int) {
+func (c *ctx) expectInstance(t *testing.T, name string, nb int, showAll bool) {
 	listInstancesFn := func(t *testing.T, r *e2e.ApptainerCmdResult) {
 		var instances instanceList
 
@@ -89,11 +89,17 @@ func (c *ctx) expectInstance(t *testing.T, name string, nb int) {
 		}
 	}
 
+	var args e2e.ApptainerCmdOp
+	if showAll {
+		args = e2e.WithArgs([]string{"--all", "--json", name}...)
+	} else {
+		args = e2e.WithArgs([]string{"--json", name}...)
+	}
 	c.env.RunApptainer(
 		t,
 		e2e.WithProfile(c.profile),
 		e2e.WithCommand("instance list"),
-		e2e.WithArgs([]string{"--json", name}...),
+		args,
 		e2e.WithEnv(c.withEnv),
 		e2e.ExpectExit(0, listInstancesFn),
 	)

--- a/internal/app/apptainer/instance_linux.go
+++ b/internal/app/apptainer/instance_linux.go
@@ -46,7 +46,7 @@ type instanceInfo struct {
 // user filters, and prints it in a regular or a JSON format (if
 // formatJSON is true) to the passed writer. Additionally, fetches
 // log paths (if showLogs is true).
-func PrintInstanceList(w io.Writer, name, user string, formatJSON bool, showLogs bool) error {
+func PrintInstanceList(w io.Writer, name, user string, formatJSON bool, showLogs bool, all bool) error {
 	if formatJSON && showLogs {
 		sylog.Fatalf("more than one flags have been set")
 	}
@@ -54,7 +54,7 @@ func PrintInstanceList(w io.Writer, name, user string, formatJSON bool, showLogs
 	tabWriter := tabwriter.NewWriter(w, 0, 8, 4, ' ', 0)
 	defer tabWriter.Flush()
 
-	ii, err := instance.List(user, name, instance.AppSubDir)
+	ii, err := instance.List(user, name, instance.AppSubDir, all)
 	if err != nil {
 		return fmt.Errorf("could not retrieve instance list: %v", err)
 	}
@@ -115,7 +115,7 @@ func PrintInstanceList(w io.Writer, name, user string, formatJSON bool, showLogs
 // truncating it if it already exists. Note that the name should not be a glob,
 // i.e. name should identify a single instance only, otherwise an error is returned.
 func WriteInstancePidFile(name, pidFile string) error {
-	inst, err := instance.List("", name, instance.AppSubDir)
+	inst, err := instance.List("", name, instance.AppSubDir, true)
 	if err != nil {
 		return fmt.Errorf("could not retrieve instance list: %v", err)
 	}
@@ -139,7 +139,7 @@ func WriteInstancePidFile(name, pidFile string) error {
 // instanceListOrError is a private function to retrieve named instances or fail if there are no instances
 // We wrap the error from instance.List to provide a more specific error message
 func instanceListOrError(instanceUser, name string) ([]*instance.File, error) {
-	ii, err := instance.List(instanceUser, name, instance.AppSubDir)
+	ii, err := instance.List(instanceUser, name, instance.AppSubDir, true)
 	if err != nil {
 		return ii, fmt.Errorf("could not retrieve instance list: %w", err)
 	}

--- a/internal/pkg/instance/instance_linux.go
+++ b/internal/pkg/instance/instance_linux.go
@@ -188,7 +188,7 @@ func List(username string, name string, subDir string, all bool) ([]*File, error
 		r.Close()
 		f.Path = file
 		// delete ghost apptainer instance files
-		if subDir == AppSubDir && f.isExited() {
+		if subDir == AppSubDir && f.isExited() && !f.ShareNSMode {
 			f.Delete()
 			continue
 		}

--- a/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/capabilities"
+	"github.com/apptainer/apptainer/pkg/util/fs/lock"
 )
 
 // CleanupContainer is called from master after the MonitorContainer returns.
@@ -43,6 +44,13 @@ import (
 // CleanupContainer is performing step 8/9 here.
 func (e *EngineOperations) CleanupContainer(ctx context.Context, fatal error, status syscall.WaitStatus) error {
 	sylog.Debugf("Cleanup container")
+	if fd := e.EngineConfig.GetShareNSFd(); fd != -1 && e.EngineConfig.GetShareNSMode() {
+		br := lock.NewByteRange(fd, 0, 1)
+		// wait all other processes first
+		if err := br.Lockw(); err != nil {
+			sylog.Errorf("sharens waiting processes error: %s", err)
+		}
+	}
 
 	// close the connection between apptainer and apptheus
 	if e.CommonConfig.ApptheusSocket != nil {

--- a/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
@@ -45,10 +45,23 @@ import (
 func (e *EngineOperations) CleanupContainer(ctx context.Context, fatal error, status syscall.WaitStatus) error {
 	sylog.Debugf("Cleanup container")
 	if fd := e.EngineConfig.GetShareNSFd(); fd != -1 && e.EngineConfig.GetShareNSMode() {
-		br := lock.NewByteRange(fd, 0, 1)
+		br := lock.NewByteRange(fd, 0, 0)
 		// wait all other processes first
 		if err := br.Lockw(); err != nil {
 			sylog.Errorf("sharens waiting processes error: %s", err)
+		}
+
+		// clean up the lock file, this is first process
+		if path, err := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", fd)); err == nil {
+			if err := syscall.Close(fd); err == nil {
+				if err := syscall.Unlink(path); err != nil {
+					sylog.Errorf("unable to unlink path: %s, err: %v", path, err)
+				}
+			} else {
+				sylog.Errorf("unable to close file descriptor for sharens lock file: %d", fd)
+			}
+		} else {
+			sylog.Errorf("unable to locate the file descriptor: %d in /proc folder", fd)
 		}
 	}
 

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -626,7 +626,13 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 
 	starterConfig.SetBringLoopbackInterface(true)
 
-	starterConfig.SetInstance(e.EngineConfig.GetInstance())
+	// check whether container should run in sharens mode
+	if e.EngineConfig.GetShareNSMode() {
+		// for --sharens mode, won't start the container as instance
+		starterConfig.SetInstance(false)
+	} else {
+		starterConfig.SetInstance(e.EngineConfig.GetInstance())
+	}
 
 	starterConfig.SetNsFlagsFromSpec(e.EngineConfig.OciConfig.Linux.Namespaces)
 

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -451,7 +451,7 @@ func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error 
 				return err
 			}
 		} else if fd := e.EngineConfig.GetShareNSFd(); fd != -1 {
-			br := lock.NewByteRange(fd, 0, 1)
+			br := lock.NewByteRange(fd, 0, 0)
 			if err := br.Unlock(); err != nil {
 				return err
 			}

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -335,7 +335,13 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	// Setup instance specific configuration if required.
 	if instanceName != "" {
 		l.generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "INSTANCE", instanceName)
-		l.cfg.Namespaces.PID = !l.cfg.ShareNSMode
+		// instance are always using PID namespace by default
+		pidNamespace := true
+		if l.cfg.ShareNSMode && !l.cfg.Namespaces.PID {
+			// sharens disable PID namespace by default
+			pidNamespace = false
+		}
+		l.cfg.Namespaces.PID = pidNamespace
 		l.engineConfig.SetInstance(true)
 		l.engineConfig.SetBootInstance(l.cfg.Boot)
 

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -359,6 +359,10 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 			}
 			l.generator.SetProcessArgs([]string{"/sbin/init"})
 		}
+
+		// Set sharens mode
+		l.engineConfig.SetShareNSMode(l.cfg.ShareNSMode)
+		l.engineConfig.SetShareNSFd(l.cfg.ShareNSFd)
 	}
 
 	// Set the required namespaces in the engine config.
@@ -1176,14 +1180,21 @@ func (l *Launcher) starterInstance(loadOverlay bool, insideUserNs bool, name str
 		return err
 	}
 
-	stdout, stderr, err := instance.SetLogFile(name, l.cfg.Namespaces.User || insideUserNs, int(l.uid), instance.LogSubDir)
-	if err != nil {
-		return fmt.Errorf("failed to create instance log files: %w", err)
-	}
-
-	start, err := stderr.Seek(0, io.SeekEnd)
-	if err != nil {
-		sylog.Warningf("failed to get standard error stream offset: %s", err)
+	var stdout, stderr *os.File
+	var start int64
+	if l.engineConfig.GetShareNSMode() {
+		// sharens mode will uses os.stdout and os.stderr instead of log files
+		stdout, stderr = os.Stdout, os.Stderr
+	} else {
+		var err error
+		stdout, stderr, err = instance.SetLogFile(name, l.cfg.Namespaces.User || insideUserNs, int(l.uid), instance.LogSubDir)
+		if err != nil {
+			return fmt.Errorf("failed to create instance log files: %w", err)
+		}
+		start, err = stderr.Seek(0, io.SeekEnd)
+		if err != nil {
+			sylog.Warningf("failed to get standard error stream offset: %s", err)
+		}
 	}
 
 	cmdErr := starter.Run(
@@ -1195,28 +1206,32 @@ func (l *Launcher) starterInstance(loadOverlay bool, insideUserNs bool, name str
 		starter.LoadOverlayModule(loadOverlay),
 	)
 
-	if sylog.GetLevel() != 0 {
-		// starter can exit a bit before all errors has been reported
-		// by instance process, wait a bit to catch all errors
-		time.Sleep(100 * time.Millisecond)
+	if !l.engineConfig.GetShareNSMode() {
+		if sylog.GetLevel() != 0 {
+			// starter can exit a bit before all errors has been reported
+			// by instance process, wait a bit to catch all errors
+			time.Sleep(100 * time.Millisecond)
 
-		end, err := stderr.Seek(0, io.SeekEnd)
-		if err != nil {
-			sylog.Warningf("failed to get standard error stream offset: %s", err)
-		}
-		if end-start > 0 {
-			output := make([]byte, end-start)
-			stderr.ReadAt(output, start)
-			fmt.Println(string(output))
+			end, err := stderr.Seek(0, io.SeekEnd)
+			if err != nil {
+				sylog.Warningf("failed to get standard error stream offset: %s", err)
+			}
+			if end-start > 0 {
+				output := make([]byte, end-start)
+				stderr.ReadAt(output, start)
+				fmt.Println(string(output))
+			}
 		}
 	}
 
 	if cmdErr != nil {
 		return fmt.Errorf("failed to start instance: %w", cmdErr)
 	}
-	sylog.Verbosef("you will find instance output here: %s", stdout.Name())
-	sylog.Verbosef("you will find instance error here: %s", stderr.Name())
-	sylog.Infof("instance started successfully")
+	if !l.engineConfig.GetShareNSMode() {
+		sylog.Verbosef("you will find instance output here: %s", stdout.Name())
+		sylog.Verbosef("you will find instance error here: %s", stderr.Name())
+		sylog.Infof("instance started successfully")
+	}
 
 	return nil
 }

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -375,6 +375,10 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	l.setProcessCwd()
 
 	l.generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "APPNAME", l.cfg.AppName)
+	// set an additional environment APPTAINER_SHARENS_MASTER = 1 inside container
+	if fd := l.engineConfig.GetShareNSFd(); fd != -1 && l.engineConfig.GetShareNSMode() {
+		l.generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "SHARENS_MASTER", "1")
+	}
 
 	// Get image ready to run, if needed, via FUSE mount / extraction / image driver handling.
 	if err := l.prepareImage(ctx, insideUserNs, image); err != nil {

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -151,6 +151,8 @@ type launchOptions struct {
 	UseBuildConfig    bool
 	TmpDir            string
 	Underlay          bool // whether prefer underlay over overlay
+	ShareNSMode       bool // whether running in sharens mode
+	ShareNSFd         int  // fd opened in sharens mode
 }
 
 type Launcher struct {
@@ -565,6 +567,22 @@ func OptTmpDir(a string) Option {
 func OptUnderlay(b bool) Option {
 	return func(lo *launchOptions) error {
 		lo.Underlay = b
+		return nil
+	}
+}
+
+// OptShareNSMode
+func OptShareNSMode(b bool) Option {
+	return func(lo *launchOptions) error {
+		lo.ShareNSMode = b
+		return nil
+	}
+}
+
+// OptShareNSFd
+func OptShareNSFd(fd int) Option {
+	return func(lo *launchOptions) error {
+		lo.ShareNSFd = fd
 		return nil
 	}
 }

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -153,6 +153,8 @@ type JSONConfig struct {
 	Underlay              bool              `json:"underlay,omitempty"`
 	UserInfo              UserInfo          `json:"userInfo,omitempty"`
 	WritableOverlay       bool              `json:"writableOverlay,omitempty"`
+	ShareNSMode           bool              `json:"sharensMode,omitempty"`
+	ShareNSFd             int               `json:"sharensFd,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -941,4 +943,24 @@ func (e *EngineConfig) SetWritableOverlay(writableOverlay bool) {
 // GetWritableOverlay gets the value of whether the overlay is writable or not
 func (e *EngineConfig) GetWritableOverlay() bool {
 	return e.JSON.WritableOverlay
+}
+
+// SetShareNSMode sets whether container should run in shared namespace mode
+func (e *EngineConfig) SetShareNSMode(mode bool) {
+	e.JSON.ShareNSMode = mode
+}
+
+// GetShareNSMode gets the value of previous SetShareNSMode
+func (e *EngineConfig) GetShareNSMode() bool {
+	return e.JSON.ShareNSMode
+}
+
+// SetShareNSFd sets the locked fd
+func (e *EngineConfig) SetShareNSFd(fd int) {
+	e.JSON.ShareNSFd = fd
+}
+
+// GetShareNSFd gets the locked fd
+func (e *EngineConfig) GetShareNSFd() int {
+	return e.JSON.ShareNSFd
 }

--- a/pkg/util/fs/lock/lock.go
+++ b/pkg/util/fs/lock/lock.go
@@ -75,7 +75,7 @@ func NewByteRange(fd int, start, len int64) *ByteRange {
 }
 
 // flock places a byte-range lock.
-func (r *ByteRange) flock(lockType int16) error {
+func (r *ByteRange) flock(lockType int16, cmd int) error {
 	lk := &unix.Flock_t{
 		Type:   lockType,
 		Whence: io.SeekStart,
@@ -83,7 +83,7 @@ func (r *ByteRange) flock(lockType int16) error {
 		Len:    r.len,
 	}
 
-	err := unix.FcntlFlock(uintptr(r.fd), setLk, lk)
+	err := unix.FcntlFlock(uintptr(r.fd), cmd, lk)
 	if err == unix.EAGAIN || err == unix.EACCES {
 		return ErrByteRangeAcquired
 	} else if err == unix.ENOLCK {
@@ -95,15 +95,25 @@ func (r *ByteRange) flock(lockType int16) error {
 
 // Lock places a write lock for the corresponding byte-range.
 func (r *ByteRange) Lock() error {
-	return r.flock(unix.F_WRLCK)
+	return r.flock(unix.F_WRLCK, setLk)
+}
+
+// Lock places a write lock and wait for the corresponding byte-range.
+func (r *ByteRange) Lockw() error {
+	return r.flock(unix.F_WRLCK, setLkw)
 }
 
 // RLock places a read lock for the corresponding byte-range.
 func (r *ByteRange) RLock() error {
-	return r.flock(unix.F_RDLCK)
+	return r.flock(unix.F_RDLCK, setLk)
+}
+
+// RLock places a read lock and wait for the corresponding byte-range.
+func (r *ByteRange) RLockw() error {
+	return r.flock(unix.F_RDLCK, setLkw)
 }
 
 // Unlock removes the lock for the corresponding byte-range.
 func (r *ByteRange) Unlock() error {
-	return r.flock(unix.F_UNLCK)
+	return r.flock(unix.F_UNLCK, setLk)
 }

--- a/pkg/util/fs/lock/lock.go
+++ b/pkg/util/fs/lock/lock.go
@@ -98,7 +98,7 @@ func (r *ByteRange) Lock() error {
 	return r.flock(unix.F_WRLCK, setLk)
 }
 
-// Lock places a write lock and wait for the corresponding byte-range.
+// Lock places a write lock and waits for the corresponding byte-range.
 func (r *ByteRange) Lockw() error {
 	return r.flock(unix.F_WRLCK, setLkw)
 }
@@ -108,7 +108,7 @@ func (r *ByteRange) RLock() error {
 	return r.flock(unix.F_RDLCK, setLk)
 }
 
-// RLock places a read lock and wait for the corresponding byte-range.
+// RLock places a read lock and waits for the corresponding byte-range.
 func (r *ByteRange) RLockw() error {
 	return r.flock(unix.F_RDLCK, setLkw)
 }

--- a/pkg/util/fs/lock/var.go
+++ b/pkg/util/fs/lock/var.go
@@ -11,4 +11,7 @@ package lock
 
 import "golang.org/x/sys/unix"
 
-var setLk = unix.F_SETLK
+var (
+	setLk  = unix.F_SETLK
+	setLkw = unix.F_SETLKW
+)

--- a/pkg/util/fs/lock/var_linux_32bit.go
+++ b/pkg/util/fs/lock/var_linux_32bit.go
@@ -15,4 +15,5 @@ import "golang.org/x/sys/unix"
 
 func init() {
 	setLk = unix.F_SETLK64
+	setLkw = unix.F_SETLKW64
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adding mpi mode for apptainer exec/run to run multiple containers in the same namespace when launched with mpirun


### This fixes or addresses the following GitHub issues:

 - Fixes #1583 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
