### PR TITLE
Add missing copyright comments

### DIFF
--- a/scripts/clean-dependencies
+++ b/scripts/clean-dependencies
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
+#   For website terms of use, trademark policy, privacy policy and other
+#   project policies see https://lfprojects.org/policies
+#
 # Clean out old versions in the current directory of the dependent
 # FUSE-based packages.
 

--- a/scripts/compile-dependencies
+++ b/scripts/compile-dependencies
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
+#   For website terms of use, trademark policy, privacy policy and other
+#   project policies see https://lfprojects.org/policies
+#
 # Compile dependencies.  The source tarballs and patches should be in the
 # directory passed in as $1, default "."
 

--- a/scripts/download-dependencies
+++ b/scripts/download-dependencies
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
+#   For website terms of use, trademark policy, privacy policy and other
+#   project policies see https://lfprojects.org/policies
+#
 # Download additional source urls listed in rpm into directory in $1.
 # Assumes being run from the top of the apptainer source directory.
 

--- a/scripts/get-min-go-version
+++ b/scripts/get-min-go-version
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
+#   For website terms of use, trademark policy, privacy policy and other
+#   project policies see https://lfprojects.org/policies
+
 HERE=${0%/*}
 PARENT=${HERE%/*}
 if [ "$PARENT" = "$HERE" ]; then

--- a/scripts/go-generate.in
+++ b/scripts/go-generate.in
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
+#   For website terms of use, trademark policy, privacy policy and other
+#   project policies see https://lfprojects.org/policies
 
 export BUILDDIR='@BUILDDIR@'
 export GO111MODULE='@GO111MODULE@'

--- a/scripts/install-dependencies
+++ b/scripts/install-dependencies
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Copyright (c) Contributors to the Apptainer project, established as
+#   Apptainer a Series of LF Projects LLC.
+#   For website terms of use, trademark policy, privacy policy and other
+#   project policies see https://lfprojects.org/policies
+#
 # Install dependencies.  The compiled tools are expected to be in
 # subdirectories under the current directory as produced by the
 # compile-dependencies script. The install prefix is passed in as $1,


### PR DESCRIPTION
This adds the copyright comment to the beginning of scripts where it was missing.

- Fixes #1936