### PR TITLE
Change fakeroot in install-unprivileged.sh to also not look in /usr/lib64/libfakeroot

### DIFF
--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -379,6 +379,7 @@ echo "Patching fakeroot-sysv to make it relocatable"
 # shellcheck disable=SC2016
 if ! sed -i -e 's,^FAKEROOT_PREFIX=/.*,FAKEROOT_BINDIR=${0%/*},' \
 	-e 's,FAKEROOT_BINDIR=/.*,FAKEROOT_PREFIX=${FAKEROOT_BINDIR%/*},' \
+	-e 's,^PATHS=/usr/lib[^/]*/libfakeroot:,PATHS=,' \
 	usr/bin/fakeroot-sysv
 then
 	fatal "failure patching fakeroot-sysv"


### PR DESCRIPTION
In order to avoid using the system's fakeroot library, as part of install-unprivileged.sh's patch to make fakeroot-sysv relocatable remove the reference to /usr/lib64/libfakeroot.  The fakeroot-sysv script is used inside the container and that path is not a problem there, but it is first used [outside the container](https://github.com/apptainer/apptainer/blob/release-1.3/internal/pkg/fakeroot/fakefake.go#L105) to execute the `env` command to locate the library to link, and that's where this path causes a problem, if fakeroot is installed on the host.

- Fixes #1863