### PR TITLE
Use session dir rather than temp dir when doing gocryptfs mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   supplying the `--no-default` (or `-n`) flag to `remote add`.
 - Skip parsing build definition file template variables after comments
   beginning with a hash symbol.
+- Using the session directory instead of the global temp directory for gocryptfs
+  mount.
 
 ### New Features & Functionality
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -11,6 +11,7 @@ package apptainer
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -44,6 +45,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/fs/proc"
 	"github.com/apptainer/apptainer/pkg/util/namespaces"
 	"github.com/apptainer/apptainer/pkg/util/slice"
+	"github.com/google/uuid"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -2984,17 +2986,23 @@ func (c *container) getBindFlags(source string, defaultFlags uintptr) (uintptr, 
 
 func (c *container) gocryptfsMount(params *image.MountParams, system *mount.System, mfunc image.MountFunc) error {
 	// Prepare gocryptfs decryption info
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "gocryptfs-")
+	gocryptfsDir := fmt.Sprintf("/gocryptfs-%s", base64.StdEncoding.EncodeToString([]byte(uuid.NewString())))
+	err := c.session.AddDir(gocryptfsDir)
+	if err != nil {
+		return err
+	}
+
+	tmpDir, err := c.session.GetPath(gocryptfsDir)
 	if err != nil {
 		return err
 	}
 	cipherDir := filepath.Join(tmpDir, "cipher")
-	err = os.Mkdir(cipherDir, 0o700)
+	err = os.MkdirAll(cipherDir, 0o700)
 	if err != nil {
 		return err
 	}
 	plainDir := filepath.Join(tmpDir, "plain")
-	err = os.Mkdir(plainDir, 0o700)
+	err = os.MkdirAll(plainDir, 0o700)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Using session dir rather than temp dir.


### This fixes or addresses the following GitHub issues:

 - Fixes #1832 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
