### PR TITLE
Adding libnvidia-nvvm.so to nvliblist.conf to accomodate changes in CUDA12 and NVIDIA Drivers > 530 (release-1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## v1.2.x - \[TBA\]
+
+- Added `libnvidia-nvvm` to `nvliblist.conf`. Newer
+  NVIDIA Drivers (known with >= 525.85.05) require this lib to compile
+  OpenCL programs against NVIDIA GPUs, i.e. `libnvidia-opencl` depends on
+  `libnvidia-nvvm.`
+
 ## v1.2.4 - \[2023-10-10\]
 
 - Fixed a problem with relocating an unprivileged installation of

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -112,4 +112,5 @@
 - Charles Vejnar <charles.vejnar@gmail.com>
 - Carmelo Piccione <carmelo.piccione@gmail.com>
 - Filip Gorczyca <filip.gorczyca141@gmail.com>
+- Benedikt Riedel <benedikt.riedel@gmail.com>
 ```

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -45,6 +45,7 @@ libnvidia-gtk2.so
 libnvidia-gtk3.so
 libnvidia-ifr.so
 libnvidia-ml.so
+libnvidia-nvvm.so
 libnvidia-opencl.so
 libnvidia-opticalflow.so
 libnvidia-ptxjitcompiler.so


### PR DESCRIPTION
Cherry-pick of #1753 to the release-1.2 branch.