### PR TITLE
add --config to `keyserver` cmd, honor optional remoteName arg, from sylabs #2035

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   cgroup and collect system metrics.
 - A new `--no-pid` flag for `apptainer run/shell/exec` disables the PID namespace
   inferred by `--containall` and `--compat`.
+- Added `--config` option to`keyserver` commands.
+- Honor an optional remoteName argument to the `keyserver list` command.
 
 ### Developer / API
 

--- a/cmd/internal/cli/keyserver.go
+++ b/cmd/internal/cli/keyserver.go
@@ -25,6 +25,16 @@ var (
 	keyserverOrder    uint32
 )
 
+// -c|--config
+var keyserverConfigFlag = cmdline.Flag{
+	ID:           "keyserverConfigFlag",
+	Value:        &remoteConfig,
+	DefaultValue: remoteConfigUser,
+	Name:         "config",
+	ShortHand:    "c",
+	Usage:        "path to the file holding keyserver configurations",
+}
+
 // -i|--insecure
 var keyserverInsecureFlag = cmdline.Flag{
 	ID:           "keyserverInsecureFlag",
@@ -84,6 +94,9 @@ func init() {
 		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverLoginCmd)
 		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverLogoutCmd)
 		cmdManager.RegisterSubCmd(KeyserverCmd, KeyserverListCmd)
+
+		// default location of the remote.yaml file is the user directory
+		cmdManager.RegisterFlagForCmd(&keyserverConfigFlag, KeyserverCmd)
 
 		cmdManager.RegisterFlagForCmd(&keyserverOrderFlag, KeyserverAddCmd)
 		cmdManager.RegisterFlagForCmd(&keyserverInsecureFlag, KeyserverAddCmd)

--- a/cmd/internal/cli/registry.go
+++ b/cmd/internal/cli/registry.go
@@ -25,7 +25,7 @@ var registryConfigFlag = cmdline.Flag{
 	DefaultValue: remoteConfigUser,
 	Name:         "config",
 	ShortHand:    "c",
-	Usage:        "path to the file holding remote endpoint configurations",
+	Usage:        "path to the file holding registry configurations",
 }
 
 // -u|--username

--- a/docs/keyserver.go
+++ b/docs/keyserver.go
@@ -81,9 +81,9 @@ const (
 	KeyserverListUse   string = `list [remoteName]`
 	KeyserverListShort string = `List all keyservers that are configured`
 	KeyserverListLong  string = `
-  The 'keyserver list' command lists all keyservers configured for use with a
-  given remote endpoint. If no endpoint is specified, the default
-  remote endpoint will be assumed.`
+  The 'keyserver list' command lists the keyservers configured for use with
+  each remote endpoint. If the optional remoteName argument is provided, the
+  command will only list keyservers for the remote endpoint matching that name.`
 	KeyserverListExample string = `
   $ apptainer keyserver list`
 )

--- a/e2e/remote/remote.go
+++ b/e2e/remote/remote.go
@@ -35,7 +35,11 @@ func (c ctx) remoteAdd(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	testPass := []struct {
 		name   string
@@ -175,7 +179,11 @@ func (c ctx) remoteRemove(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	// Prep config by adding multiple remotes
 	add := []struct {
@@ -248,7 +256,11 @@ func (c ctx) remoteUse(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	testFail := []struct {
 		name   string
@@ -322,7 +334,11 @@ func (c ctx) remoteStatus(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	// Prep config by adding multiple remotes
 	add := []struct {
@@ -393,7 +409,11 @@ func (c ctx) remoteList(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	defer os.Remove(config.Name()) // clean up
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.Remove(config.Name()) // clean up
+		}
+	})
 
 	testPass := []struct {
 		name string


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry pick
- sylabs/singularity#2035
which addressed
- sylabs/singularity#2034

which had an original description of

>  Add --config option to keyserver command. (This was available when keyservers were manipulated using the remote command, but not ported over to the keyserver command until this PR.) Utilize this flag in e2e testing of keyserver command. 
> Honor optional remoteName argument to keyserver list subcommand to list only the keyservers configured for a particular remote endpoint. Add e2e tests for this.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in
- #1844
