### PR TITLE
lint: enable exportloopref + corresponding fixes, from sylabs 2064

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - dogsled
     - dupl
     - dupword
+    - exportloopref
     - gofumpt
     - goimports
     - gomodguard

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -1334,22 +1334,14 @@ func (c *container) addImageBindMount(system *mount.System) error {
 				if err != nil {
 					return fmt.Errorf("while getting partitions for %s: %s", img.Path, err)
 				}
-				for _, part := range partitions {
-					if part.ID == partID {
-						data = &part
-						break
-					}
-				}
+				data = getPartitionByID(partitions, partID)
 			} else {
 				// take the first data partition found
 				partitions, err := img.GetDataPartitions()
 				if err != nil {
 					return fmt.Errorf("while getting data partition for %s: %s", img.Path, err)
 				}
-				for _, part := range partitions {
-					data = &part
-					break
-				}
+				data = getFirstPartition(partitions)
 			}
 
 			if data == nil {
@@ -1406,6 +1398,25 @@ func (c *container) addImageBindMount(system *mount.System) error {
 			if err := system.Points.AddBind(mount.UserbindsTag, src, destination, syscall.MS_BIND); err != nil {
 				return fmt.Errorf("while adding data bind %s -> %s: %s", src, destination, err)
 			}
+		}
+	}
+
+	return nil
+}
+
+func getFirstPartition(partitions []image.Section) *image.Section {
+	if len(partitions) > 0 {
+		return &partitions[0]
+	}
+
+	return nil
+}
+
+func getPartitionByID(partitions []image.Section, partID uint32) *image.Section {
+	var part image.Section
+	for _, part = range partitions {
+		if part.ID == partID {
+			return &part
 		}
 	}
 

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -209,25 +209,7 @@ func checkBlackList(v *integrity.Verifier, egroup *Execgroup) (ok bool, err erro
 }
 
 func shouldRun(ctx context.Context, ecl *EclConfig, fp *os.File, kr openpgp.KeyRing) (ok bool, err error) {
-	var egroup *Execgroup
-
-	// look what execgroup a container is part of
-	for _, v := range ecl.ExecGroups {
-		if filepath.Dir(fp.Name()) == v.DirPath {
-			egroup = &v
-			break
-		}
-	}
-	// go back at it and this time look for an empty dirpath execgroup to fallback into
-	if egroup == nil {
-		for _, v := range ecl.ExecGroups {
-			if v.DirPath == "" {
-				egroup = &v
-				break
-			}
-		}
-	}
-
+	egroup := getExecGroup(ecl, fp)
 	if egroup == nil {
 		return false, fmt.Errorf("%s not part of any execgroup", fp.Name())
 	}
@@ -298,6 +280,25 @@ func shouldRun(ctx context.Context, ecl *EclConfig, fp *os.File, kr openpgp.KeyR
 	}
 
 	return false, fmt.Errorf("ecl config file invalid")
+}
+
+func getExecGroup(ecl *EclConfig, fp *os.File) *Execgroup {
+	var v Execgroup
+	// look what execgroup a container is part of
+	for _, v = range ecl.ExecGroups {
+		if filepath.Dir(fp.Name()) == v.DirPath {
+			return &v
+		}
+	}
+
+	// go back at it and this time look for an empty dirpath execgroup to fallback into
+	for _, v = range ecl.ExecGroups {
+		if v.DirPath == "" {
+			return &v
+		}
+	}
+
+	return nil
 }
 
 // ShouldRun determines if a container should run according to its execgroup rules


### PR DESCRIPTION
This pulls in sylabs PR
* sylabs/singularity#2064

The original PR description was:
> Enable the `exportloopref` linter in golangci-lint, and perform fixes, as appropriate, in code.