### PR TITLE
golang is packaged as go in suse

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,6 +63,7 @@
 - Marcelo Magallon <marcelo@sylabs.io>
 - Marco Rubin <marco.rubin@protonmail.com>
 - Mark Egan-Fuller <markeganfuller@googlemail.com>
+- Matt Ezell <ezellma@ornl.gov>
 - Matthias Gerstner <matthias.gerstner@suse.com>
 - Matt Wiens <mwiens91@gmail.com>
 - Max Schwarz <max.schwarz@online.de>

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -105,8 +105,10 @@ Provides: bundled(fuse-overlayfs) = %{fuse_overlayfs_version}
 
 %if "%{_target_vendor}" == "suse"
 BuildRequires: binutils-gold
-%endif
+BuildRequires: go
+%else
 BuildRequires: golang
+%endif
 BuildRequires: git
 BuildRequires: gcc
 BuildRequires: make


### PR DESCRIPTION
## Description of the Pull Request (PR):

Trying to build an RPM under SLES 15 sp4, it failed with a missing dependency on `golang`. SLES calls this `go`

### This fixes or addresses the following GitHub issues:

 - No issue was opened for this

#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
