### PR TITLE
make runscript timeout configurable (release-1.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Fix problem where credentials locally stored with `registry login` command
   were not usable in some execution flows. Run `registry login` again with
   latest version to ensure credentials are stored correctly.
+- Make runscript timeout configurable.
 
 ## v1.3.0 - \[2024-03-12\]
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -92,6 +92,8 @@ var (
 	underlay bool // whether using underlay instead of overlay
 
 	shareNS bool // mode for launching container using shared namespace
+
+	runscriptTimeout string // runscript timeout
 )
 
 // --app
@@ -830,6 +832,17 @@ var actionShareNSFlag = cmdline.Flag{
 	Hidden:       false,
 }
 
+// --runscript-timeout
+var actionRunscriptTimeoutFlag = cmdline.Flag{
+	ID:           "runscriptTimeoutFlag",
+	Value:        &runscriptTimeout,
+	DefaultValue: "",
+	Name:         "runscript-timeout",
+	Usage:        "set the timeout duration for runscript (default 1m)",
+	EnvKeys:      []string{"RUNSCRIPT_TIMEOUT"},
+	Hidden:       false,
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -847,6 +860,9 @@ func init() {
 			cmdManager.SetCmdGroup("actions_instance", actionsCmd...)
 		}
 		actionsInstanceCmd := cmdManager.GetCmdGroup("actions_instance")
+
+		cmdManager.SetCmdGroup("actions_runscript", RunCmd, instanceRunCmd)
+		actionsRunscriptCmd := cmdManager.GetCmdGroup("actions_runscript")
 
 		cmdManager.RegisterFlagForCmd(&actionAddCapsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionAllowSetuidFlag, actionsInstanceCmd...)
@@ -923,5 +939,6 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionIgnoreUsernsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionUnderlayFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionShareNSFlag, actionsCmd...)
+		cmdManager.RegisterFlagForCmd(&actionRunscriptTimeoutFlag, actionsRunscriptCmd...)
 	})
 }

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -354,6 +354,7 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 		launch.OptUnderlay(underlay),
 		launch.OptShareNSMode(shareNS),
 		launch.OptShareNSFd(fd),
+		launch.OptRunscriptTimeout(runscriptTimeout),
 	}
 
 	l, err := launch.NewLauncher(opts...)

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -372,6 +372,9 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 		l.engineConfig.SetShareNSFd(l.cfg.ShareNSFd)
 	}
 
+	// Set runscript timeout
+	l.engineConfig.SetRunscriptTimout(l.cfg.RunscriptTimeout)
+
 	// Set the required namespaces in the engine config.
 	l.setNamespaces()
 	// Set the container environment.

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -150,9 +150,10 @@ type launchOptions struct {
 	IgnoreUserns      bool
 	UseBuildConfig    bool
 	TmpDir            string
-	Underlay          bool // whether prefer underlay over overlay
-	ShareNSMode       bool // whether running in sharens mode
-	ShareNSFd         int  // fd opened in sharens mode
+	Underlay          bool   // whether prefer underlay over overlay
+	ShareNSMode       bool   // whether running in sharens mode
+	ShareNSFd         int    // fd opened in sharens mode
+	RunscriptTimeout  string // runscript timeout
 }
 
 type Launcher struct {
@@ -583,6 +584,14 @@ func OptShareNSMode(b bool) Option {
 func OptShareNSFd(fd int) Option {
 	return func(lo *launchOptions) error {
 		lo.ShareNSFd = fd
+		return nil
+	}
+}
+
+// OptRunscriptTimeout
+func OptRunscriptTimeout(timeout string) Option {
+	return func(lo *launchOptions) error {
+		lo.RunscriptTimeout = timeout
 		return nil
 	}
 }

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -155,6 +155,7 @@ type JSONConfig struct {
 	WritableOverlay       bool              `json:"writableOverlay,omitempty"`
 	ShareNSMode           bool              `json:"sharensMode,omitempty"`
 	ShareNSFd             int               `json:"sharensFd,omitempty"`
+	RunscriptTimeout      string            `json:"runscriptTimeout,omitempty"`
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.
@@ -963,4 +964,14 @@ func (e *EngineConfig) SetShareNSFd(fd int) {
 // GetShareNSFd gets the locked fd
 func (e *EngineConfig) GetShareNSFd() int {
 	return e.JSON.ShareNSFd
+}
+
+// SetRunscriptTimout sets the runscript timeout
+func (e *EngineConfig) SetRunscriptTimout(timeout string) {
+	e.JSON.RunscriptTimeout = timeout
+}
+
+// GetRunscriptTimeout gets the set runscript timeout
+func (e *EngineConfig) GetRunscriptTimeout() string {
+	return e.JSON.RunscriptTimeout
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry picking commit 8e1323775a1c45de88c8462cff55d956d25ab1a1 from PR
https://github.com/apptainer/apptainer/pull/2116

### This fixes or addresses the following GitHub issues:

 - Fixes #1595 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
