### PR TITLE
Clean up cryptsetup even when there's an image driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 ## Changes for v1.3.x
 
 - Make 'apptainer build' work with signed Docker containers.
+- Fixed regression introduced in 1.3.0 that prevented closing cryptsetup
+  and the corresponding loop device after running an encrypted sif container
+  file in suid mode.
 - Stopped binding over the default timezone in the container with the host's timezone,
   which led to unexpected behavior if the application changed timezones.
 - Added progress bars for `oras://` push and pull.

--- a/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
@@ -132,7 +132,7 @@ func (e *EngineOperations) CleanupContainer(ctx context.Context, fatal error, st
 		}
 	}
 
-	if cryptDev != "" && imageDriver == nil {
+	if cryptDev != "" {
 		if err := cleanupCrypt(cryptDev); err != nil {
 			sylog.Errorf("could not cleanup crypt: %v", err)
 		}


### PR DESCRIPTION
This fixes a 1.3.0 regression that prevented cleaning up the crypt device that was used by suid mode to run encrypted sif container files.
- Fixes #2175