### PR TITLE
Remove signatures from Docker images (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes for v1.3.x
+
+- Make 'apptainer build' work with signed Docker containers.
+
 ## v1.3.0 - \[2024-03-12\]
 
 Changes since v1.2.5

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -125,8 +125,9 @@ func (t *ImageReference) newImageSource(ctx context.Context, sys *types.SystemCo
 
 	// First we are fetching into the cache
 	_, err = copy.Image(ctx, policyCtx, t.ImageReference, t.source, &copy.Options{
-		ReportWriter: w,
-		SourceCtx:    sys,
+		ReportWriter:     w,
+		SourceCtx:        sys,
+		RemoveSignatures: true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -300,8 +300,9 @@ func (cp *OCIConveyorPacker) Pack(ctx context.Context) (*sytypes.Bundle, error) 
 func (cp *OCIConveyorPacker) fetch(ctx context.Context) error {
 	// cp.srcRef contains the cache source reference
 	_, err := copy.Image(ctx, cp.policyCtx, cp.tmpfsRef, cp.srcRef, &copy.Options{
-		ReportWriter: io.Discard,
-		SourceCtx:    cp.sysCtx,
+		ReportWriter:     io.Discard,
+		SourceCtx:        cp.sysCtx,
+		RemoveSignatures: true,
 	})
 	return err
 }


### PR DESCRIPTION
OCI image layouts do not support the storing of signatures. Therefore, singed containers will cause apptainer to error on ``apptainer build ..``
with the message:
 "Pushing signatures for OCI images is not supported" when
attempting to pull signed containers from a Docker registry. To fix this, set an option to remove signatures.

This fixes issue #2094.

## Description of the Pull Request (PR):

Cherry picked commit from 'main' PR #2095


### This fixes or addresses the following GitHub issues:

 - Fixes #2094


