### PR TITLE
feat: --no-pid action flag, from sylabs #1971

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Add monitoring feature support, which requires the usage of an additional tool
   named `apptheus`, this tool will put apptainer starter into a newly created
   cgroup and collect system metrics.
+- A new `--no-pid` flag for `apptainer run/shell/exec` disables the PID namespace
+  inferred by `--containall` and `--compat`.
 
 ### Developer / API
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -59,11 +59,12 @@ var (
 	noUmask         bool
 	disableCache    bool
 
-	netNamespace  bool
-	utsNamespace  bool
-	userNamespace bool
-	pidNamespace  bool
-	ipcNamespace  bool
+	netNamespace   bool
+	utsNamespace   bool
+	userNamespace  bool
+	pidNamespace   bool
+	noPidNamespace bool
+	ipcNamespace   bool
 
 	allowSUID bool
 	keepPrivs bool
@@ -489,6 +490,16 @@ var actionPidNamespaceFlag = cmdline.Flag{
 	EnvKeys:      []string{"PID", "UNSHARE_PID"},
 }
 
+// --no-pid
+var actionNoPidNamespaceFlag = cmdline.Flag{
+	ID:           "actionNoPidNamespaceFlag",
+	Value:        &noPidNamespace,
+	DefaultValue: false,
+	Name:         "no-pid",
+	Usage:        "do not run container in a new PID namespace",
+	EnvKeys:      []string{"NO_PID"},
+}
+
 // -i|--ipc
 var actionIpcNamespaceFlag = cmdline.Flag{
 	ID:           "actionIpcNamespaceFlag",
@@ -859,6 +870,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&commonPromptForPassphraseFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonPEMFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPidNamespaceFlag, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNoPidNamespaceFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionCwdFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionPwdFlag, actionsCmd...)
 		cmdManager.RegisterFlagForCmd(&actionScratchFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -249,11 +249,12 @@ var TestCmd = &cobra.Command{
 
 func launchContainer(cmd *cobra.Command, image string, args []string, instanceName string) error {
 	ns := launch.Namespaces{
-		User: userNamespace,
-		UTS:  utsNamespace,
-		PID:  pidNamespace,
-		IPC:  ipcNamespace,
-		Net:  netNamespace,
+		User:  userNamespace,
+		UTS:   utsNamespace,
+		PID:   pidNamespace,
+		IPC:   ipcNamespace,
+		Net:   netNamespace,
+		NoPID: noPidNamespace,
 	}
 
 	cgJSON, err := getCgroupsJSON()

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -169,6 +169,8 @@ type Namespaces struct {
 	PID  bool
 	IPC  bool
 	Net  bool
+	// NoPID will force the PID namespace not to be used, even if set by default / other flags.
+	NoPID bool
 }
 
 type Option func(co *launchOptions) error


### PR DESCRIPTION
## Description of the Pull Request (PR):

Reimplementation of the following PR
https://github.com/sylabs/singularity/pull/1971

which had an original description of

> Add a new flag, --no-pid which prevents the use of a PID namespace, when running a container with --compat / --containall / --oci which infer --pid.
> Allows working around potential issues with applications across parallel container executions that expect to be working in a common PID namespace.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in
- #1844