### PR TITLE
fix: prevent scope error with docker io registry login, from sylab #2033

### DIFF
--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -144,10 +144,8 @@ func checkOCILogin(regName string, username, password string, insecure bool) err
 		Password: password,
 	})
 
-	scopes := []string{reg.Scope("")}
-
 	// Creating a new transport pings the registry and works through auth flow.
-	_, err = transport.NewWithContext(context.TODO(), reg, auth, http.DefaultTransport, scopes)
+	_, err = transport.NewWithContext(context.TODO(), reg, auth, http.DefaultTransport, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry-pick https://github.com/sylabs/singularity/pull/2033

which had an original description of
> Use empty scopes for the registry ping after singularity registry login, as a "" scope is resolving to a registry level scope that gives an error when logging in to Docker Hub. May result in the credentials not being properly validated, i.e. login with bad password succeeding. However, this is the best we can do at the moment with ggcr - after extensive investigation by tri-adam and wobito.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in
- #1844
