### PR TITLE
Optionally use image driver for squashfs and gocryptfs in setuid mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,10 +322,18 @@ jobs:
 
       - name: Fetch deps
         if: env.run_tests
-        run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
+        run: |
+          set -e
+          sudo apt-get -q update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf automake libtool pkg-config libfuse3-dev zlib1g-dev
 
-      - name: Fetch gocryptfs
-        run: wget -O gocryptfs.tar.gz https://github.com/rfjakob/gocryptfs/releases/download/v2.3/gocryptfs_v2.3_linux-static_amd64.tar.gz && sudo tar xzvf gocryptfs.tar.gz -C /usr/local/bin gocryptfs
+      - name: Download, compile, and install dependent packages
+        run: |
+          set -ex
+          mlocal/scripts/download-dependencies .
+          mlocal/scripts/compile-dependencies
+          sudo cp gocryptfs*/gocryptfs squashfuse*/squashfuse_ll /usr/local/bin
 
       # The fuse-overlayfs version from ubuntu-22.04, 1.7, is buggy,
       # so update to version 1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ### Changed defaults / behaviours
 
+- In setuid privileged mode, if `allow setuid-mount squashfs = no` then
+  the squashfuse image driver will be used to mount squash images
+  instead of the kernel squashfs driver.  This eliminates the
+  vulnerability of using a kernel filesystem driver to mount a file
+  writable by an unprivileged user.  Likewise, if
+  `allow setuid-mount encrypted = no` then the unprivileged gocryptfs
+  format will be used for encrypting SIF files instead of the kernel
+  device-mapper.  If a SIF file was encrypted using the gocryptfs
+  format, it can now be mounted in setuid mode in addition to
+  non-setuid mode.
 - `--cwd` is now the preferred form of the flag for setting the container's
   working directory, though `--pwd` is still supported for compatibility.
 - When building RPM, we will now use `/var/lib/apptainer` (rather than

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,6 +28,7 @@ sudo apt-get install -y \
     fuse-overlayfs \
     fakeroot \
     cryptsetup \
+    tzdata \
     curl wget git
 ```
 
@@ -182,7 +183,7 @@ Instructions for installing it from source follow here.
 First, make sure that additional required packages are installed.  On Debian:
 
 ```sh
-apt-get install -y autoconf automake libtool pkg-config libfuse-dev zlib1g-dev
+apt-get install -y autoconf automake libtool pkg-config libfuse3-dev zlib1g-dev
 ```
 
 On CentOS/RHEL:

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -19,7 +19,7 @@ Build-Depends:
  automake,
  libtool,
  pkg-config,
- libfuse-dev,
+ libfuse3-dev,
  zlib1g-dev
 Standards-Version: 3.9.8
 Homepage: http://apptainer.org

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -64,35 +64,21 @@ export APPTAINER_CACHEDIR=$(pkgdir)/var/lib/apptainer/cache
 	dh $@  --with=autoreconf
 
 override_dh_auto_configure:
-	@SQUASHFUSETGZ="`echo debian/squashfuse-*.tar.gz`"; \
-	  if [ -f "$$SQUASHFUSETGZ" ]; then \
-	    set -x; \
-	    tar -C debian -xf $$SQUASHFUSETGZ; \
-	    cd $${SQUASHFUSETGZ%.tar.gz}; \
-	    ./autogen.sh; \
-	    FLAGS=-std=c99 ./configure --enable-multithreading; \
-	    make squashfuse_ll; \
-	  fi
-	@export PATH=$(GOROOT)/bin:$$PATH; \
+	@export GOPATH=$(GOROOT)/bin PATH=$(GOROOT)/bin:$$PATH GOCACHE=$(GOCACHE); \
+	  set -ex; \
 	  if ! ./mlocal/scripts/check-min-go-version go $(MINGO_VERSION); then \
-	    set -e; \
 	    if [ -d $(GOROOT) ]; then rm -rf $(GOROOT); fi; \
 	    mkdir -p $(GOROOT); \
 	    HERE=$$PWD; \
 	    cd $(GOROOT)/..; \
 	    tar -xf $$HERE/debian/go$(MINGO_VERSION).src.tar.gz; \
 	    cd go/src; \
-	    GOCACHE=$(GOCACHE) ./make.bash; \
-	  fi
-	@GOCRYPTFSTGZ="`echo debian/gocryptfs-*.tar.gz`"; \
-	  if [ -f "$$GOCRYPTFSTGZ" ]; then \
-	    set -x; \
-	    tar -C debian -xf $$GOCRYPTFSTGZ; \
-	    cd $${GOCRYPTFSTGZ%.tar.gz}; \
-	    export GOCACHE=$(GOCACHE); \
-	    export GOPATH=$(GOROOT)/bin; \
-	    PATH=$(GOROOT)/bin:$$PATH ./build-without-openssl.bash; \
-	  fi
+	    ./make.bash; \
+	    cd $$HERE; \
+	  fi; \
+	  cd debian; \
+	  ../mlocal/scripts/compile-dependencies; \
+	  cd ..
 ifneq ($(NEW_VERSION),)
 	$(warning "Setting new version in debian changelog: $(NEW_VERSION)")
 	@debchange -v $(NEW_VERSION)$(VERSION_POSTFIX) "Version $(NEW_VERSION)" && debchange -m -r ""

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -151,22 +151,6 @@ Provides the optional setuid-root portion of Apptainer.
 %endif
 
 %build
-%if "%{?gocryptfs_version}" != ""
-pushd ../gocryptfs-%{gocryptfs_version}
-if [ ! -d vendor ]; then
-    (
-    export GOPATH="`pwd`/gopath"
-    go mod vendor
-    go clean -modcache
-    )
-fi
-# GOPROXY=off makes sure we fail instead of making network requests
-# the -B ldflags prevent rpm complaints about "No build ID note found"
-CGO_ENABLED=0 GOPROXY=off ./build.bash -mod=vendor -tags without_openssl \
-    -ldflags="-X main.GitVersion=%{gocryptfs_version} -B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`" 
-popd
-%endif
-
 %if "%{?squashfuse_version}" != ""
 pushd ../squashfuse-%{squashfuse_version}
 ./autogen.sh
@@ -187,6 +171,22 @@ if ! ./mlocal/scripts/check-min-go-version go $GOVERSION; then
 	export PATH=$PWD/go/bin:$PATH
 	popd
 fi
+%endif
+
+%if "%{?gocryptfs_version}" != ""
+pushd ../gocryptfs-%{gocryptfs_version}
+if [ ! -d vendor ]; then
+    (
+    export GOPATH="`pwd`/gopath"
+    go mod vendor
+    go clean -modcache
+    )
+fi
+# GOPROXY=off makes sure we fail instead of making network requests
+# the -B ldflags prevent rpm complaints about "No build ID note found"
+CGO_ENABLED=0 GOPROXY=off ./build.bash -mod=vendor -tags without_openssl \
+    -ldflags="-X main.GitVersion=%{gocryptfs_version} -B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`" 
+popd
 %endif
 
 # Not all of these parameters currently have an effect, but they might be

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -123,6 +123,8 @@ func (c *configTests) prepImages(t *testing.T) (cleanup func(t *testing.T)) {
 	return cleanup
 }
 
+const findsquash = "pstree $PPID|grep squashfuse"
+
 //nolint:maintidx
 func (c configTests) configGlobal(t *testing.T) {
 	cleanup := c.prepImages(t)
@@ -507,6 +509,14 @@ func (c configTests) configGlobal(t *testing.T) {
 			exit:           255,
 		},
 		{
+			name:           "AllowSetuidMountEncryptedNoUnpriv",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedUnprivImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow setuid-mount encrypted",
+			directiveValue: "no",
+			exit:           0,
+		},
+		{
 			name:           "AllowSetuidMountEncryptedNoUserns",
 			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedUnprivImage, "true"},
 			profile:        e2e.UserNamespaceProfile,
@@ -523,32 +533,40 @@ func (c configTests) configGlobal(t *testing.T) {
 			exit:           0,
 		},
 		{
+			name:           "AllowSetuidMountEncryptedYesUnpriv",
+			argv:           []string{"--pem-path", c.pemPrivate, c.encryptedUnprivImage, "true"},
+			profile:        e2e.UserProfile,
+			directive:      "allow setuid-mount encrypted",
+			directiveValue: "yes",
+			exit:           0,
+		},
+		{
 			name:           "AllowSetuidMountSquashfsNo",
-			argv:           []string{c.squashfsImage, "true"},
+			argv:           []string{c.squashfsImage, "sh", "-c", findsquash},
 			profile:        e2e.UserProfile,
 			directive:      "allow setuid-mount squashfs",
 			directiveValue: "no",
-			exit:           255,
+			exit:           0,
 		},
 		{
 			name:           "AllowSetuidMountSquashfsNoSif",
-			argv:           []string{c.sifImage, "true"},
+			argv:           []string{c.sifImage, "sh", "-c", findsquash},
 			profile:        e2e.UserProfile,
 			directive:      "allow setuid-mount squashfs",
 			directiveValue: "no",
-			exit:           255,
+			exit:           0,
 		},
 		{
 			name:           "AllowSetuidMountSquashfsNoBind",
-			argv:           []string{"-B", c.squashfsImage + ":/sqsh:image-src=/", c.sifImage, "true"},
+			argv:           []string{"-B", c.squashfsImage + ":/sqsh:image-src=/", c.sifImage, "sh", "-c", findsquash},
 			profile:        e2e.UserProfile,
 			directive:      "allow setuid-mount squashfs",
 			directiveValue: "no",
-			exit:           255,
+			exit:           0,
 		},
 		{
 			name:           "AllowSetuidMountSquashfsNoUserns",
-			argv:           []string{c.squashfsImage, "true"},
+			argv:           []string{c.squashfsImage, "sh", "-c", findsquash},
 			profile:        e2e.UserNamespaceProfile,
 			directive:      "allow setuid-mount squashfs",
 			directiveValue: "no",
@@ -556,7 +574,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "AllowSetuidMountSquashfsNoUsernsSif",
-			argv:           []string{c.sifImage, "true"},
+			argv:           []string{c.sifImage, "sh", "-c", findsquash},
 			profile:        e2e.UserNamespaceProfile,
 			directive:      "allow setuid-mount squashfs",
 			directiveValue: "no",
@@ -564,7 +582,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "AllowSetuidMountSquashfsNoUsernsBind",
-			argv:           []string{"-B", c.squashfsImage + ":/sqsh:image-src=/", c.sifImage, "true"},
+			argv:           []string{"-B", c.squashfsImage + ":/sqsh:image-src=/", c.sifImage, "sh", "-c", findsquash},
 			profile:        e2e.UserNamespaceProfile,
 			directive:      "allow setuid-mount squashfs",
 			directiveValue: "no",
@@ -572,27 +590,27 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "AllowSetuidMountSquashfsYes",
-			argv:           []string{c.squashfsImage, "true"},
+			argv:           []string{c.squashfsImage, "sh", "-c", findsquash},
 			profile:        e2e.UserProfile,
 			directive:      "allow setuid-mount squashfs",
 			directiveValue: "yes",
-			exit:           0,
+			exit:           1,
 		},
 		{
 			name:           "AllowSetuidMountSquashfsYesSif",
-			argv:           []string{c.sifImage, "true"},
+			argv:           []string{c.sifImage, "sh", "-c", findsquash},
 			profile:        e2e.UserProfile,
 			directive:      "allow setuid-mount squashfs",
 			directiveValue: "yes",
-			exit:           0,
+			exit:           1,
 		},
 		{
 			name:           "AllowSetuidMountSquashfsYesBind",
-			argv:           []string{"-B", c.squashfsImage + ":/sqsh:image-src=/", c.sifImage, "true"},
+			argv:           []string{"-B", c.squashfsImage + ":/sqsh:image-src=/", c.sifImage, "sh", "-c", findsquash},
 			profile:        e2e.UserProfile,
 			directive:      "allow setuid-mount squashfs",
 			directiveValue: "yes",
-			exit:           0,
+			exit:           1,
 		},
 		{
 			name:           "AllowSetuidMountExtfsNo",

--- a/examples/plugins/ubuntu-userns-overlay-plugin/main.go
+++ b/examples/plugins/ubuntu-userns-overlay-plugin/main.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/apptainer/apptainer/pkg/image"
 	pluginapi "github.com/apptainer/apptainer/pkg/plugin"
@@ -67,6 +68,10 @@ func (d *ubuntuOvlDriver) Start(params *image.DriverParams, containerPid int) er
 }
 
 func (d *ubuntuOvlDriver) Stop(target string) error {
+	return nil
+}
+
+func (d *ubuntuOvlDriver) Stopped(int, syscall.WaitStatus) error {
 	return nil
 }
 

--- a/examples/plugins/ubuntu-userns-overlay-plugin/main.go
+++ b/examples/plugins/ubuntu-userns-overlay-plugin/main.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/apptainer/apptainer/pkg/image"
 	pluginapi "github.com/apptainer/apptainer/pkg/plugin"
@@ -63,15 +62,15 @@ func (d *ubuntuOvlDriver) Mount(params *image.MountParams, fn image.MountFunc) e
 	)
 }
 
-func (d *ubuntuOvlDriver) Start(params *image.DriverParams, containerPid int) error {
+func (d *ubuntuOvlDriver) MountErr() error {
+	return nil
+}
+
+func (d *ubuntuOvlDriver) Start(params *image.DriverParams, containerPid int, hybrid bool) error {
 	return nil
 }
 
 func (d *ubuntuOvlDriver) Stop(target string) error {
-	return nil
-}
-
-func (d *ubuntuOvlDriver) Stopped(int, syscall.WaitStatus) error {
 	return nil
 }
 

--- a/internal/pkg/image/packer/gocryptfs.go
+++ b/internal/pkg/image/packer/gocryptfs.go
@@ -121,6 +121,10 @@ func (g *Gocryptfs) init(tmpDir string) (cryptInfo *cryptInfo, err error) {
 		DontElevatePrivs: true,
 	}
 
+	err = g.driver.Start(nil, 0, false)
+	if err != nil {
+		return
+	}
 	err = g.driver.Mount(&mountParams, nil)
 	if err != nil {
 		return

--- a/internal/pkg/image/packer/gocryptfs.go
+++ b/internal/pkg/image/packer/gocryptfs.go
@@ -49,7 +49,7 @@ func NewGocryptfs(keyInfo *cryptkey.KeyInfo) *Gocryptfs {
 		Squashfs: NewSquashfs(),
 	}
 	appfile := apptainerconf.GetCurrentConfig()
-	driver.InitImageDrivers(true, true, appfile, image.ImageFeature)
+	driver.InitImageDrivers(true, true, appfile, image.GocryptFeature)
 	g.gocryptfsPath, _ = bin.FindBin("gocryptfs")
 	g.driver = image.GetDriver(driver.DriverName)
 	g.keyInfo = keyInfo
@@ -57,7 +57,7 @@ func NewGocryptfs(keyInfo *cryptkey.KeyInfo) *Gocryptfs {
 }
 
 func (g *Gocryptfs) HasGocryptfs() bool {
-	return g.driver.Features()&image.ImageFeature != 0 && g.gocryptfsPath != ""
+	return g.driver.Features()&image.GocryptFeature != 0
 }
 
 func (g *Gocryptfs) init(tmpDir string) (cryptInfo *cryptInfo, err error) {

--- a/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
@@ -42,6 +42,8 @@ import (
 // https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#lifecycle.
 // CleanupContainer is performing step 8/9 here.
 func (e *EngineOperations) CleanupContainer(ctx context.Context, fatal error, status syscall.WaitStatus) error {
+	sylog.Debugf("Cleanup container")
+
 	// firstly stop all fuse drivers before any image removal
 	// by image driver interruption or image cleanup for hybrid
 	// fakeroot workflow
@@ -139,6 +141,9 @@ func umount() (err error) {
 			errs = []string{"error restoring capabilities: " + e.Error()}
 		}
 	}()
+
+	// empty target to signify to driver we are entering in the stop phase
+	imageDriver.Stop("")
 
 	// gocryptfs related temp folders
 	var gocryptfsTmp []string

--- a/internal/pkg/runtime/engine/apptainer/monitor_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/monitor_linux.go
@@ -13,11 +13,9 @@ import (
 	"fmt"
 	"os"
 	"syscall"
-	"time"
 
 	"github.com/apptainer/apptainer/internal/pkg/plugin"
 	apptainercallback "github.com/apptainer/apptainer/pkg/plugin/callback/runtime/engine/apptainer"
-	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
 // MonitorContainer is called from master once the container has
@@ -31,55 +29,29 @@ import (
 // Particularly here no additional privileges are gained as monitor does
 // not need them for wait4 and kill syscalls.
 func (e *EngineOperations) MonitorContainer(pid int, signals chan os.Signal) (syscall.WaitStatus, error) {
-	var status syscall.WaitStatus
-
 	callbackType := (apptainercallback.MonitorContainer)(nil)
 	callbacks, err := plugin.LoadCallbacks(callbackType)
 	if err != nil {
-		return status, fmt.Errorf("while loading plugins callbacks '%T': %s", callbackType, err)
+		return 0, fmt.Errorf("while loading plugins callbacks '%T': %s", callbackType, err)
 	}
 	if len(callbacks) > 1 {
-		return status, fmt.Errorf("multiple plugins have registered callback for '%T'", callbackType)
+		return 0, fmt.Errorf("multiple plugins have registered callback for '%T'", callbackType)
 	} else if len(callbacks) == 1 {
 		return callbacks[0].(apptainercallback.MonitorContainer)(e.CommonConfig, pid, signals)
 	}
 
-	// Prevent the signal loop from waiting indefinitely by waking it up
-	// periodically, because we have seen sometimes SIGCHLD doesn't show.
-	// This problem has been seen in particular in setuid mode on
-	// Ubuntu 22.04 when one of the image driver programs dies with
-	// an immediate error.
-	go func() {
-		pid := syscall.Getpid()
-		for {
-			time.Sleep(time.Second)
-			syscall.Kill(pid, syscall.SIGURG)
-		}
-	}()
+	var status syscall.WaitStatus
 
 	for {
 		s := <-signals
 		switch s {
 		case syscall.SIGCHLD:
-			wpid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
-			if err != nil {
-				return status, fmt.Errorf("error while waiting for child: %s", err)
-			}
-			if wpid == 0 {
-				// no child was actually waiting to be reaped
+			if wpid, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil); err != nil {
+				return status, fmt.Errorf("error while waiting child: %s", err)
+			} else if wpid != pid {
 				continue
 			}
-			sylog.Debugf("SIGCHLD received for process %d", wpid)
-			if imageDriver != nil {
-				err := imageDriver.Stopped(wpid, status)
-				if err != nil {
-					return status, err
-				}
-			}
-			if wpid == pid {
-				return status, nil
-			}
-			continue
+			return status, nil
 		case syscall.SIGURG:
 			// Ignore SIGURG, which is used for non-cooperative goroutine
 			// preemption starting with Go 1.14. For more information, see

--- a/mlocal/scripts/compile-dependencies
+++ b/mlocal/scripts/compile-dependencies
@@ -1,0 +1,20 @@
+#!/bin/bash
+# 
+# Compile dependencies.  The source tarballs are assumed to be in the
+# current working directory.
+
+set -ex
+
+SQUASHFUSETGZ="$(echo squashfuse-*.tar.gz)"
+tar -xf $SQUASHFUSETGZ
+cd ${SQUASHFUSETGZ%.tar.gz}
+./autogen.sh
+FLAGS=-std=c99 ./configure --enable-multithreading
+make squashfuse_ll
+cd ..
+
+GOCRYPTFSTGZ="$(echo gocryptfs-*.tar.gz)"
+tar -xf $GOCRYPTFSTGZ
+cd ${GOCRYPTFSTGZ%.tar.gz}
+./build-without-openssl.bash
+cd ..

--- a/mlocal/scripts/download-dependencies
+++ b/mlocal/scripts/download-dependencies
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Download additional source urls listed in rpm into directory in $1.
+# Assumes being run from the top of the apptainer source directory.
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 downloaddir" >&2
+    exit 2
+fi
+
+set -e
+SPEC=dist/rpm/apptainer.spec.in
+DOWNLOADURL="$(sed -n "s/^Source[1-9][0-9]*: //p" $SPEC)"
+SUBS="$(sed -n "s/.*%global //p" $SPEC)"
+for URL in $DOWNLOADURL; do
+    if [[ "$URL" != http* ]]; then
+        continue
+    fi
+    URL=$(echo "$SUBS" | (while read -r FROM TO; do
+            URL="${URL//%\{$FROM\}/$TO}"
+          done
+          echo $URL))
+    BASE="$(basename $URL)"
+    echo "+ curl -f -L -sS -o $1/$BASE $URL" >&2
+    curl -f -L -sS -o $1/$BASE $URL
+done

--- a/pkg/image/driver.go
+++ b/pkg/image/driver.go
@@ -11,6 +11,7 @@ package image
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
 )
@@ -19,13 +20,20 @@ import (
 type DriverFeature uint16
 
 const (
-	// ImageFeature means the driver handle image mount setup.
-	ImageFeature DriverFeature = 1 << iota
+	// SquashFeature means the driver handles squashfs image mounts.
+	SquashFeature DriverFeature = 1 << iota
+	// Ext3Feature means the driver handles ext3fs image mounts.
+	Ext3Feature
+	// GocryptFeature means the driver handles gocryptfs image mounts.
+	GocryptFeature
 	// OverlayFeature means the driver handle overlay mount.
 	OverlayFeature
-	// FuseFeature means the driver use FUSE.
+	// FuseFeature means the driver uses FUSE as its base.
 	FuseFeature
 )
+
+// ImageFeature means the driver handles any of the image mount types
+const ImageFeature = SquashFeature | Ext3Feature | GocryptFeature
 
 // MountFunc defines mount function prototype
 type MountFunc func(source string, target string, filesystem string, flags uintptr, data string) error
@@ -61,6 +69,10 @@ type Driver interface {
 	Start(*DriverParams, int) error
 	// Stop the driver related to given mount target for cleanup.
 	Stop(string) error
+	// Check if any of the image driver processes matches the given
+	// pid that exited with the given status and return an error if
+	// one of them does, or nil if they do not.
+	Stopped(int, syscall.WaitStatus) error
 	// Features Feature returns supported features.
 	Features() DriverFeature
 }

--- a/pkg/image/driver.go
+++ b/pkg/image/driver.go
@@ -11,7 +11,6 @@ package image
 
 import (
 	"fmt"
-	"syscall"
 
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
 )
@@ -65,14 +64,13 @@ type DriverParams struct {
 type Driver interface {
 	// Mount is called each time an engine mount an image
 	Mount(*MountParams, MountFunc) error
+	// MountErr returns driver mount errors.
+	MountErr() error
 	// Start the driver for initialization.
-	Start(*DriverParams, int) error
-	// Stop the driver related to given mount target for cleanup.
+	Start(*DriverParams, int, bool) error
+	// Stop the driver related to given mount target for cleanup,
+	// an empty target signify to the driver to prepare for stop.
 	Stop(string) error
-	// Check if any of the image driver processes matches the given
-	// pid that exited with the given status and return an error if
-	// one of them does, or nil if they do not.
-	Stopped(int, syscall.WaitStatus) error
 	// Features Feature returns supported features.
 	Features() DriverFeature
 }

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -259,21 +259,25 @@ func (i *Image) GetDataPartitions() ([]Section, error) {
 	return i.getPartitions(DataUsage)
 }
 
-// HasEncryptedRootFs returns true if the image contains an encrypted
-// rootfs partition.
-func (i *Image) HasEncryptedRootFs() (encrypted bool, err error) {
+// EncryptedRootFs returns "encryptfs" if the image contains a device-mapper
+// encrypted root partition, "gocryptfs" if it contains a gocryptfs
+// encrypted root partition, or an empty string if there is no encryption
+func (i *Image) EncryptedRootFs() (encryptionType string, err error) {
 	rootFsParts, err := i.GetRootFsPartitions()
 	if err != nil {
-		return false, fmt.Errorf("while getting root FS partitions: %v", err)
+		return "", fmt.Errorf("while getting root FS partitions: %v", err)
 	}
 
 	for _, p := range rootFsParts {
-		if p.Type == ENCRYPTSQUASHFS || p.Type == GOCRYPTFSSQUASHFS {
-			return true, nil
+		if p.Type == ENCRYPTSQUASHFS {
+			return "encryptfs", nil
+		}
+		if p.Type == GOCRYPTFSSQUASHFS {
+			return "gocryptfs", nil
 		}
 	}
 
-	return false, nil
+	return "", nil
 }
 
 // writeLocks tracks write locks for the current process.

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -20,6 +20,7 @@ apt-get install -y \
     fuse-overlayfs \
     fakeroot \
     cryptsetup \
+    tzdata \
     curl wget git
 apt-get install -y \
     devscripts \
@@ -32,7 +33,7 @@ apt-get install -y \
     uuid-dev \
     golang-go
 # for squashfuse_ll build
-apt-get install -y autoconf automake libtool pkg-config libfuse-dev zlib1g-dev
+apt-get install -y autoconf automake libtool pkg-config libfuse3-dev zlib1g-dev
 
 # move source code down a level because debuild writes into parent dir
 shopt -s extglob
@@ -66,24 +67,10 @@ su testuser -c '
     fi
   fi
   go version
-  # download additional source urls listed in rpm
-  SPEC=dist/rpm/apptainer.spec.in
-  DOWNLOADURL="$(sed -n "s/^Source[1-9][0-9]*: //p" $SPEC)"
-  SUBS="$(sed -n "s/.*%global //p" $SPEC)"
-  for URL in $DOWNLOADURL; do
-      if [[ "$URL" != http* ]]; then
-	  continue
-      fi
-      URL=$(echo "$SUBS" | (while read FROM TO; do
-	      URL="$(echo $URL|sed "s,%{$FROM},$TO,g")"
-	    done
-	    echo $URL))
-      BASE="$(basename $URL)"
-      curl -f -L -sS -o debian/$BASE $URL
-  done
+  mlocal/scripts/download-dependencies debian
   export DEB_FULLNAME="'"${DEB_FULLNAME:-CI Test}"'"
   export DEBEMAIL="'${DEBEMAIL:-citest@example.com}'"
-  debuild --build=binary --no-sign --lintian-opts --display-info --show-overrides
+  debuild --prepend-path $PATH --build=binary --no-sign --lintian-opts --display-info --show-overrides
   sudo dpkg -i ../apptainer*.deb
 
   apptainer exec oras://ghcr.io/apptainer/alpine:3.15.0 /bin/true

--- a/scripts/ci-docker-run
+++ b/scripts/ci-docker-run
@@ -16,7 +16,7 @@
 DOCKER_HUB_URI="$OS_TYPE:$OS_VERSION"
 docker pull "$DOCKER_HUB_URI"
 
-DOCKER_CONTAINER_NAME="test_${OS_TYPE##*/}_${OS_VERSION}"
+DOCKER_CONTAINER_NAME="test_${OS_TYPE##*/}_${OS_VERSION//./_}"
 PKGTYPE=rpm
 if [ "$OS_TYPE" = "debian" ] || [ "$OS_TYPE" = "ubuntu" ]; then
     PKGTYPE=deb


### PR DESCRIPTION
This enables using the fuse-based internal image driver for squashfs and gocryptfs in setuid mode in addition to the unprivileged mode it supported previously.  Requires that the fuse programs are using libfuse3 because it uses the newer feature where the privileged code does the mount and passes in an open file descriptor pointing to /dev/fuse in place of the mountpoint to the library.  This also makes things ready for fuse2fs in setuid mode, but that needs to wait until fuse2fs supports libfuse3.  I will make another issue for that.

- Fixes #1411