### PR TITLE
Add new default `allow setuid-mount squashfs = iflimited`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,37 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.3.x
 
+Changes since v1.2.5
+
 ### Changed defaults / behaviours
 
-- In setuid privileged mode, if `allow setuid-mount squashfs = no` then
-  the squashfuse image driver will be used to mount squash images
-  instead of the kernel squashfs driver.  This eliminates the
-  vulnerability of using a kernel filesystem driver to mount a file
-  writable by an unprivileged user.
-  Likewise, if `allow setuid-mount extfs = no` (the default) then the
-  fuse2fs image driver will be used to mount ext3 images in setuid mode
-  instead of the kernel driver (ext3 images are primarily used for the
-  `--overlay` feature).
-  The `fuse-overlayfs` driver will also now be tried in setuid mode
+- FUSE mounts are now supported in setuid mode, enabling full
+  functionality even when kernel filesystem mounts are insecure
+  due to unprivileged users having write access to raw filesystems
+  in containers.
+
+  When `allow setuid-mount extfs = no` (the default) in apptainer.conf,
+  then the fuse2fs image driver will be used to mount ext3 images in setuid
+  mode instead of the kernel driver (ext3 images are primarily used for the
+  `--overlay` feature), restoring functionality that was removed by
+  default in Apptainer 1.1.8 because of the security risk.
+
+  The `allow setuid-mount squashfs` configuration option in
+  apptainer.conf now has a new default called `iflimited` which allows
+  kernel squashfs mounts only if there is at least one `limit container`
+  option set or if Execution Control Lists are activated in ecl.toml.
+  If kernel squashfs mounts are are not allowed, then the squashfuse
+  image driver will be used instead.
+  `iflimited` is the default because if one of those limits are used
+  the system administrator ensures that unprivileged users do not have
+  write access to the containers, but on the other hand using FUSE would
+  enable a user to theoretically bypass the limits via ptrace() because
+  the FUSE process runs as that user.
+
+  The `fuse-overlayfs` image driver will also now be tried in setuid mode
   if the kernel overlayfs driver does not work (for example if one of
   the layers is a FUSE filesystem).
+
   In addition,
   if `allow setuid-mount encrypted = no` then the unprivileged gocryptfs
   format will be used for encrypting SIF files instead of the kernel

--- a/e2e/ecl/ecl.go
+++ b/e2e/ecl/ecl.go
@@ -176,6 +176,24 @@ func (c *ctx) eclConfig(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name:    "make sure kernel squashfs is used with ECL and default config",
+			command: "exec",
+			profile: e2e.UserProfile,
+			config: &syecl.EclConfig{
+				Activated: true,
+				ExecGroups: []syecl.Execgroup{
+					{
+						TagName:  "group1",
+						ListMode: "whitelist",
+						DirPath:  tmpDir,
+						KeyFPs:   []string{KeyMap["key1"]},
+					},
+				},
+			},
+			args: []string{signed, "sh", "-c", e2e.Findsquash},
+			exit: 1,
+		},
+		{
 			name:    "run with whitelist key2 and signed image",
 			command: "exec",
 			profile: e2e.UserProfile,

--- a/e2e/internal/e2e/config.go
+++ b/e2e/internal/e2e/config.go
@@ -18,6 +18,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	Findsquash  = "pstree $PPID|grep squashfuse"
+	Findfuse2fs = "pstree $PPID|grep fuse2fs"
+)
+
 func SetupDefaultConfig(t *testing.T, path string) {
 	c, err := apptainerconf.Parse("")
 	if err != nil {

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/sypgp"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs/overlay"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs/squashfs"
 	"github.com/apptainer/apptainer/internal/pkg/util/mainthread"
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
 	"github.com/apptainer/apptainer/pkg/image"
@@ -1458,7 +1459,7 @@ func (e *EngineOperations) loadImage(path string, writable bool, userNS bool, el
 		if !e.EngineConfig.File.AllowContainerSquashfs {
 			return nil, fmt.Errorf("configuration disallows users from running squashFS containers")
 		}
-		if elevated && !e.EngineConfig.File.AllowSetuidMountSquashfs && !hasFeature(image.SquashFeature) {
+		if elevated && !squashfs.SetuidMountAllowed(e.EngineConfig.File) && !hasFeature(image.SquashFeature) {
 			return nil, fmt.Errorf("configuration disallows users from mounting squashFS in setuid mode, try --userns")
 		}
 	// Bare EXT3
@@ -1476,7 +1477,7 @@ func (e *EngineOperations) loadImage(path string, writable bool, userNS bool, el
 		}
 	// SIF
 	case image.SIF:
-		if elevated && !e.EngineConfig.File.AllowSetuidMountSquashfs && !hasFeature(image.SquashFeature) {
+		if elevated && !squashfs.SetuidMountAllowed(e.EngineConfig.File) && !hasFeature(image.SquashFeature) {
 			return nil, fmt.Errorf("configuration disallows users from mounting SIF squashFS partition in setuid mode, try --userns")
 		}
 		// Check if SIF contains an encrypted rootfs partition.

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -35,6 +35,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs/squashfs"
 	"github.com/apptainer/apptainer/internal/pkg/util/gpu"
 	"github.com/apptainer/apptainer/internal/pkg/util/shell/interpreter"
 	"github.com/apptainer/apptainer/internal/pkg/util/starter"
@@ -1118,7 +1119,7 @@ func (l *Launcher) prepareImage(c context.Context, insideUserNs bool, image stri
 		if l.cfg.Unsquash {
 			convert = true
 		} else if l.cfg.Namespaces.User || insideUserNs ||
-			!fileconf.AllowSetuidMountSquashfs {
+			!squashfs.SetuidMountAllowed(fileconf) {
 			convert = true
 			if fileconf.ImageDriver != "" {
 				// load image driver plugins

--- a/internal/pkg/util/fs/squashfs/squashfs.go
+++ b/internal/pkg/util/fs/squashfs/squashfs.go
@@ -10,9 +10,12 @@
 package squashfs
 
 import (
+	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
+	"github.com/apptainer/apptainer/internal/pkg/syecl"
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
+	"github.com/apptainer/apptainer/pkg/util/namespaces"
 )
 
 func getConfig() (*apptainerconf.File, error) {
@@ -51,4 +54,46 @@ func GetMem() (string, error) {
 	mem := c.MksquashfsMem
 
 	return mem, err
+}
+
+var (
+	setuidMountKnown   bool
+	setuidMountAllowed bool
+)
+
+// SetuidMountAllowed calculates whether or not it is allowed to
+// mount a squashfs filesystem using the kernel driver in setuid mode.
+func SetuidMountAllowed(cfg *apptainerconf.File) bool {
+	if setuidMountKnown {
+		return setuidMountAllowed
+	}
+	setuidMountKnown = true
+	str := cfg.AllowSetuidMountSquashfs
+	if !namespaces.IsUnprivileged() {
+		setuidMountAllowed = true
+		sylog.Debugf("Kernel squashfs mount allowed because running as root")
+	} else if str == "yes" {
+		setuidMountAllowed = true
+		sylog.Debugf("Kernel squashfs mount allowed by configuration")
+	} else if str == "iflimited" {
+		if len(cfg.LimitContainerOwners) > 0 ||
+			len(cfg.LimitContainerGroups) > 0 ||
+			len(cfg.LimitContainerPaths) > 0 {
+			setuidMountAllowed = true
+			sylog.Debugf("Kernel squashfs mount allowed because of limit container")
+		} else {
+			eclcfg, err := syecl.LoadConfig(buildcfg.ECL_FILE)
+			if err != nil {
+				sylog.Debugf("Kernel squashfs mount not allowed because error loading %s: %v", buildcfg.ECL_FILE, err)
+			} else if eclcfg.Activated {
+				setuidMountAllowed = true
+				sylog.Debugf("Kernel squashfs mount allowed because of activated ECL")
+			} else {
+				sylog.Debugf("Kernel squashfs mount not allowed because ECL not activated")
+			}
+		}
+	} else {
+		sylog.Debugf("Kernel squashfs mount not allowed by configuration")
+	}
+	return setuidMountAllowed
 }


### PR DESCRIPTION
This adds a new middle option called `iflimited` to `allow setuid-mount squashfs` and makes it the default.  E2e tests are updated correspondingly.
- Fixes #1874 