### PR TITLE
Add libcudadebugger.so to nvliblist.conf. Fixes #2261.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Label process for starter binary of interactive containers with image filename,
   for example: `Apptainer runtime parent: example.sif`.
 
+## Changes for v1.3.x
+
+- Added libcudadebugger.so to nvliblist.conf to support cuda-gdb in CUDA 12+.
+
 ## v1.3.2 - \[2024-05-28\]
 
 ### Security fix

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -84,6 +84,7 @@
 - Olivier Sallou <olivier.sallou@irisa.fr>
 - Omer Preminger <omer@sylabs.io>
 - Paul Charlton <techguru@byiq.com>
+- Patrick LoPresti <lopresti@gmail.com>
 - Peter Steinbach <steinbach@scionics.de>
 - Petr Votava <votava.petr@gene.com>
 - Rafal Gumienny <rafal.gumienny@gmail.com>

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -15,6 +15,7 @@ nvidia-cuda-mps-server
 
 # put libs here (must end in .so) 
 libcuda.so
+libcudadebugger.so
 libEGL_installertest.so
 libEGL_nvidia.so
 libEGL.so


### PR DESCRIPTION
## Description of the Pull Request (PR):

CUDA 12 introduced libcudadebugger.so, required for cuda-gdb to work. This PR adds it to nvliblist.conf.


### This fixes or addresses the following GitHub issues:

 - Fixes #2261


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
