### PR TITLE
disable cgroup when --fakeroot is used in instance start (release-1.2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   NVIDIA Drivers (known with >= 525.85.05) require this lib to compile
   OpenCL programs against NVIDIA GPUs, i.e. `libnvidia-opencl` depends on
   `libnvidia-nvvm.`
+- Disable the usage of cgroup in instance creation when `--fakeroot` is passed.
 
 ## v1.2.4 - \[2023-10-10\]
 

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -1050,7 +1050,7 @@ func (l *Launcher) setCgroups(instanceName string) error {
 	// root can always create a cgroup.
 	useCG := l.uid == 0
 	// non-root needs cgroups v2 unified mode + systemd as cgroups manager.
-	if l.uid != 0 && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups {
+	if !useCG && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups && !l.cfg.Fakeroot {
 		if os.Getenv("XDG_RUNTIME_DIR") == "" || os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
 			sylog.Infof("Instance stats will not be available because XDG_RUNTIME_DIR")
 			sylog.Infof("  or DBUS_SESSION_BUS_ADDRESS is not set")
@@ -1066,6 +1066,11 @@ func (l *Launcher) setCgroups(instanceName string) error {
 			return err
 		}
 		l.engineConfig.SetCgroupsJSON(cgJSON)
+		return nil
+	}
+
+	if l.cfg.Fakeroot {
+		sylog.Debugf("Instance stats will not be available because of fakeroot mode")
 		return nil
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry pick https://github.com/apptainer/apptainer/pull/1773 into release-1.2 branch

### This fixes or addresses the following GitHub issues:

 - Fixes #1749


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
