### PR TITLE
Fix default install-dependencies parameter (release-1.3, again)

### DIFF
--- a/scripts/install-dependencies
+++ b/scripts/install-dependencies
@@ -13,6 +13,7 @@ if [ -n "$1" ]; then
     LIBEXECDIR="$1"
 elif [ ! -f builddir/Makefile ]; then
     echo "builddir/Makefile not found" >&2
+else
     LIBEXECDIR="$(sed -n 's/^LIBEXECDIR := //p' builddir/Makefile)"
 fi
 


### PR DESCRIPTION
This re-does the cherry-pick of #1911 to release-1.3, replacing #1929 which was accidentally submitted against the main branch.