### PR TITLE
Fix harbor registry login failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes since v1.3.0-rc.1
   Also the `--underlay` option can be used in setuid mode or as the root
   user, although it was ignored previously.
 - Fix `--sharens` failure on EL8.
+- Fix Harbor registry login failure.
 
 ## v1.3.0-rc.1 - \[2024-01-10\]
 

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -63,7 +63,7 @@ func ensurePassword(password string) (string, error) {
 			return "", fmt.Errorf("failed to read password: %s", err)
 		}
 		if input == "" {
-			return "", fmt.Errorf("A password is required")
+			return "", fmt.Errorf("a password is required")
 		}
 		return input, nil
 	}
@@ -87,7 +87,7 @@ func (h *ociHandler) login(u *url.URL, username, password string, insecure bool)
 		return nil, err
 	}
 
-	if err := checkOCILogin(regName, username, password, insecure); err != nil {
+	if err := checkOCILogin(regName, username, pass, insecure); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix harbor registry login failure. (This issue might also be applied to other registry login)

### This fixes or addresses the following GitHub issues:

 - Fixes #1910


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)

###
Test
```
vagrant@ubuntu:~/test$ apptainer remote login --username xxxx docker://demo.goharbor.io
WARNING: 'remote login' is deprecated for registries or keyservers and will be removed in a future release; running 'registry login'
Password / Token: 
INFO:    Token stored in /home/vagrant/.apptainer/remote.yaml
vagrant@ubuntu:~/test$ apptainer remote list

NAME           URI                  DEFAULT?  GLOBAL?  EXCLUSIVE?  SECURE?
DefaultRemote  cloud.apptainer.org  ✓         ✓                    ✓
vagrant@ubuntu:~/test$ cat ~/.apptainer/remote.yaml 
Active: DefaultRemote
Remotes:
    DefaultRemote:
        URI: cloud.apptainer.org
        System: true
        Exclusive: false
Credentials:
    - URI: docker://demo.goharbor.io
      Insecure: false
```
