### PR TITLE
Fix the preload offset function for fuse2fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes since v1.3.0-rc.1
   from 1.2.0.  Another workaround was found for the problem that change
   addressed.  This applies in both setuid mode and in user namespace
   mode (except the latter not on CentOS7 where it isn't supported).
+- Fix the use of an overlay ext3 filesystem in SIF files.
 - Fix `--sharens` failure on EL8.
 - Fix Harbor registry login failure.
 


### PR DESCRIPTION
As installed in the current main branch, fuse2fs is using a different `open` library call variant than before, which prevents the preload tool which implemented SIF file offset from working.  This PR fixes that.

- Fixes #1908