### PR TITLE
Clean up cryptsetup even when there's an image driver (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 ## Changes for v1.3.x
 
 - Make 'apptainer build' work with signed Docker containers.
+- Fixed regression introduced in 1.3.0 that prevented closing cryptsetup
+  and the corresponding loop device after running an encrypted sif container
+  file in suid mode.
 - Stopped binding over the default timezone in the container with the host's timezone,
   which led to unexpected behavior if the application changed timezones.
 - Added progress bars for `oras://` push and pull.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
-## Changes for v1.4.x
-
 ## Changes for v1.3.x
 
 - Make 'apptainer build' work with signed Docker containers.
@@ -165,9 +163,7 @@ Changes since v1.2.5
 ### Release change
 
 - Releases will generate apptainer Docker images for the Linux amd64 and arm64
-  architectures.
-
-## Changes for v1.2.x
+  architectures at `ghcr.io/apptainer/apptainer`.
 
 ## v1.2.5 - \[2023-11-21\]
 
@@ -976,7 +972,7 @@ Accidentally included no code changes.
 
 ### Comparison to SingularityCE
 
-This release candidate has most of the new features, bug fixes, and
+This release has most of the new features, bug fixes, and
 changes that went into SingularityCE up through their version 3.9.5,
 except where the maintainers of Apptainer disagreed with what went into
 SingularityCE since the project fork.  The biggest difference is that

--- a/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
@@ -132,7 +132,7 @@ func (e *EngineOperations) CleanupContainer(ctx context.Context, fatal error, st
 		}
 	}
 
-	if cryptDev != "" && imageDriver == nil {
+	if cryptDev != "" {
 		if err := cleanupCrypt(cryptDev); err != nil {
 			sylog.Errorf("could not cleanup crypt: %v", err)
 		}


### PR DESCRIPTION
Cherry-pick #2177 to the release-1.3 branch