### PR TITLE
Label interactive process with image filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.4.x
 
+- Label process for starter binary of interactive containers with image filename,
+  for example: `Apptainer runtime parent: example.sif`.
+
 ## v1.3.2 - \[2024-05-28\]
 
 ### Security fix

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,7 @@
 - Jarrod Johnson <jjohnson2@lenovo.com>
 - Jason Stover <jms@sylabs.io>, <jason.stover@gmail.com>
 - Jeff Kriske <jekriske@gmail.com>
+- Jeremy Spencer <jeremy.spencer@stfc.ac.uk>
 - Jia Li <jiali@sylabs.io>
 - Jim Phillips <jcphill@users.noreply.github.com>
 - Joana Chavez <joana@sylabs.io>, <j.chavezlavalle@gmail.com>

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -419,7 +419,13 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	if l.engineConfig.GetInstance() && !l.cfg.ShareNSMode {
 		err = l.starterInstance(loadOverlay, insideUserNs, instanceName, useSuid, cfg)
 	} else {
-		err = l.starterInteractive(loadOverlay, useSuid, cfg)
+		var imageFilename string
+		var fileInfoErr error
+		info, fileInfoErr := os.Stat(image)
+		if fileInfoErr == nil {
+			imageFilename = info.Name()
+		}
+		err = l.starterInteractive(loadOverlay, useSuid, cfg, imageFilename)
 	}
 
 	// Execution is finished.
@@ -1177,9 +1183,9 @@ func (l *Launcher) prepareImage(c context.Context, insideUserNs bool, image stri
 }
 
 // starterInteractive executes the starter binary to run an image interactively, given the supplied engineConfig
-func (l *Launcher) starterInteractive(loadOverlay bool, useSuid bool, cfg *config.Common) error {
+func (l *Launcher) starterInteractive(loadOverlay bool, useSuid bool, cfg *config.Common, imageFilename string) error {
 	err := starter.Exec(
-		"Apptainer runtime parent",
+		"Apptainer runtime parent: "+imageFilename,
 		cfg,
 		starter.UseSuid(useSuid),
 		starter.LoadOverlayModule(loadOverlay),


### PR DESCRIPTION
## Description of the Pull Request (PR):

When starting interactive container, append image filename to process name.
Such that the process name is of the form:
```
Apptainer runtime parent: example.sif
```

**Reasoning for this change:**
My team runs a service where users run containerised software as and when they need.
There are many different containers, and we'd like to get metrics about which are used, and how much.
In our case, the containers are not started as instances, so they don't appear in `apptainer instance list`.
Labelling the `Apptainer runtime parent` process with the filename gives a clear indication of which container is running.

If there is an easier/preferred mechanism to see which containers are currently running, please let me know.

This is my first attempt at `Go`, so apologies if I've made any rookie mistakes!

**Note:** Regarding the changelog, I made an entry under `Changes for v1.4.x`, I hope that's the correct place.
The docs in `CONTRIBUTING.md` talk about creating a new top level section, `Changes Since vX.Y.Z`, but I'm working under the impression the style has changed a little bit. Happy to update it though!

### This fixes or addresses the following GitHub issues:

 - Fixes - No corresponding issue.


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
