### PR TITLE
Update for all fuse tools included in package

### DIFF
--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -34,7 +34,7 @@
 %global package_version @PACKAGE_VERSION@
 
 %global gocryptfs_version 2.4.0
-%global squashfuse_version 0.2.0
+%global squashfuse_version 0.5.0
 %global e2fsprogs_version 1.47.0
 %global fuse_overlayfs_version 1.13
 

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -635,6 +635,8 @@ func (i *fuseappsInstance) filterMsg() string {
 		// from squashfuse_ll
 		"failed to clone device fd",
 		"continue without -o clone_fd",
+		// from fuse-overlayfs sometimes
+		"unknown argument ignored: lazytime",
 		// from fuse-overlayfs due to a bug
 		// (see https://github.com/containers/fuse-overlayfs/issues/397)
 		"/proc seems to be mounted as readonly",
@@ -642,6 +644,9 @@ func (i *fuseappsInstance) filterMsg() string {
 		"Reading Password from stdin",
 		"Decrypting master key",
 		"Filesystem mounted and ready.",
+		// from any of the programs when an older fuse3 lib is used
+		// than what the programs were compiled with
+		"fuse: warning: library too old",
 	}
 
 	errmsg := ""


### PR DESCRIPTION
This primarily updates the install-unprivileged.sh script to work correctly with and without the additional fuse tools included in the apptainer package.  I also tested it again with all the combinations and made some tweaks, including ignoring a couple of additional messages from the fuse tools.  Also, update the included squashfuse version to the latest, even though none of the changes are relevant to apptainer; all the other fuse tools were up to date.
- Fixes #1798