### PR TITLE
Fix compile instructions to use a full path for builddir

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -146,7 +146,7 @@ You can configure, build, and install Apptainer using the following commands:
 
 ```sh
 ./mconfig
-cd ./builddir
+cd $(/bin/pwd)/builddir
 make
 sudo make install
 ```


### PR DESCRIPTION
This makes the compile instructions work even when the current working directory includes a symlink.
- Fixes #1730