### PR TITLE
disable cgroup when --fakeroot is used in instance start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.2.x
 
+- Disable the usage of cgroup in instance creation when `--fakeroot` is passed.
+
 ## v1.2.4 - \[2023-10-10\]
 
 - Fixed a problem with relocating an unprivileged installation of

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -1050,7 +1050,7 @@ func (l *Launcher) setCgroups(instanceName string) error {
 	// root can always create a cgroup.
 	useCG := l.uid == 0
 	// non-root needs cgroups v2 unified mode + systemd as cgroups manager.
-	if l.uid != 0 && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups {
+	if !useCG && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups && !l.cfg.Fakeroot {
 		if os.Getenv("XDG_RUNTIME_DIR") == "" || os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
 			sylog.Infof("Instance stats will not be available because XDG_RUNTIME_DIR")
 			sylog.Infof("  or DBUS_SESSION_BUS_ADDRESS is not set")
@@ -1066,6 +1066,11 @@ func (l *Launcher) setCgroups(instanceName string) error {
 			return err
 		}
 		l.engineConfig.SetCgroupsJSON(cgJSON)
+		return nil
+	}
+
+	if l.cfg.Fakeroot {
+		sylog.Debugf("Instance stats will not be available because of fakeroot mode")
 		return nil
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Aligning the behavior of `apptaienr instance start --fakeroot` on cgroup v1 &v2. 
Disable the cgroup usage on cgroup v2 when `--fakeroot` is passed as well.


### This fixes or addresses the following GitHub issues:

 - Fixes #1749 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)

### Test
```
vagrant@ubuntu:~/test$ cat /etc/os-release 
PRETTY_NAME="Ubuntu 22.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.3 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
vagrant@ubuntu:~/test$ apptainer version
1.2.0-rc.1+457-g1f2bce9ac
vagrant@ubuntu:~/test$ apptainer instance start --fakeroot alpine.sif a1
INFO:    instance started successfully
vagrant@ubuntu:~/test$ apptainer instance list
INSTANCE NAME    PID       IP    IMAGE
a1               282416          /home/vagrant/test/alpine.sif
vagrant@ubuntu:~/test$ apptainer instance stop a1
INFO:    Stopping a1 instance of /home/vagrant/test/alpine.sif (PID=282416)
vagrant@ubuntu:~/test$ 
```