### PR TITLE
refactor the oras download progress code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.3.x
 
+- Fixed the issue that oras download progress bar gets stuck
+  when downloading large images.
+
 ## v1.3.1 - \[2024-04-24\]
 
 - Make 'apptainer build' work with signed Docker containers.

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -33,9 +33,11 @@ import (
 )
 
 // DownloadImage downloads a SIF image specified by an oci reference to a file using the included credentials
-func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, pb *client.DownloadProgressBar) error {
-	im, err := remoteImage(ref, ociAuth, noHTTPS, pb)
+func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool) error {
+	rt := client.NewRoundTripper(ctx, nil)
+	im, err := remoteImage(ref, ociAuth, noHTTPS, rt)
 	if err != nil {
+		rt.ProgressShutdown()
 		return err
 	}
 
@@ -47,6 +49,7 @@ func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.Dock
 	//
 	manifest, err := im.Manifest()
 	if err != nil {
+		rt.ProgressShutdown()
 		return err
 	}
 	if len(manifest.Layers) != 1 {
@@ -55,12 +58,14 @@ func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.Dock
 	layer := manifest.Layers[0]
 	if layer.MediaType != SifLayerMediaTypeV1 &&
 		layer.MediaType != SifLayerMediaTypeProto {
+		rt.ProgressShutdown()
 		return fmt.Errorf("invalid layer mediatype: %s", layer.MediaType)
 	}
 
 	// Retrieve image to a temporary OCI layout
 	tmpDir, err := os.MkdirTemp("", "oras-tmp-")
 	if err != nil {
+		rt.ProgressShutdown()
 		return err
 	}
 	defer func() {
@@ -70,11 +75,16 @@ func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.Dock
 	}()
 	tmpLayout, err := layout.Write(tmpDir, empty.Index)
 	if err != nil {
+		rt.ProgressShutdown()
 		return err
 	}
 	if err := tmpLayout.AppendImage(im); err != nil {
+		rt.ProgressShutdown()
 		return err
 	}
+
+	rt.ProgressComplete()
+	rt.ProgressWait()
 
 	// Copy SIF blob out from layout to final location
 	blob, err := tmpLayout.Blob(layer.Digest)
@@ -235,7 +245,7 @@ func sha256sum(r io.Reader) (result string, nBytes int64, err error) {
 }
 
 // remoteImage returns a v1.Image for the provided remote ref.
-func remoteImage(ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, pb *client.DownloadProgressBar) (v1.Image, error) {
+func remoteImage(ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, rt *client.RoundTripper) (v1.Image, error) {
 	ref = strings.TrimPrefix(ref, "oras://")
 	ref = strings.TrimPrefix(ref, "//")
 
@@ -249,8 +259,7 @@ func remoteImage(ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, p
 		return nil, fmt.Errorf("invalid reference %q: %w", ref, err)
 	}
 	remoteOpts := []remote.Option{AuthOptn(ociAuth)}
-	if pb != nil {
-		rt := client.NewRoundTripper(nil, pb)
+	if rt != nil {
 		remoteOpts = append(remoteOpts, remote.WithTransport(rt))
 	}
 	im, err := remote.Image(ir, remoteOpts...)

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -15,11 +15,9 @@ import (
 	"os"
 
 	"github.com/apptainer/apptainer/internal/pkg/cache"
-	"github.com/apptainer/apptainer/internal/pkg/client"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	ocitypes "github.com/containers/image/v5/types"
-	"golang.org/x/term"
 )
 
 // pull will pull an oras image into the cache if directTo="", or a specific file if directTo is set.
@@ -29,13 +27,9 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
 	}
 
-	var pb *client.DownloadProgressBar
-	if term.IsTerminal(2) {
-		pb = &client.DownloadProgressBar{}
-	}
 	if directTo != "" {
 		sylog.Infof("Downloading oras image")
-		if err := DownloadImage(ctx, directTo, pullFrom, ociAuth, noHTTPS, pb); err != nil {
+		if err := DownloadImage(ctx, directTo, pullFrom, ociAuth, noHTTPS); err != nil {
 			return "", fmt.Errorf("unable to Download Image: %v", err)
 		}
 		imagePath = directTo
@@ -49,7 +43,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 		if !cacheEntry.Exists {
 			sylog.Infof("Downloading oras image")
 
-			if err := DownloadImage(ctx, cacheEntry.TmpPath, pullFrom, ociAuth, noHTTPS, pb); err != nil {
+			if err := DownloadImage(ctx, cacheEntry.TmpPath, pullFrom, ociAuth, noHTTPS); err != nil {
 				return "", fmt.Errorf("unable to Download Image: %v", err)
 			}
 			if cacheFileHash, err := ImageHash(cacheEntry.TmpPath); err != nil {

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -18,6 +18,17 @@ import (
 	"github.com/vbauerster/mpb/v8/decor"
 )
 
+var defaultOption = []mpb.BarOption{
+	mpb.PrependDecorators(
+		decor.Counters(decor.SizeB1024(0), "%.1f / %.1f"),
+	),
+	mpb.AppendDecorators(
+		decor.Percentage(),
+		decor.AverageSpeed(decor.SizeB1024(0), " % .1f "),
+		decor.AverageETA(decor.ET_STYLE_GO),
+	),
+}
+
 func initProgressBar(totalSize int64) (*mpb.Progress, *mpb.Bar) {
 	p := mpb.New()
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

When downloading large images using the oras protocol, the download progress bar gets stuck. In this PR, the oras progress bar code gets refactored. 


### This fixes or addresses the following GitHub issues:

 - Fixes #2214


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)

## Test
![apptainer](https://github.com/apptainer/apptainer/assets/2051711/6ee3c097-b377-49f3-9915-e5caa30160fc)
