### PR TITLE
hide `instance stats will not be available` message under `--sharens` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Stopped binding over the default timezone in the container with the host's timezone,
   which led to unexpected behavior if the application changed timezones.
 - Added progress bars for `oras://` push and pull.
+- Hide `Instance stats will not be available` message under `--sharens` mode.
 
 ## v1.3.0 - \[2024-03-12\]
 

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -1095,7 +1095,11 @@ func (l *Launcher) setCgroups(instanceName string) error {
 		return nil
 	}
 
-	sylog.Infof("Instance stats will not be available - requires cgroups v2 with systemd as manager.")
+	if l.cfg.ShareNSMode {
+		sylog.Debugf("Instance stats will not be available - requires cgroups v2 with systemd as manager.")
+	} else {
+		sylog.Infof("Instance stats will not be available - requires cgroups v2 with systemd as manager.")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

hide `instance stats will not be available` message under `--sharens` mode

### This fixes or addresses the following GitHub issues:

 - Fixes #2128


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
