### PR TITLE
chore: enable additional linters without lint, from sylabs 2028

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,21 +7,28 @@ linters:
   disable-all: true
   enable-all: false
   enable:
+    - asciicheck
+    - bidichk
     - containedctx
     - contextcheck
     - decorder
     - dupl
     - gofumpt
     - goimports
+    - gomodguard
+    - goprintffuncname
     - gosimple
     - govet
     - grouper
     - ineffassign
+    - interfacebloat
     - maintidx
     - misspell
     - nakedret
+    - reassign
     - revive
     - staticcheck
+    - typecheck
     - unused
 
 linters-settings:


### PR DESCRIPTION
This pulls in sylabs PR

    sylabs/singularity#2028

The original PR description was:
> From #2024, enable the linters that don't (yet) report any lint.