### PR TITLE
Use ldconfig.real instead of ldconfig if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since v1.3.0-rc.2
 
+- Fix the use of `nvidia-container-cli` on Ubuntu 22.04 where an
+  `ldconfig` wrapper script gets in the way. Instead, we use
+  `ldconfig.real` directly.
+
 ## v1.3.0-rc.2 - \[2024-02-15\]
 
 Changes since v1.3.0-rc.1

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,6 +65,7 @@
 - Mark Egan-Fuller <markeganfuller@googlemail.com>
 - Matthias Gerstner <matthias.gerstner@suse.com>
 - Matt Wiens <mwiens91@gmail.com>
+- Max Schwarz <max.schwarz@online.de>
 - Michael Bauer <m@sylabs.io>, <bauerm@umich.edu>
 - Michael Herzberg <michael@mherzberg.de>
 - Michael Milton <ttmigueltt@gmail.com>

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -37,6 +37,15 @@ func FindBin(name string) (path string, err error) {
 	// We must not search the user's PATH when in the suid flow with these
 	case "cryptsetup":
 		return findOnPath(name, true)
+	// ldconfig is special on Ubuntu: "ldconfig" is a wrapper around
+	// "ldconfig.real" and the latter is the one we want, since the wrapper
+	// interacts may drop capabilities. So try "ldconfig.real" first.
+	case "ldconfig":
+		path, err = findOnPath("ldconfig.real", false)
+		if err == nil {
+			return path, err
+		}
+		return findOnPath("ldconfig", false)
 	// All other executables
 	// We will always search the user's PATH first for these
 	case "curl",
@@ -47,7 +56,6 @@ func FindBin(name string) (path string, err error) {
 		"fuse-overlayfs",
 		"fuse2fs",
 		"go",
-		"ldconfig",
 		"mksquashfs",
 		"newgidmap",
 		"newuidmap",


### PR DESCRIPTION
## Description of the Pull Request (PR):

On Ubuntu, `ldconfig` is a shell script wrapper around `ldconfig.real`, providing deferred ldconfig updates during apt package installs. This leads to failures when used by `nvidia-container-cli` (see #2028).

We now look for `ldconfig.real` first and use that if available.

### This fixes or addresses the following GitHub issues:

 - Fixes #2028