### PR TITLE
Clean dependencies so they stay out of release assets

### DIFF
--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -58,5 +58,5 @@ su testuser -c '
   cp $HOME/rpmbuild/SRPMS/*.rpm $HOME/rpmbuild/RPMS/*/*.rpm .
 
   # remove any downloaded files so tar files do not get into release assets
-  rm -f $DOWNLOADEDFILES
+  ./scripts/clean-dependencies
 '


### PR DESCRIPTION
Forgot to update that earlier in scripts/ci-rpm-build-test.