### PR TITLE
env var OMP_NUM_THREADS is upper bound on mksquashfs processors

### DIFF
--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -476,6 +476,8 @@ memory fs type = {{ .MemoryFSType }}
 # This allows the administrator to specify the number of CPUs for mksquashfs 
 # to use when building an image.  The fewer processors the longer it takes.
 # To enable it to use all available CPU's set this to 0.
+# If the environment variable OMP_NUM_THREADS is set to a positive whole 
+# number, OMP_NUM_THREADS will be an upper bound on the number of processors used.
 # mksquashfs procs = 0
 mksquashfs procs = {{ .MksquashfsProcs }}
 


### PR DESCRIPTION

If environment variable OMP_NUM_THREADS is set to some positive integral value, it caps the number of processors used by mksquashfs.  This is useful when running concurrent builds in jobs in a batch environment, and the batch system provisions a certain number of cores for each job to use via the OMP_NUM_THREADS environment variable.  With the default of using all the cores, we can end up with an n-squared problem, where n is the number of cores.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
