### PR TITLE
Use a more helpful INFO message when a timeout happens during FUSE shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   latest version to ensure credentials are stored correctly.
 - Make runscript timeout configurable.
 - Return invalid bind path mount options during bind path parsing.
+- Make the INFO message more helpful when a running background process
+  at exit time causes a FUSE mount to not shut down cleanly.
 
 ## v1.3.0 - \[2024-03-12\]
 


### PR DESCRIPTION
Don't treat a FUSE processes exiting with no error message as an error.  Instead, print an INFO message when FUSE process is terminated because of a timeout, and indicate that it might be because of running background process.

- Fixes #2104