### PR TITLE
Add `Provides: bundled` for included fuse tools in rpm spec

### DIFF
--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -96,6 +96,11 @@ Obsoletes: singularity-runtime < 3.0
 Provides: sif-runtime
 Conflicts: sif-runtime
 
+Provides: bundled(gocryptfs) = %{gocryptfs_version}
+Provides: bundled(squashfuse) = %{squashfuse_version}
+Provides: bundled(e2fsprogs) = %{e2fsprogs_version}
+Provides: bundled(fuse2fs) = %{e2fsprogs_version}
+Provides: bundled(fuse-overlayfs) = %{fuse_overlayfs_version}
 @BUNDLED_PROVIDES@
 
 %if "%{_target_vendor}" == "suse"


### PR DESCRIPTION
This adds `Provides: bundled(<pkg>) = <version>` statements to the rpm spec file.

- Fixes #1948