### PR TITLE
Deprecate underlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,19 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.3.x
 
-Changes since 1.3.0-rc.1.
+Changes since v1.3.0-rc.1
 
-- Fix check for rootless overlay so it will work when something is
-  mounted under `/mnt`.  This check is used to decide whether to use the
-  kernel overlayfs in user namespace mode by default or underlay.
+- Change the default in user namespace mode to use either kernel
+  overlayfs or fuse-overlayfs instead of the underlay feature for the
+  purpose of adding bind mount points.  That was already the default in
+  setuid mode; this change makes it consistent.  The underlay feature can
+  still be used with the `--underlay` option, but it is deprecated because
+  the implementation is complicated and measurements have shown that the
+  performance of underlay is similar to overlayfs and fuse-overlayfs.
+  For now the underlay feature can be made the default again with a new
+  `preferred` value on the `enable underlay` configuration option.
+  Also the `--underlay` option can be used in setuid mode or as the root
+  user, although it was ignored previously.
 - Fix `--sharens` failure on EL8.
 
 ## v1.3.0-rc.1 - \[2024-01-10\]

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -807,12 +807,13 @@ var actionIgnoreUsernsFlag = cmdline.Flag{
 	Hidden:       true,
 }
 
-// --underlay
+// --underlay (deprecated)
 var actionUnderlayFlag = cmdline.Flag{
 	ID:           "underlayFlag",
 	Value:        &underlay,
 	DefaultValue: false,
 	Name:         "underlay",
+	Deprecated:   "default overlay is preferred",
 	Usage:        "use underlay instead of overlay for bind mounts",
 	EnvKeys:      []string{"UNDERLAY"},
 	Hidden:       false,

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -935,9 +935,8 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			},
 			exit: 255,
 		},
-		// disable overlay to force underlay
 		{
-			name:    "EnableUnderlayNo",
+			name:    "EnableOverlayNoUnderlayNo",
 			argv:    []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
 			profile: e2e.UserProfile,
 			directives: map[string]string{
@@ -949,13 +948,24 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 		},
 		{
 			name:    "EnableUnderlayYes",
-			argv:    []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "test", "-f", "/passwd"},
+			argv:    []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "sh", "-c", "test -f /passwd && mount"},
 			profile: e2e.UserProfile,
 			directives: map[string]string{
 				"enable overlay":  "no",
 				"enable underlay": "yes",
 			},
-			exit: 0,
+			resultOp: e2e.ExpectOutput(e2e.ContainMatch, "on / type tmpfs"),
+			exit:     0,
+		},
+		{
+			name:    "EnableUnderlayPreferred",
+			argv:    []string{"--bind", "/etc/passwd:/passwd", c.env.ImagePath, "sh", "-c", "test -f /passwd && mount"},
+			profile: e2e.UserProfile,
+			directives: map[string]string{
+				"enable underlay": "preferred",
+			},
+			resultOp: e2e.ExpectOutput(e2e.ContainMatch, "on / type tmpfs"),
+			exit:     0,
 		},
 	}
 

--- a/internal/pkg/confgen/testdata/test_1.out.correct
+++ b/internal/pkg/confgen/testdata/test_1.out.correct
@@ -133,7 +133,7 @@ user bind control = yes
 # Enabling this option will make it possible to specify bind paths to locations
 # that do not currently exist within the container.  If 'try' is chosen,
 # overlayfs will be tried but if it is unavailable it will be silently ignored.
-enable overlay = try
+enable overlay = yes
 
 
 # MOUNT SLAVE: [BOOL]

--- a/internal/pkg/util/fs/overlay/overlay_linux.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux.go
@@ -10,14 +10,8 @@
 package overlay
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"syscall"
 
-	"github.com/apptainer/apptainer/internal/pkg/util/bin"
-	"github.com/apptainer/apptainer/pkg/sylog"
 	"golang.org/x/sys/unix"
 )
 
@@ -144,49 +138,4 @@ func IsIncompatible(err error) bool {
 		return true
 	}
 	return false
-}
-
-var ErrNoRootlessOverlay = errors.New("rootless overlay not supported by kernel")
-
-// CheckRootless checks whether the kernel overlay driver supports unprivileged use in a user namespace.
-func CheckRootless() error {
-	mountBin, err := bin.FindBin("mount")
-	if err != nil {
-		return fmt.Errorf("while looking for mount command: %s", err)
-	}
-
-	args := []string{
-		"-t", "overlay",
-		"-o", "lowerdir=/etc/sysctl.d:/etc/modprobe.d",
-		"none",
-		"/tmp",
-	}
-
-	cmd := exec.Command(mountBin, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	// Unshare user and mount namespace
-	cmd.SysProcAttr.Unshareflags = syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS
-	// Map to user to root inside the user namespace
-	cmd.SysProcAttr.UidMappings = []syscall.SysProcIDMap{
-		{
-			ContainerID: 0,
-			HostID:      os.Getuid(),
-			Size:        1,
-		},
-	}
-	cmd.SysProcAttr.GidMappings = []syscall.SysProcIDMap{
-		{
-			ContainerID: 0,
-			HostID:      os.Getgid(),
-			Size:        1,
-		},
-	}
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		sylog.Debugf("Rootless overlay not supported on this system: %s\n%s", err, out)
-		return ErrNoRootlessOverlay
-	}
-
-	sylog.Debugf("Rootless overlay appears supported on this system.")
-	return nil
 }


### PR DESCRIPTION
As documented in #1918, underlay performance for bind mount points is not much different than overlayfs or fuse-overlayfs.  The implementation is quite complicated, and it introduces more code paths in which bugs can arise (e.g. #1905 and #1913).  For these reasons, this PR makes overlayfs/fuse-overlayfs the default for user namespace mode as it was for setuid mode, and deprecates underlay.  For now the `--underlay` option can still be used, also now in setuid mode where it wasn't before, and there's a new `enable underlay = preferred` value in apptainer.conf to make it the default.   The selection of whether to use underlay or overlay is now greatly simplified and made the same in user namespace and setuid mode.  A consequence is that `enable overlay = try` is now the same as `yes`.  

In addition, all command line flags marked with the `Deprecated:` field now send the deprecated message as a WARNING instead of just printing to stderr.

- Fixes #1905
- Fixes #1918
