### PR TITLE
Remove dist from rpm release assets

### DIFF
--- a/scripts/ci-docker-run
+++ b/scripts/ci-docker-run
@@ -26,6 +26,7 @@ CONTAINER_VERS="${CONTAINER_VERS:-$DOCKER_HUB_URI}"
 
 docker run --privileged --network=host -v "$(pwd):/build:rw" \
   -e OS_TYPE=$OS_TYPE -e GO_ARCH=$GO_ARCH -e CONTAINER_VERS="$CONTAINER_VERS" \
+  -e HIDE_DIST=$HIDE_DIST \
   --name "$DOCKER_CONTAINER_NAME" "$DOCKER_HUB_URI" /bin/bash -exc \
 	"cd /build && scripts/ci-${TEST_TYPE:-$PKGTYPE-build}-test"
 


### PR DESCRIPTION
I noticed that the rpm release assets for 1.3.0-rc.[12] included `.el7` in their names, which was not supposed to happen.  This fixes that.