### PR TITLE
Fix the preload offset function for fuse2fs (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes since v1.3.0-rc.1
   from 1.2.0.  Another workaround was found for the problem that change
   addressed.  This applies in both setuid mode and in user namespace
   mode (except the latter not on CentOS7 where it isn't supported).
+- Fix the use of an overlay ext3 filesystem in SIF files.
 - Fix `--sharens` failure on EL8.
 - Fix Harbor registry login failure.
 - Prevent container builds from failing when `$HOME` points to a non-readable directory.


### PR DESCRIPTION
Cherry-pick #2013 to the release-1.3 branch.