### PR TITLE
Add Rocky Linux yum def file example 

### DIFF
--- a/examples/rocky/Apptainer
+++ b/examples/rocky/Apptainer
@@ -1,0 +1,11 @@
+bootstrap: yum
+include: dnf
+mirrorurl: http://dl.rockylinux.org/pub/rocky/%{OSVERSION}/BaseOS/x86_64/os/
+osversion: 9
+
+%environment
+    LC_ALL=C
+
+%post
+    dnf -y update
+    dnf install -y epel-release


### PR DESCRIPTION
Added a new example def file to illustrate building a container from Rocky Linux mirrors using yum.

 - Fixes #2196 
