### PR TITLE
reset `$HOME` if it is non-readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes since v1.3.0-rc.1
   user, although it was ignored previously.
 - Fix `--sharens` failure on EL8.
 - Fix Harbor registry login failure.
+- Prevent container builds from failing when `$HOME` points to a non-readable directory.
 
 ## v1.3.0-rc.1 - \[2024-01-10\]
 

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
@@ -74,6 +75,15 @@ func configDir(dir string) string {
 			homedir = cwd
 		} else {
 			homedir = user.HomeDir
+		}
+	}
+
+	if !fs.IsReadable(homedir) {
+		sylog.Debugf("Home dir: %s is not readable, will reset it to '/'", homedir)
+		homedir = "/"
+		err := os.Setenv("HOME", "/")
+		if err != nil {
+			sylog.Warningf("Unable to update `$HOME`: %s", err)
 		}
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

reset `$HOME` value if it is non-readable. 


### This fixes or addresses the following GitHub issues:

 - Fixes #1959 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)

## Test
```
vagrant@ubuntu:~/test$ HOME=/root apptainer build /tmp/centos7.sif docker://centos:7
Build target 'centos7.sif' already exists and will be deleted during the build process. Do you want to continue? [y/N] y
WARNING: Cache disabled - cache location / is not writable.
INFO:    Starting build...
Getting image source signatures
Copying blob 6717b8ec66cd skipped: already exists  
Copying config a61e0eb37c done   | 
Writing manifest to image destination
2024/02/13 13:16:27  info unpack layer: sha256:6717b8ec66cd6add0272c6391165585613c31314a43ff77d9751b53010e531ec
2024/02/13 13:16:27  warn rootless{usr/bin/newgidmap} ignoring (usually) harmless EPERM on setxattr "security.capability"
2024/02/13 13:16:27  warn rootless{usr/bin/newuidmap} ignoring (usually) harmless EPERM on setxattr "security.capability"
2024/02/13 13:16:27  warn rootless{usr/bin/ping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2024/02/13 13:16:28  warn rootless{usr/sbin/arping} ignoring (usually) harmless EPERM on setxattr "security.capability"
2024/02/13 13:16:28  warn rootless{usr/sbin/clockdiff} ignoring (usually) harmless EPERM on setxattr "security.capability"
INFO:    Creating SIF file...
INFO:    Build complete: /tmp/centos7.sif
```