### PR TITLE
 add indicator for the default remote in keyserver list output, from sylabs #1958 

### DIFF
--- a/e2e/keyserver/keyserver.go
+++ b/e2e/keyserver/keyserver.go
@@ -50,7 +50,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: addKeyserver,
 			args:    []string{"--insecure", testKeyserver},
 			listLines: []string{
-				"DefaultRemote*",
+				"DefaultRemote*^",
 				"   #1  https://keys.openpgp.org  🔒",
 				"   #2  http://localhost:11371",
 			},
@@ -83,7 +83,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: addKeyserver,
 			args:    []string{"--order", "1", testKeyserver},
 			listLines: []string{
-				"DefaultRemote*",
+				"DefaultRemote*^",
 				"   #1  http://localhost:11371    🔒",
 				"   #2  https://keys.openpgp.org  🔒",
 			},
@@ -102,7 +102,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: removeKeyserver,
 			args:    []string{apptainerKeyserver},
 			listLines: []string{
-				"DefaultRemote*",
+				"DefaultRemote*^",
 				"   #1  http://localhost:11371  🔒",
 			},
 			expectExit: 0,
@@ -120,7 +120,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: addKeyserver,
 			args:    []string{apptainerKeyserver},
 			listLines: []string{
-				"DefaultRemote*",
+				"DefaultRemote*^",
 				"   #1  http://localhost:11371    🔒",
 				"   #2  https://keys.openpgp.org  🔒",
 			},
@@ -132,7 +132,7 @@ func (c ctx) keyserver(t *testing.T) {
 			command: removeKeyserver,
 			args:    []string{testKeyserver},
 			listLines: []string{
-				"DefaultRemote*",
+				"DefaultRemote*^",
 				"   #1  https://keys.openpgp.org  🔒",
 			},
 			expectExit: 0,

--- a/internal/app/apptainer/keyserver_list.go
+++ b/internal/app/apptainer/keyserver_list.go
@@ -42,13 +42,22 @@ func KeyserverList(remoteName string, usrConfigFile string) (err error) {
 		return err
 	}
 
+	defaultRemote, err := c.GetDefault()
+	if err != nil {
+		return fmt.Errorf("error getting default remote-endpoint: %w", err)
+	}
+
 	for epName, ep := range c.Remotes {
 		fmt.Println()
 		isSystem := ""
 		if ep.System {
 			isSystem = "*"
 		}
-		fmt.Printf("%s%s\n", epName, isSystem)
+		isDefault := ""
+		if ep == defaultRemote {
+			isDefault = "^"
+		}
+		fmt.Printf("%s%s%s\n", epName, isSystem, isDefault)
 
 		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		if err := ep.UpdateKeyserversConfig(); err != nil {
@@ -71,7 +80,7 @@ func KeyserverList(remoteName string, usrConfigFile string) (err error) {
 	}
 
 	fmt.Println()
-	fmt.Println("(* = system endpoint)")
+	fmt.Println("(* = system endpoint, ^ = default endpoint)")
 
 	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry pick
- https://github.com/sylabs/singularity/pull/1958

which had an original description of
> Adds an indicator for the in-use (="default") remote endpoint in the output of singularity keyserver list.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in
- #1844
