### PR TITLE
disable cgroup when hidepid mount flag is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 ## Changes for v1.2.x
 
 - Disable the usage of cgroup in instance creation when `--fakeroot` is passed.
+- Disable the usage of cgroup in instance creation when `hidepid` mount option
+  on /proc is set.
 
 ## v1.2.4 - \[2023-10-10\]
 

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -1046,11 +1046,12 @@ func (l *Launcher) setCgroups(instanceName string) error {
 		return nil
 	}
 
+	hidePid := hidepidProc()
 	// If we are an instance, always use a cgroup if possible, to enable stats.
 	// root can always create a cgroup.
 	useCG := l.uid == 0
 	// non-root needs cgroups v2 unified mode + systemd as cgroups manager.
-	if !useCG && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups && !l.cfg.Fakeroot {
+	if !useCG && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups && !l.cfg.Fakeroot && !hidePid {
 		if os.Getenv("XDG_RUNTIME_DIR") == "" || os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
 			sylog.Infof("Instance stats will not be available because XDG_RUNTIME_DIR")
 			sylog.Infof("  or DBUS_SESSION_BUS_ADDRESS is not set")
@@ -1071,6 +1072,11 @@ func (l *Launcher) setCgroups(instanceName string) error {
 
 	if l.cfg.Fakeroot {
 		sylog.Debugf("Instance stats will not be available because of fakeroot mode")
+		return nil
+	}
+
+	if hidePid {
+		sylog.Debugf("Instance stats will not be available because of hidepid option is set on /proc mount")
 		return nil
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

disable cgroup when `hidepid` mount flag is set.

### This fixes or addresses the following GitHub issues:

 - Fixes #1779


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
