### PR TITLE
Fix CheckRootless() for when something is mounted under /mnt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.3.x
 
+Changes since 1.3.0-rc.1.
+
+- Fix check for rootless overlay so it will work when something is
+  mounted under `/mnt`.  This check is used to decide whether to use the
+  kernel overlayfs in user namespace mode by default or underlay.
+
 ## v1.3.0-rc.1 - \[2024-01-10\]
 
 Changes since v1.2.5

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -157,7 +157,7 @@ func CheckRootless() error {
 
 	args := []string{
 		"-t", "overlay",
-		"-o", "lowerdir=/mnt:/etc",
+		"-o", "lowerdir=/etc/sysctl.d:/etc/modprobe.d",
 		"none",
 		"/tmp",
 	}


### PR DESCRIPTION
Instead of using `/mnt` and `/etc` as test lower and upper layers in an overlay mount in `CheckRootless()`, use two `/etc` subdirectories that always exist with Linux (as verified on Alpine).
- Fixes #1914