### PR TITLE
reset HOME if it is not readable (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changes since v1.3.0-rc.1
   user, although it was ignored previously.
 - Fix `--sharens` failure on EL8.
 - Fix Harbor registry login failure.
+- Prevent container builds from failing when `$HOME` points to a non-readable directory.
 
 ## v1.3.0-rc.1 - \[2024-01-10\]
 

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
@@ -74,6 +75,15 @@ func configDir(dir string) string {
 			homedir = cwd
 		} else {
 			homedir = user.HomeDir
+		}
+	}
+
+	if !fs.IsReadable(homedir) {
+		sylog.Debugf("Home dir: %s is not readable, will reset it to '/'", homedir)
+		homedir = "/"
+		err := os.Setenv("HOME", "/")
+		if err != nil {
+			sylog.Warningf("Unable to update `$HOME`: %s", err)
 		}
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This cherry picks commit https://github.com/apptainer/apptainer/pull/2004/commits/a15cf665d35af65c9c8625f270346928fc1515fa in PR: https://github.com/apptainer/apptainer/pull/2004


### This fixes or addresses the following GitHub issues:

 - Fixes #1959


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
