### PR TITLE
Add libcudadebugger.so to nvliblist.conf. Fixes #2261.

### DIFF
--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -15,6 +15,7 @@ nvidia-cuda-mps-server
 
 # put libs here (must end in .so) 
 libcuda.so
+libcudadebugger.so
 libEGL_installertest.so
 libEGL_nvidia.so
 libEGL.so


### PR DESCRIPTION
## Description of the Pull Request (PR):

CUDA 12 adds a new library (libcudadebugger.so) required for cuda-gdb to work.


### This fixes or addresses the following GitHub issues:

 - Fixes #2261


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
