### PR TITLE
deps: update mvdan.cc/sh to commit 8b67386, from sylabs #2287

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Don't bind `/var/tmp` on top of `/tmp` in the container, where `/var/tmp`
   resolves to same location as `/tmp`.
+- Support parentheses in `test` / `[` commands in container startup scripts,
+  via dependency update of mvdan.cc/sh.
 
 ## Changes for v1.2.x
 

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1
-	mvdan.cc/sh/v3 v3.7.0
+	mvdan.cc/sh/v3 v3.7.1-0.20231014181306-8b673862efc6
 	oras.land/oras-go v1.2.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -834,5 +834,5 @@ gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-mvdan.cc/sh/v3 v3.7.0 h1:lSTjdP/1xsddtaKfGg7Myu7DnlHItd3/M2tomOcNNBg=
-mvdan.cc/sh/v3 v3.7.0/go.mod h1:K2gwkaesF/D7av7Kxl0HbF5kGOd2ArupNTX3X44+8l8=
+mvdan.cc/sh/v3 v3.7.1-0.20231014181306-8b673862efc6 h1:X0JtrTYSV9TYmOIoNhB/mMYkg1YxwRl9iwFNMhI+En0=
+mvdan.cc/sh/v3 v3.7.1-0.20231014181306-8b673862efc6/go.mod h1:5hco898titbMf+9Y1bnuzVQAHgb/EpGCSN390uVmAVU=


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry pick
- sylabs/singularity#2287
which fixed
- sylabs/singularity#2286

> Update mvdan.cc/sh to commit 8b67386. This allows execution of action scripts to correctly support parentheses in test / [ commands.
> Required to support NVIDIA's NGC container .singularity.d scripts without error.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in
- #1844
