### PR TITLE
Improve key list output, from sylabs 1957

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   supplying the `--no-default` (or `-n`) flag to `remote add`.
 - Skip parsing build definition file template variables after comments
   beginning with a hash symbol.
+- Improved the clarity of `apptainer key list` output.
 
 ### New Features & Functionality
 

--- a/e2e/key/key.go
+++ b/e2e/key/key.go
@@ -650,7 +650,10 @@ func (c *ctx) checkKeyLength(t *testing.T, expectedKeyLength int) {
 			e2e.WithArgs(cmdArgs...),
 			e2e.ExpectExit(
 				0,
-				e2e.ExpectOutput(e2e.ContainMatch, "L: "+strconv.Itoa(expectedKeyLength)),
+				e2e.ExpectOutput(
+					e2e.RegexMatch,
+					`Length \(in bits\):[ ]+`+strconv.Itoa(expectedKeyLength),
+				),
 			),
 		)
 	}

--- a/internal/pkg/sypgp/sypgp.go
+++ b/internal/pkg/sypgp/sypgp.go
@@ -283,7 +283,7 @@ func loadKeysFromFile(fn string) (openpgp.EntityList, error) {
 
 // printEntity pretty prints an entity entry to w
 func printEntity(w io.Writer, index int, e *openpgp.Entity) {
-	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(tw, "%d)", index)
 	for _, v := range e.Identities {
 		fmt.Fprintf(tw, "\tUser:\t%s (%s) <%s>\n", v.UserId.Name, v.UserId.Comment, v.UserId.Email)

--- a/internal/pkg/sypgp/sypgp.go
+++ b/internal/pkg/sypgp/sypgp.go
@@ -283,20 +283,22 @@ func loadKeysFromFile(fn string) (openpgp.EntityList, error) {
 
 // printEntity pretty prints an entity entry to w
 func printEntity(w io.Writer, index int, e *openpgp.Entity) {
-	// TODO(mem): this should not be here, this is presentation
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "%d)", index)
 	for _, v := range e.Identities {
-		fmt.Fprintf(w, "%d) U: %s (%s) <%s>\n", index, v.UserId.Name, v.UserId.Comment, v.UserId.Email)
+		fmt.Fprintf(tw, "\tUser:\t%s (%s) <%s>\n", v.UserId.Name, v.UserId.Comment, v.UserId.Email)
 	}
-	fmt.Fprintf(w, "   C: %s\n", e.PrimaryKey.CreationTime)
-	fmt.Fprintf(w, "   F: %0X\n", e.PrimaryKey.Fingerprint)
+	fmt.Fprintf(tw, "\tCreation time:\t%s\n", e.PrimaryKey.CreationTime)
+	fmt.Fprintf(tw, "\tFingerprint:\t%0X\n", e.PrimaryKey.Fingerprint)
 	bits, _ := e.PrimaryKey.BitLength()
-	fmt.Fprintf(w, "   L: %d\n", bits)
+	fmt.Fprintf(tw, "\tLength (in bits):\t%d\n", bits)
+	tw.Flush()
+	fmt.Fprintln(w)
 }
 
 func printEntities(w io.Writer, entities openpgp.EntityList) {
 	for i, e := range entities {
 		printEntity(w, i, e)
-		fmt.Fprint(w, "   --------\n")
 	}
 }
 

--- a/internal/pkg/sypgp/sypgp_test.go
+++ b/internal/pkg/sypgp/sypgp_test.go
@@ -331,7 +331,7 @@ func TestPrintEntity(t *testing.T) {
 					},
 				},
 			},
-			expected: "1) U: name 1 (comment 1) <email.1@example.org>\n   C: 2011-01-23 16:49:20 +0000 UTC\n   F: 5FB74B1D03B1E3CB31BC2F8AA34D7E18C20C31BB\n   L: 1024\n",
+			expected: "1)  User:              name 1 (comment 1) <email.1@example.org>\n    Creation time:     2011-01-23 16:49:20 +0000 UTC\n    Fingerprint:       5FB74B1D03B1E3CB31BC2F8AA34D7E18C20C31BB\n    Length (in bits):  1024\n\n",
 		},
 		{
 			name:  "DSA key",
@@ -348,7 +348,7 @@ func TestPrintEntity(t *testing.T) {
 					},
 				},
 			},
-			expected: "2) U: name 2 (comment 2) <email.2@example.org>\n   C: 2011-01-28 21:05:13 +0000 UTC\n   F: EECE4C094DB002103714C63C8E8FBE54062F19ED\n   L: 1024\n",
+			expected: "2)  User:              name 2 (comment 2) <email.2@example.org>\n    Creation time:     2011-01-28 21:05:13 +0000 UTC\n    Fingerprint:       EECE4C094DB002103714C63C8E8FBE54062F19ED\n    Length (in bits):  1024\n\n",
 		},
 		{
 			name:  "ECDSA key",
@@ -365,7 +365,7 @@ func TestPrintEntity(t *testing.T) {
 					},
 				},
 			},
-			expected: "3) U: name 3 (comment 3) <email.3@example.org>\n   C: 2012-10-07 17:57:40 +0000 UTC\n   F: 9892270B38B8980B05C8D56D43FE956C542CA00B\n   L: 1059\n",
+			expected: "3)  User:              name 3 (comment 3) <email.3@example.org>\n    Creation time:     2012-10-07 17:57:40 +0000 UTC\n    Fingerprint:       9892270B38B8980B05C8D56D43FE956C542CA00B\n    Length (in bits):  1059\n\n",
 		},
 	}
 
@@ -424,12 +424,9 @@ func TestPrintEntities(t *testing.T) {
 		},
 	}
 
-	expected := "0) U: name 1 (comment 1) <email.1@example.org>\n   C: 2011-01-23 16:49:20 +0000 UTC\n   F: 5FB74B1D03B1E3CB31BC2F8AA34D7E18C20C31BB\n   L: 1024\n" +
-		"   --------\n" +
-		"1) U: name 2 (comment 2) <email.2@example.org>\n   C: 2011-01-28 21:05:13 +0000 UTC\n   F: EECE4C094DB002103714C63C8E8FBE54062F19ED\n   L: 1024\n" +
-		"   --------\n" +
-		"2) U: name 3 (comment 3) <email.3@example.org>\n   C: 2012-10-07 17:57:40 +0000 UTC\n   F: 9892270B38B8980B05C8D56D43FE956C542CA00B\n   L: 1059\n" +
-		"   --------\n"
+	expected := "0)  User:              name 1 (comment 1) <email.1@example.org>\n    Creation time:     2011-01-23 16:49:20 +0000 UTC\n    Fingerprint:       5FB74B1D03B1E3CB31BC2F8AA34D7E18C20C31BB\n    Length (in bits):  1024\n\n" +
+		"1)  User:              name 2 (comment 2) <email.2@example.org>\n    Creation time:     2011-01-28 21:05:13 +0000 UTC\n    Fingerprint:       EECE4C094DB002103714C63C8E8FBE54062F19ED\n    Length (in bits):  1024\n\n" +
+		"2)  User:              name 3 (comment 3) <email.3@example.org>\n    Creation time:     2012-10-07 17:57:40 +0000 UTC\n    Fingerprint:       9892270B38B8980B05C8D56D43FE956C542CA00B\n    Length (in bits):  1059\n\n"
 
 	var b bytes.Buffer
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Cherry pick
- sylabs/singularity#1957

which had an original description of  
> Improves the clarity of the output of `singularity key list`.


### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in
- #1844
