### PR TITLE
Fix default install-dependencies parameter

### DIFF
--- a/scripts/install-dependencies
+++ b/scripts/install-dependencies
@@ -13,6 +13,7 @@ if [ -n "$1" ]; then
     LIBEXECDIR="$1"
 elif [ ! -f builddir/Makefile ]; then
     echo "builddir/Makefile not found" >&2
+else
     LIBEXECDIR="$(sed -n 's/^LIBEXECDIR := //p' builddir/Makefile)"
 fi
 


### PR DESCRIPTION
The default parameter for scripts/install-dependencies wasn't working correctly.  It looks like an else statement accidentally got deleted after I tested it.