### PR TITLE
Remove signatures from Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.3.x
 
+- Make 'apptainer build' work with signed Docker containers.
+
 ## v1.3.0 - \[2024-03-12\]
 
 Changes since v1.2.5

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -125,8 +125,9 @@ func (t *ImageReference) newImageSource(ctx context.Context, sys *types.SystemCo
 
 	// First we are fetching into the cache
 	_, err = copy.Image(ctx, policyCtx, t.ImageReference, t.source, &copy.Options{
-		ReportWriter: w,
-		SourceCtx:    sys,
+		ReportWriter:     w,
+		SourceCtx:        sys,
+		RemoveSignatures: true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -301,8 +301,9 @@ func (cp *OCIConveyorPacker) Pack(ctx context.Context) (*sytypes.Bundle, error) 
 func (cp *OCIConveyorPacker) fetch(ctx context.Context) error {
 	// cp.srcRef contains the cache source reference
 	_, err := copy.Image(ctx, cp.policyCtx, cp.tmpfsRef, cp.srcRef, &copy.Options{
-		ReportWriter: io.Discard,
-		SourceCtx:    cp.sysCtx,
+		ReportWriter:     io.Discard,
+		SourceCtx:        cp.sysCtx,
+		RemoveSignatures: true,
 	})
 	return err
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

OCI image layouts do not support the storing of signatures. Therefore, singed containers will cause apptainer to error with the message:
 _Pushing signatures for OCI images is not supported_.
To fix this, set an option to remove signatures.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.

### This fixes or addresses the following GitHub issues:

 - Fixes #2094

