### PR TITLE
Use kernel overlayfs with fuse lower layer when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Changes since v1.3.0-rc.1
   `preferred` value on the `enable underlay` configuration option.
   Also the `--underlay` option can be used in setuid mode or as the root
   user, although it was ignored previously.
+- Prefer again to use kernel overlayfs over fuse-overlayfs when a lower
+  layer is FUSE and there's no writable upper layer, undoing the change
+  from 1.2.0.  Another workaround was found for the problem that change
+  addressed.  This applies in both setuid mode and in user namespace
+  mode (except the latter not on CentOS7 where it isn't supported).
 - Fix `--sharens` failure on EL8.
 
 ## v1.3.0-rc.1 - \[2024-01-10\]

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -1965,7 +1965,7 @@ func (c actionTests) actionLayerType(t *testing.T) {
 			args: []string{
 				c.env.ImagePath,
 			},
-			expectType: "fuse",
+			expectType: "overlay",
 		},
 		{
 			name:    "UserWithUnderlayOption",
@@ -1999,7 +1999,7 @@ func (c actionTests) actionLayerType(t *testing.T) {
 			args: []string{
 				c.env.ImagePath,
 			},
-			expectType: "fuse",
+			expectType: "overlay",
 		},
 		{
 			name:    "UserNamespaceWithUnderlayOption",

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -665,20 +665,15 @@ func (c *container) mountImageDriver(params *image.MountParams, system *mount.Sy
 	params.Target = fmt.Sprintf("/dev/fd/%d", fuseFd)
 
 	rootmode := syscall.S_IFDIR & syscall.S_IFMT
-	allowOther := ""
-	if c.engine.EngineConfig.GetFakeroot() {
-		allowOther = ",allow_other"
-	}
-	opts := fmt.Sprintf("fd=%d,rootmode=%o,user_id=%d,group_id=%d%s",
+	opts := fmt.Sprintf("fd=%d,rootmode=%o,user_id=%d,group_id=%d,allow_other",
 		fuseRPCFd,
 		rootmode,
 		os.Getuid(),
 		os.Getgid(),
-		allowOther,
 	)
 
 	sylog.Debugf("Do FUSE mount for image driver with %s %s", opts, saveTarget)
-	err = c.rpcOps.Mount("fuse", saveTarget, "fuse", syscall.MS_NOSUID|syscall.MS_NODEV, opts)
+	err = c.rpcOps.Mount("fuse", saveTarget, "fuse", syscall.MS_NOSUID|syscall.MS_NODEV|params.Flags, opts)
 	if err != nil {
 		sylog.Debugf("While mounting fuse for image driver: %s", err)
 		return fmt.Errorf("while mounting fuse for image driver: %s", err)
@@ -767,33 +762,29 @@ mount:
 			err = fmt.Errorf("overlay image driver selected by configuration")
 		} else {
 			lowerdirs := ""
+			hasUpper := false
 			for _, opt := range opts {
 				if strings.HasPrefix(opt, "lowerdir=") {
 					lowerdirs = opt[len("lowerdir="):]
+				} else if strings.HasPrefix(opt, "upperdir=") {
+					hasUpper = true
 				}
 			}
-			// This is an overlay and there is an overlay image
-			//  driver.  When a lower layer is of type FUSE
-			//  we want to skip trying the kernel overlayfs. That's
-			//  because sometimes the mount succeeds but the
-			//  operation doesn't work, due to a kernel regression
-			//  related to fuse under overlayfs that first showed up
-			//  in kernel version 5.15, as discussed at
-			//   https://lore.kernel.org/lkml/CAJfpegvaUyCUkucNwP0P419hC8v78PEM25pW5mBho94HRCgO3Q@mail.gmail.com/
-			// At first we checked only for a writable overlay
-			//  (which is specified as an "upperdir"), but there
-			//  were also problems seen when the overlay was
-			//  squashfuse, so we changed this to also check
-			//  non-writable overlays.  See
-			//  https://github.com/apptainer/apptainer/issues/1459
-			//  Unfortunately this also affects read-only fuse2fs
-			//  overlays even though no problems had been seen with
-			//  those using the kernel overlayfs.
+			if hasUpper {
+				// This is an overlay and there is an overlay image
+				//  driver.  When a lower layer is of type FUSE
+				//  we want to skip trying the kernel overlayfs. That's
+				//  because sometimes the mount succeeds but the
+				//  operation doesn't work, due to a kernel regression
+				//  related to fuse under overlayfs that first showed up
+				//  in kernel version 5.15, as discussed at
+				//   https://lore.kernel.org/lkml/CAJfpegvaUyCUkucNwP0P419hC8v78PEM25pW5mBho94HRCgO3Q@mail.gmail.com/
 
-			for _, ldir := range strings.Split(lowerdirs, ":") {
-				err = fsoverlay.CheckFuse(ldir)
-				if err != nil {
-					break
+				for _, ldir := range strings.Split(lowerdirs, ":") {
+					err = fsoverlay.CheckFuse(ldir)
+					if err != nil {
+						break
+					}
 				}
 			}
 		}

--- a/internal/pkg/runtime/engine/apptainer/rpc/args.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/args.go
@@ -43,6 +43,12 @@ type MountArgs struct {
 	Data       string
 }
 
+// UnmountArgs defines the arguments to unmount.
+type UnmountArgs struct {
+	Target       string
+	Unmountflags int
+}
+
 // CryptArgs defines the arguments to mount.
 type CryptArgs struct {
 	Offset    uint64

--- a/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/client/client.go
@@ -45,6 +45,24 @@ func (t *RPC) Mount(source string, target string, filesystem string, flags uintp
 	return err
 }
 
+// Unmount calls the unmount RPC using the supplied arguments.
+func (t *RPC) Unmount(target string, flags int) error {
+	arguments := &args.UnmountArgs{
+		Target:       target,
+		Unmountflags: flags,
+	}
+
+	var unmountErr error
+
+	err := t.Client.Call(t.Name+".Unmount", arguments, &unmountErr)
+	// RPC communication will take precedence over unmount error
+	if err == nil {
+		err = unmountErr
+	}
+
+	return err
+}
+
 // Decrypt calls the DeCrypt RPC using the supplied arguments.
 func (t *RPC) Decrypt(offset uint64, path string, key []byte, masterPid int) (string, error) {
 	arguments := &args.CryptArgs{

--- a/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
@@ -73,6 +73,14 @@ func (t *Methods) Mount(arguments *args.MountArgs, mountErr *error) (err error) 
 	return
 }
 
+// Unmount performs an unmount with the specified arguments.
+func (t *Methods) Unmount(arguments *args.UnmountArgs, unmountErr *error) (err error) {
+	mainthread.Execute(func() {
+		*unmountErr = syscall.Unmount(arguments.Target, arguments.Unmountflags)
+	})
+	return
+}
+
 // Decrypt decrypts the loop device.
 func (t *Methods) Decrypt(arguments *args.CryptArgs, reply *string) (err error) {
 	cryptName := ""


### PR DESCRIPTION
This switches to use the kernel overlayfs with FUSE lower layers, when they are readonly.  It includes a better fix for #1459 than what was implemented in #1465, and undoes the change in that PR.

- Fixes #1945