### PR TITLE
fix `--sharens` issue and update the lock type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes since 1.3.0-rc.1.
 - Fix check for rootless overlay so it will work when something is
   mounted under `/mnt`.  This check is used to decide whether to use the
   kernel overlayfs in user namespace mode by default or underlay.
+- Fix `--sharens` failure on EL8.
 
 ## v1.3.0-rc.1 - \[2024-01-10\]
 

--- a/pkg/util/fs/lock/var.go
+++ b/pkg/util/fs/lock/var.go
@@ -12,6 +12,6 @@ package lock
 import "golang.org/x/sys/unix"
 
 var (
-	setLk  = unix.F_SETLK
-	setLkw = unix.F_SETLKW
+	setLk  = unix.F_OFD_SETLK
+	setLkw = unix.F_OFD_SETLKW
 )

--- a/pkg/util/fs/lock/var_linux_32bit.go
+++ b/pkg/util/fs/lock/var_linux_32bit.go
@@ -14,6 +14,6 @@ package lock
 import "golang.org/x/sys/unix"
 
 func init() {
-	setLk = unix.F_SETLK64
-	setLkw = unix.F_SETLKW64
+	setLk = unix.F_OFD_SETLK64
+	setLkw = unix.F_OFD_SETLKW64
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

updating the lock type


### This fixes or addresses the following GitHub issues:

 - Fixes #1906 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
