### PR TITLE
fixed the wrong mediaType in the oras push manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Return invalid bind path mount options during bind path parsing.
 - Make the INFO message more helpful when a running background process
   at exit time causes a FUSE mount to not shut down cleanly.
+- Fixed the wrong mediaType in the oras push manifest.
 
 ## v1.3.0 - \[2024-03-12\]
 

--- a/internal/pkg/client/oras/image.go
+++ b/internal/pkg/client/oras/image.go
@@ -147,7 +147,7 @@ func NewImageFromSIF(file string, layerMediaType types.MediaType) (*SifImage, er
 	//   }
 	si.manifest = v1.Manifest{
 		SchemaVersion: 2,
-		MediaType:     types.DockerManifestSchema2,
+		MediaType:     types.OCIManifestSchema1,
 		Config: v1.Descriptor{
 			MediaType: types.MediaType(SifConfigMediaTypeV1),
 			Digest:    emptyHash,


### PR DESCRIPTION
## Description of the Pull Request (PR):

using `application/vnd.oci.image.manifest.v1+json` rather than `application/vnd.docker.distribution.manifest.v2+json`


### This fixes or addresses the following GitHub issues:

 - Fixes #2178


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)

### Test
Download and push alpine.sif to ghcr.io
![image](https://github.com/apptainer/apptainer/assets/2051711/7f9ced09-4afc-46c3-83f9-d7110085a012)
