### PR TITLE
Merge release-1.3 into the main branch after the 1.3.0 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,3 @@ updates:
     schedule:
       interval: "daily"
     target-branch: release-1.3
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    target-branch: release-1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,45 +9,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.3.x
 
-Changes since v1.3.0-rc.2
-
-- Run image drivers with CAP_DAC_OVERRIDE in user namespace mode. This
-  fixes --nvccli with NVIDIA_DRIVER_CAPABILITIES=graphics, which
-  previously failed when using fuse-overlayfs.
-- Fix the use of `nvidia-container-cli` on Ubuntu 22.04 where an
-  `ldconfig` wrapper script gets in the way. Instead, we use
-  `ldconfig.real` directly.
-- Remove unneeded 32-bit specific lock types that were changed in 1.3.0-rc.2,
-  because they interfered with 32-bit builds.
-- Update the bundled squashfuse_ll to version 0.5.1.
-
-## v1.3.0-rc.2 - \[2024-02-15\]
-
-Changes since v1.3.0-rc.1
-
-- Change the default in user namespace mode to use either kernel
-  overlayfs or fuse-overlayfs instead of the underlay feature for the
-  purpose of adding bind mount points.  That was already the default in
-  setuid mode; this change makes it consistent.  The underlay feature can
-  still be used with the `--underlay` option, but it is deprecated because
-  the implementation is complicated and measurements have shown that the
-  performance of underlay is similar to overlayfs and fuse-overlayfs.
-  For now the underlay feature can be made the default again with a new
-  `preferred` value on the `enable underlay` configuration option.
-  Also the `--underlay` option can be used in setuid mode or as the root
-  user, although it was ignored previously.
-- Prefer again to use kernel overlayfs over fuse-overlayfs when a lower
-  layer is FUSE and there's no writable upper layer, undoing the change
-  from 1.2.0.  Another workaround was found for the problem that change
-  addressed.  This applies in both setuid mode and in user namespace
-  mode (except the latter not on CentOS7 where it isn't supported).
-- Fix the use of an overlay ext3 filesystem in SIF files.
-- Fix `--sharens` failure on EL8.
-- Fix Harbor registry login failure.
-- Prevent container builds from failing when `$HOME` points to a non-readable
-  directory.
-
-## v1.3.0-rc.1 - \[2024-01-10\]
+## v1.3.0 - \[2024-03-12\]
 
 Changes since v1.2.5
 
@@ -91,6 +53,23 @@ Changes since v1.2.5
   packages.
   Scripts are provided to make this easy; see the updated instructions
   in [INSTALL.md](INSTALL.md).
+  The bundled squashfuse_ll is updated to version 0.5.1.
+- Change the default in user namespace mode to use either kernel
+  overlayfs or fuse-overlayfs instead of the underlay feature for the
+  purpose of adding bind mount points.  That was already the default in
+  setuid mode; this change makes it consistent.  The underlay feature can
+  still be used with the `--underlay` option, but it is deprecated because
+  the implementation is complicated and measurements have shown that the
+  performance of underlay is similar to overlayfs and fuse-overlayfs.
+  For now the underlay feature can be made the default again with a new
+  `preferred` value on the `enable underlay` configuration option.
+  Also the `--underlay` option can be used in setuid mode or as the root
+  user, although it was ignored previously.
+- Prefer again to use kernel overlayfs over fuse-overlayfs when a lower
+  layer is FUSE and there's no writable upper layer, undoing the change
+  from 1.2.0.  Another workaround was found for the problem that change
+  addressed.  This applies in both setuid mode and in user namespace
+  mode (except the latter not on CentOS7 where it isn't supported).
 - `--cwd` is now the preferred form of the flag for setting the container's
   working directory, though `--pwd` is still supported for compatibility.
 - When building RPM, we will now use `/var/lib/apptainer` (rather than
@@ -158,11 +137,19 @@ Changes since v1.2.5
   via dependency update of mvdan.cc/sh.
 - Fix regression introduced in v1.2.0 that led to an empty user's shell field
   in the `/etc/passwd` file.
+- Prevent container builds from failing when `$HOME` points to a non-readable
+  directory.
+- Fix the use of `nvidia-container-cli` on Ubuntu 22.04 where an
+  `ldconfig` wrapper script gets in the way. Instead, we use
+  `ldconfig.real` directly.
+- Run image drivers with CAP_DAC_OVERRIDE in user namespace mode. This
+  fixes --nvccli with NVIDIA_DRIVER_CAPABILITIES=graphics, which
+  previously failed when using fuse-overlayfs.
 
 ### Release change
 
 - Releases will generate apptainer Docker images for the Linux amd64 and arm64
-  architectures.
+  architectures at `ghcr.io/apptainer/apptainer`.
 
 ## v1.2.5 - \[2023-11-21\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,7 +132,7 @@ To build a specific version of Apptainer, check out a
 for example:
 
 ```sh
-git checkout v1.3.0-rc.2
+git checkout v1.3.0
 ```
 
 ## Compiling Apptainer
@@ -238,7 +238,7 @@ Then download the latest
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-VERSION=1.3.0-rc.2  # this is the apptainer version, change as you need
+VERSION=1.3.0  # this is the apptainer version, change as you need
 # Fetch the source
 wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/apptainer-${VERSION}.tar.gz
 ```

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.3.2
-	github.com/docker/cli v25.0.3+incompatible
+	github.com/docker/cli v25.0.4+incompatible
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/google/go-containerregistry v0.19.0
 	github.com/samber/lo v1.39.0
@@ -79,7 +79,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
-	github.com/containers/ocicrypt v1.1.9 // indirect
+	github.com/containers/ocicrypt v1.1.10 // indirect
 	github.com/containers/storage v1.53.0 // indirect
 	github.com/coreos/go-iptables v0.7.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
@@ -94,7 +94,7 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.2 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/containers/image/v5 v5.30.0 h1:CmHeSwI6W2kTRWnUsxATDFY5TEX4b58gPkaQcE
 github.com/containers/image/v5 v5.30.0/go.mod h1:gSD8MVOyqBspc0ynLsuiMR9qmt8UQ4jpVImjmK0uXfk=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
-github.com/containers/ocicrypt v1.1.9 h1:2Csfba4jse85Raxk5HIyEk8OwZNjRvfkhEGijOjIdEM=
-github.com/containers/ocicrypt v1.1.9/go.mod h1:dTKx1918d8TDkxXvarscpNVY+lyPakPNFN4jwA9GBys=
+github.com/containers/ocicrypt v1.1.10 h1:r7UR6o8+lyhkEywetubUUgcKFjOWOaWz8cEBrCPX0ic=
+github.com/containers/ocicrypt v1.1.10/go.mod h1:YfzSSr06PTHQwSTUKqDSjish9BeW1E4HUmreluQcMd8=
 github.com/containers/storage v1.53.0 h1:VSES3C/u1pxjTJIXvLrSmyP7OBtDky04oGu07UvdTEA=
 github.com/containers/storage v1.53.0/go.mod h1:pujcoOSc+upx15Jirdkebhtd8uJiLwbSd/mYT6zDJK8=
 github.com/coreos/go-iptables v0.7.0 h1:XWM3V+MPRr5/q51NuWSgU0fqMad64Zyxs8ZUoMsamr8=
@@ -121,8 +121,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/cli v25.0.3+incompatible h1:KLeNs7zws74oFuVhgZQ5ONGZiXUUdgsdy6/EsX/6284=
-github.com/docker/cli v25.0.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v25.0.4+incompatible h1:DatRkJ+nrFoYL2HZUzjM5Z5sAmcA5XGp+AW0oEw2+cA=
+github.com/docker/cli v25.0.4+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
@@ -153,8 +153,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
-github.com/go-jose/go-jose/v3 v3.0.2 h1:2Edjn8Nrb44UvTdp84KU0bBPs1cO7noRCybtS3eJEUQ=
-github.com/go-jose/go-jose/v3 v3.0.2/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
+github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-log/log v0.2.0 h1:z8i91GBudxD5L3RmF0KVpetCbcGWAV7q1Tw1eRwQM9Q=
 github.com/go-log/log v0.2.0/go.mod h1:xzCnwajcues/6w7lne3yK2QU7DBPW7kqbgPGG5AF65U=

--- a/scripts/ci-docker-run
+++ b/scripts/ci-docker-run
@@ -26,6 +26,7 @@ CONTAINER_VERS="${CONTAINER_VERS:-$DOCKER_HUB_URI}"
 
 docker run --privileged --network=host -v "$(pwd):/build:rw" \
   -e OS_TYPE=$OS_TYPE -e GO_ARCH=$GO_ARCH -e CONTAINER_VERS="$CONTAINER_VERS" \
+  -e HIDE_DIST=$HIDE_DIST \
   --name "$DOCKER_CONTAINER_NAME" "$DOCKER_HUB_URI" /bin/bash -exc \
 	"cd /build && scripts/ci-${TEST_TYPE:-$PKGTYPE-build}-test"
 


### PR DESCRIPTION
Also adds `ghcr.io/apptainer/apptainer` to the last 1.3.0 changelog entry (already reflected in the release announcement) and disables dependabot on the release-1.2 branch.