### PR TITLE
Update to squashfuse-0.5.1 (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changes since v1.3.0-rc.2
 - Run image drivers with CAP_DAC_OVERRIDE in user namespace mode. This
   fixes --nvccli with NVIDIA_DRIVER_CAPABILITIES=graphics, which
   previously failed when using fuse-overlayfs.
+- Update the bundled squashfuse_ll to version 0.5.1.
 
 ## v1.3.0-rc.2 - \[2024-02-15\]
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -34,7 +34,7 @@
 %global package_version @PACKAGE_VERSION@
 
 %global gocryptfs_version 2.4.0
-%global squashfuse_version 0.5.0
+%global squashfuse_version 0.5.1
 %global e2fsprogs_version 1.47.0
 %global fuse_overlayfs_version 1.13
 


### PR DESCRIPTION
This cherry-picks #2057 to the release-1.3 branch.