### PR TITLE
Run image drivers with CAP_DAC_OVERRIDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Changes since v1.3.0-rc.2
   `ldconfig.real` directly.
 - Remove unneeded 32-bit specific lock types that were changed in 1.3.0-rc.2,
   because they interfered with 32-bit builds.
+- Run image drivers with CAP_DAC_OVERRIDE in user namespace mode. This
+  fixes --nvccli with NVIDIA_DRIVER_CAPABILITIES=graphics, which
+  previously failed when using fuse-overlayfs.
 
 ## v1.3.0-rc.2 - \[2024-02-15\]
 

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -169,6 +169,14 @@ func (c ctx) testNvCCLI(t *testing.T) {
 			expectExit:  255,
 		},
 		{
+			// Test "graphics" capability without privileges (issue #2033)
+			name:       "UserGraphics",
+			profile:    e2e.UserProfile,
+			args:       []string{"--nvccli", imagePath, "true"},
+			env:        []string{"NVIDIA_DRIVER_CAPABILITIES=graphics"},
+			expectExit: 0,
+		},
+		{
 			// Require CUDA version >8 should be fine!
 			name:       "UserValidRequire",
 			profile:    e2e.RootProfile,

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -363,6 +363,9 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 				// Needed for nsenter
 				//  https://stackoverflow.com/a/69724124/10457761
 				uintptr(capabilities.Map["CAP_SYS_PTRACE"].Value),
+				// Required for fuse-overlayfs
+				//  see https://github.com/containers/fuse-overlayfs/issues/414#issuecomment-1956140097
+				uintptr(capabilities.Map["CAP_DAC_OVERRIDE"].Value),
 			},
 		}
 	}


### PR DESCRIPTION
Rebased version of #2036 for the release-1.3 branch.

## Description of the Pull Request (PR):

This is required for fuse-overlayfs, which assumes it can create / modify files in its work directory without caring for permissions.

Also includes an e2e test for this case.

See https://github.com/containers/fuse-overlayfs/issues/414 for a related discussion.

### This fixes or addresses the following GitHub issues:

 - Fixes #2033
