### PR TITLE
add apparmor profiles for ubuntu 24.04 or higher distros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,21 @@ jobs:
           GO_ARCH: linux-amd64
         run: ./scripts/ci-docker-run
 
+  ubuntu-2404:
+    name: debbuild-ubuntu24
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v2
+      # fetch tags as checkout@v2 doesn't do that by default
+      - run: git fetch --prune --unshallow --tags --force
+
+      - name: Build and test deb under docker
+        env:
+          OS_TYPE: ubuntu
+          OS_VERSION: 24.04
+          GO_ARCH: linux-amd64
+        run: ./scripts/ci-docker-run
+
   rpmbuild-rocky8:
     runs-on: ubuntu-22.04
     name: rpmbuild-rocky8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Ensure opened/kept file descriptors in stage 1 are not closed during the Go
   garbage collection to avoid "bad file descriptor" errors at startup.
 - Fixed a segmentation violation issue when running Apptainer checkpoint.
+- Add apparmor profiles for ubuntu 24.04 or higher distros.
 
 ## v1.3.2 - \[2024-05-28\]
 

--- a/dist/debian/apparmor-placeholder
+++ b/dist/debian/apparmor-placeholder
@@ -1,0 +1,9 @@
+# Permit unprivileged user namespace creation for apptainer starter, placeholder
+abi <abi/4.0>,
+include <tunables/global>
+ 
+profile apptainer /usr/lib/@{multiarch}/apptainer/bin/starter{,-suid} flags=(unconfined) {
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/apptainer>
+}
+

--- a/dist/debian/apparmor-userns
+++ b/dist/debian/apparmor-userns
@@ -1,0 +1,11 @@
+# Permit unprivileged user namespace creation for apptainer starter
+abi <abi/4.0>,
+include <tunables/global>
+
+profile apptainer /usr/lib/@{multiarch}/apptainer/bin/starter{,-suid} flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/apptainer>
+}
+

--- a/dist/debian/apptainer.install
+++ b/dist/debian/apptainer.install
@@ -3,3 +3,4 @@ usr/bin
 usr/libexec
 usr/share
 var/lib/apptainer
+etc/apparmor.d/apptainer

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -20,7 +20,8 @@ Build-Depends:
  libtool,
  pkg-config,
  libfuse3-dev,
- zlib1g-dev
+ zlib1g-dev,
+ dh-apparmor
 Standards-Version: 3.9.8
 Homepage: http://apptainer.org
 Vcs-Git: https://github.com/apptainer/apptainer.git

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -3,6 +3,9 @@
 pkgsrc = $(shell LC_ALL=C dpkg-parsechangelog --show-field Source )
 pkgver = $(shell LC_ALL=C dpkg-parsechangelog --show-field Version )
 
+OS_MAJOR := $(shell grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI' | cut -d'.' -f1)
+OS_NAME := $(shell grep ^NAME /etc/os-release | cut -d '=' -f2 | sed 's/\"//gI')
+
 # Needed by debchange to set Name and EMAIL in changelog
 # DEBFULLNAME is filtered out by debuild
 # use DEB_FULLNAME instead, which will set DEBFULLNAME
@@ -93,6 +96,15 @@ override_dh_auto_build:
 override_dh_auto_install:
 	@dh_auto_install -Smakefile -D$(DEB_SC_BUILDDIR)
 	@./scripts/install-dependencies $(pkgdir)/usr/libexec
+# Apparmor userns profile needed on Ubuntu 24.04, or unconfined placeholder for older versions.	
+	if [ $(OS_MAJOR) -gt 23 ] && [[ $(OS_NAME) = "Ubuntu" ]]; then \
+		echo "Ubuntu 24.04 or newer - installing apparmor userns profile"; \
+		install -D -m 644 dist/debian/apparmor-userns $(pkgdir)/etc/apparmor.d/apptainer; \
+	else \
+		echo "other debian/ubuntu distros - installing apparmor placeholder profile"; \
+		install -D -m 644 dist/debian/apparmor-placeholder $(pkgdir)/etc/apparmor.d/apptainer; \
+	fi;
+	dh_apparmor --profile-name=apptainer
 
 override_dh_install:
 	@dh_install -papptainer-suid usr/libexec/apptainer/bin/starter-suid

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -6,6 +6,9 @@
 
 # this script runs as root under docker --privileged
 
+OS_MAJOR=$(grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI' | cut -d'.' -f1)
+OS_NAME=$(grep ^NAME /etc/os-release | cut -d '=' -f2 | sed 's/\"//gI')
+
 # install dependencies
 apt-get update
 export DEBIAN_FRONTEND=noninteractive
@@ -19,6 +22,7 @@ apt-get install -y \
     cryptsetup \
     tzdata \
     curl wget git
+
 apt-get install -y \
     devscripts \
     debhelper \
@@ -26,9 +30,10 @@ apt-get install -y \
     help2man \
     libarchive-dev \
     libssl-dev \
-    python2 \
     uuid-dev \
-    golang-go
+    golang-go \
+    dh-apparmor
+
 # for squashfuse_ll build
 apt-get install -y autoconf automake libtool pkg-config libfuse3-dev zlib1g-dev
 
@@ -39,7 +44,14 @@ mv .??* !(src) src
 
 # switch to an unprivileged user with sudo privileges
 apt-get install -y sudo
-useradd -u 1000 --create-home -s /bin/bash testuser
+
+if [[ $OS_NAME = "Ubuntu" ]] && [ $OS_MAJOR -gt 23 ]; then
+# uid 1000 is occupied by user 'ubuntu' in ubuntu 24.04, here using a different uid = 1001
+    useradd -u 1001 --create-home -s /bin/bash testuser
+else
+    useradd -u 1000 --create-home -s /bin/bash testuser
+fi
+
 echo "Defaults:testuser env_keep=DOCKER_HOST" >>/etc/sudoers
 echo "testuser ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
 mkdir -p /local


### PR DESCRIPTION
## Description of the Pull Request (PR):

add apparmor profiles for ubuntu 24.04 or higher distros

### This fixes or addresses the following GitHub issues:

 - Fixes #2027


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
