### PR TITLE
Add release-1.3 branch to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    target-branch: release-1.3
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
     target-branch: release-1.2


### PR DESCRIPTION
Add release-1.3 to dependabot.  I'll remove release-1.2 after 1.3.0 is fully released.