### PR TITLE
Update minimum golang to 1.21, drop el7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   check_go_mod:
     name: check_go_mod
     runs-on: ubuntu-22.04
-    container: golang:1.20.10
+    container: golang:1.21.9
     steps:
       - uses: actions/checkout@v2
 
@@ -31,7 +31,7 @@ jobs:
   check_source:
     name: check_source
     runs-on: ubuntu-22.04
-    container: golangci/golangci-lint:v1.51.1
+    container: golangci/golangci-lint:v1.59.1
     steps:
       - uses: actions/checkout@v2
 
@@ -54,7 +54,7 @@ jobs:
   alpine:
     name: alpine
     runs-on: ubuntu-22.04
-    container: golang:1.20.12-alpine
+    container: golang:1.22-alpine
     steps:
       - name: Fetch deps
         run: apk add -q --no-cache git bash alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
@@ -71,7 +71,7 @@ jobs:
     name: oldgo
     runs-on: ubuntu-22.04
     # match the minimum version required by mconfig
-    container: golang:1.20-alpine
+    container: golang:1.21-alpine
     steps:
       - name: Fetch deps
         run: apk add -q --no-cache git bash alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed cryptsetup
@@ -87,7 +87,7 @@ jobs:
   check_test_corpus:
     name: check_test_corpus
     runs-on: ubuntu-22.04
-    container: golang:1.20.10
+    container: golang:1.21.9
     steps:
       - uses: actions/checkout@v2
 
@@ -102,7 +102,7 @@ jobs:
   check_license_dependencies:
     name: check_license_dependencies
     runs-on: ubuntu-22.04
-    container: golang:1.20.10
+    container: golang:1.21.9
     steps:
       - uses: actions/checkout@v2
 
@@ -128,28 +128,6 @@ jobs:
           OS_VERSION: 11
           # setting GO_ARCH speeds things by using go binaries instead of source
           GO_ARCH: linux-amd64
-        run: ./scripts/ci-docker-run
-
-  rpmbuild-centos7:
-    runs-on: ubuntu-22.04
-    name: rpmbuild-centos7
-    steps:
-      - uses: actions/checkout@v2
-      # fetch tags as checkout@v2 doesn't do that by default
-      - run: git fetch --prune --unshallow --tags --force
-
-      - name: Build and test rpm under docker
-        env:
-          OS_TYPE: centos
-          OS_VERSION: 7
-          GO_ARCH: linux-amd64
-        run: ./scripts/ci-docker-run
-
-      - name: Install and test unprivileged
-        env:
-          OS_TYPE: centos
-          OS_VERSION: 7
-          TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 
   rpmbuild-rocky8:
@@ -243,7 +221,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.10
+          go-version: 1.21.9
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
@@ -273,7 +251,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.10
+          go-version: 1.21.9
 
       - name: Fetch deps
         run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup dbus-user-session
@@ -318,7 +296,7 @@ jobs:
         if: env.run_tests
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.10
+          go-version: 1.21.9
 
       - name: Fetch deps
         if: env.run_tests
@@ -392,7 +370,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.10
+          go-version: 1.21.9
 
       - name: Check pkg/... doesn't depend on buildcfg
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 run:
+  concurrency: 4
   timeout: 3m
   skip-files:
     - "internal/pkg/util/user/cgo_lookup_unix.go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.4.x
 
+- Updated the minimum golang version to 1.21.
+- Remove support for EL7.
 - Label process for starter binary of interactive containers with image filename,
   for example: `Apptainer runtime parent: example.sif`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,7 +101,7 @@ run:
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
 ```
 
 <!-- markdownlint-enable MD013 -->
@@ -260,9 +260,9 @@ Then build the rpms from the tarball:
 rpmbuild -tb apptainer-${VERSION}.tar.gz
 # Install Apptainer using the resulting rpm
 RPMVERSION="$(scripts/rpm-version "${VERSION}")"
-sudo rpm -Uvh ~/rpmbuild/RPMS/x86_64/apptainer-${RPMVERSION}-1.el7.x86_64.rpm
+sudo rpm -Uvh ~/rpmbuild/RPMS/x86_64/apptainer-${RPMVERSION}-1.el8.x86_64.rpm
 # (Optionally) Install the setuid-root portion
-sudo rpm -Uvh ~/rpmbuild/RPMS/x86_64/apptainer-suid-${RPMVERSION}-1.el7.x86_64.rpm
+sudo rpm -Uvh ~/rpmbuild/RPMS/x86_64/apptainer-suid-${RPMVERSION}-1.el8.x86_64.rpm
 # (Optionally) Remove the build tree, source, and dependencies
 rm -rf ~/rpmbuild apptainer-${VERSION}.tar.gz
 ./scripts/clean-dependencies

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -50,7 +50,7 @@ func manDocs(rootCmd *cobra.Command, outDir string) {
 func rstDocs(rootCmd *cobra.Command, outDir string) {
 	assertAccess(outDir)
 	sylog.Infof("Creating Apptainer RST docs at %s\n", outDir)
-	if err := doc.GenReSTTreeCustom(rootCmd, outDir, func(a string) string {
+	if err := doc.GenReSTTreeCustom(rootCmd, outDir, func(_ string) string {
 		return ""
 	}, func(name, ref string) string {
 		return fmt.Sprintf(":ref:`%s <%s>`", name, ref)
@@ -66,7 +66,7 @@ func main() {
 		Args:      cobra.ExactArgs(1),
 		Use:       "makeDocs {markdown | man | rst}",
 		Short:     "Generates Apptainer documentation",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			// We must Init() as loading commands etc. is deferred until this is called.
 			// Using true here will result in local docs including any content for installed
 			// plugins.

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -373,7 +373,7 @@ func handleConfDir(confDir, legacyConfigDir string) {
 	migrateKeys(confDir, legacyConfigDir)
 }
 
-func migrateRemoteConf(confDir, legacyConfigDir string) {
+func migrateRemoteConf(_, _ string) {
 	ok, err := fs.PathExists(syfs.LegacyRemoteConf())
 	if err != nil {
 		sylog.Warningf("Failed to retrieve information for %s: %s", syfs.LegacyRemoteConf(), err)
@@ -400,7 +400,7 @@ func migrateRemoteConf(confDir, legacyConfigDir string) {
 	}
 }
 
-func migrateDockerConf(confDir, legacyConfigDir string) {
+func migrateDockerConf(_, _ string) {
 	ok, err := fs.PathExists(syfs.LegacyDockerConf())
 	if err != nil {
 		sylog.Warningf("Failed to retrieve information for %s: %s", syfs.LegacyDockerConf(), err)
@@ -418,7 +418,7 @@ func migrateDockerConf(confDir, legacyConfigDir string) {
 	}
 }
 
-func migrateKeys(confDir, legacyConfigDir string) {
+func migrateKeys(_, _ string) {
 	legacySypgpDir := filepath.Join(syfs.LegacyConfigDir(), sypgp.LegacyDirectory)
 	keysDir := filepath.Join(syfs.ConfigDir(), sypgp.Directory)
 	ok, err := fs.PathExists(legacySypgpDir)
@@ -481,7 +481,7 @@ func migrateGPGPrivate(sypgpDir, legacySypgpDir string) {
 	}
 }
 
-func persistentPreRun(cmd *cobra.Command, args []string) error {
+func persistentPreRun(cmd *cobra.Command, _ []string) error {
 	setSylogMessageLevel()
 	sylog.Debugf("Apptainer version: %s", buildcfg.PACKAGE_VERSION)
 
@@ -617,7 +617,7 @@ func Init(loadPlugins bool) {
 var apptainerCmd = &cobra.Command{
 	TraverseChildren:      true,
 	DisableFlagsInUseLine: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return cmdline.CommandError("invalid command")
 	},
 
@@ -715,7 +715,7 @@ func TraverseParentsUses(cmd *cobra.Command) string {
 // VersionCmd displays installed apptainer version
 var VersionCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		fmt.Println(buildcfg.PACKAGE_VERSION)
 	},
 
@@ -814,7 +814,7 @@ func apptainerExec(image string, args []string) (string, error) {
 }
 
 // CheckRoot ensures that a command is executed with root privileges.
-func CheckRoot(cmd *cobra.Command, args []string) {
+func CheckRoot(cmd *cobra.Command, _ []string) {
 	if os.Geteuid() != 0 {
 		sylog.Fatalf("%q command requires root privileges", cmd.CommandPath())
 	}
@@ -822,7 +822,7 @@ func CheckRoot(cmd *cobra.Command, args []string) {
 
 // CheckRootOrUnpriv ensures that a command is executed with root
 // privileges or that Apptainer is installed unprivileged.
-func CheckRootOrUnpriv(cmd *cobra.Command, args []string) {
+func CheckRootOrUnpriv(cmd *cobra.Command, _ []string) {
 	if os.Geteuid() != 0 && buildcfg.APPTAINER_SUID_INSTALL == 1 {
 		sylog.Fatalf("%q command requires root privileges or an unprivileged installation", cmd.CommandPath())
 	}

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -375,7 +375,7 @@ var buildCmd = &cobra.Command{
 	TraverseChildren: true,
 }
 
-func preRun(cmd *cobra.Command, args []string) {
+func preRun(_ *cobra.Command, args []string) {
 	spec := args[len(args)-1]
 	isDeffile := fs.IsFile(spec) && !isImage(spec)
 	if buildArgs.fakeroot {

--- a/cmd/internal/cli/buildconfig.go
+++ b/cmd/internal/cli/buildconfig.go
@@ -26,7 +26,7 @@ func init() {
 // BuildConfigCmd outputs a list of the compile-time parameters with which
 // apptainer was compiled
 var BuildConfigCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		name := ""
 		if len(args) > 0 {
 			name = args[0]

--- a/cmd/internal/cli/cache_clean_linux.go
+++ b/cmd/internal/cli/cache_clean_linux.go
@@ -81,7 +81,7 @@ var (
 	// cacheCleanCmd is 'apptainer cache clean' and will clear your local apptainer cache
 	cacheCleanCmd = &cobra.Command{
 		DisableFlagsInUseLine: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			if err := cleanCache(); err != nil {
 				sylog.Fatalf("Handle clean failed: %v", err)
 			}

--- a/cmd/internal/cli/cache_linux.go
+++ b/cmd/internal/cli/cache_linux.go
@@ -27,7 +27,7 @@ func init() {
 
 // CacheCmd : aka, `apptainer cache`
 var CacheCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/cache_list_linux.go
+++ b/cmd/internal/cli/cache_list_linux.go
@@ -55,7 +55,7 @@ func init() {
 // CacheListCmd is 'apptainer cache list' and will list your local apptainer cache
 var CacheListCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if err := cacheListCmd(); err != nil {
 			os.Exit(2)
 		}

--- a/cmd/internal/cli/capability_linux.go
+++ b/cmd/internal/cli/capability_linux.go
@@ -54,7 +54,7 @@ var capGroupFlag = cmdline.Flag{
 var CapabilityAvailCmd = &cobra.Command{
 	Args:                  cobra.RangeArgs(0, 1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		caps := ""
 		if len(args) > 0 {
 			caps = args[0]
@@ -78,7 +78,7 @@ var CapabilityAvailCmd = &cobra.Command{
 var CapabilityAddCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		c := apptainer.CapManageConfig{
 			Caps:  args[0],
 			User:  capConfig.CapUser,
@@ -100,7 +100,7 @@ var CapabilityAddCmd = &cobra.Command{
 var CapabilityDropCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		c := apptainer.CapManageConfig{
 			Caps:  args[0],
 			User:  capConfig.CapUser,
@@ -122,7 +122,7 @@ var CapabilityDropCmd = &cobra.Command{
 var CapabilityListCmd = &cobra.Command{
 	Args:                  cobra.RangeArgs(0, 1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		userGroup := ""
 		if len(args) == 1 {
 			userGroup = args[0]
@@ -146,7 +146,7 @@ var CapabilityListCmd = &cobra.Command{
 
 // CapabilityCmd is the capability command
 var CapabilityCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/checkpoint.go
+++ b/cmd/internal/cli/checkpoint.go
@@ -36,7 +36,7 @@ func init() {
 	})
 }
 
-func checkpointPreRun(cmd *cobra.Command, args []string) {
+func checkpointPreRun(_ *cobra.Command, _ []string) {
 	dmtcp.QuickInstallationCheck()
 }
 
@@ -55,7 +55,7 @@ var CheckpointCmd = &cobra.Command{
 var CheckpointListCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(0),
 	PreRun: checkpointPreRun,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		m := dmtcp.NewManager()
 
 		entries, err := m.List()
@@ -85,7 +85,7 @@ var CheckpointListCmd = &cobra.Command{
 var CheckpointCreateCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 	PreRun: checkpointPreRun,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 		m := dmtcp.NewManager()
 
@@ -114,7 +114,7 @@ var CheckpointCreateCmd = &cobra.Command{
 var CheckpointDeleteCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 	PreRun: checkpointPreRun,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 		m := dmtcp.NewManager()
 

--- a/cmd/internal/cli/confgen.go
+++ b/cmd/internal/cli/confgen.go
@@ -23,7 +23,7 @@ func init() {
 // ConfGenCmd generates an apptainer.conf file, optionally taking an
 // old singularity.conf or apptainer.conf for initial settings.
 var ConfGenCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		return confgen.Gen(args)
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/config_fakeroot_linux.go
+++ b/cmd/internal/cli/config_fakeroot_linux.go
@@ -72,7 +72,7 @@ var configFakerootCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		username := args[0]
 		var op apptainer.FakerootConfigOp
 

--- a/cmd/internal/cli/config_global_linux.go
+++ b/cmd/internal/cli/config_global_linux.go
@@ -84,7 +84,7 @@ var configGlobalCmd = &cobra.Command{
 	Args:                  cobra.RangeArgs(1, 2),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRootOrUnpriv,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		var op apptainer.GlobalConfigOp
 
 		if globalConfigSet {

--- a/cmd/internal/cli/inspect.go
+++ b/cmd/internal/cli/inspect.go
@@ -640,7 +640,7 @@ var InspectCmd = &cobra.Command{
 	Long:    docs.InspectLong,
 	Example: docs.InspectExample,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		img, err := image.Init(args[0], false)
 		if err != nil {
 			sylog.Fatalf("Failed to open image %s: %s", args[0], err)

--- a/cmd/internal/cli/instance_linux.go
+++ b/cmd/internal/cli/instance_linux.go
@@ -30,7 +30,7 @@ func init() {
 
 // apptainer instance
 var instanceCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/instance_list_linux.go
+++ b/cmd/internal/cli/instance_list_linux.go
@@ -84,7 +84,7 @@ var instanceListAllFlag = cmdline.Flag{
 // apptainer instance list
 var instanceListCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := "*"
 		if len(args) > 0 {
 			name = args[0]

--- a/cmd/internal/cli/instance_stop_linux.go
+++ b/cmd/internal/cli/instance_stop_linux.go
@@ -103,7 +103,7 @@ var instanceStopTimeoutFlag = cmdline.Flag{
 var instanceStopCmd = &cobra.Command{
 	Args:                  cobra.RangeArgs(0, 1),
 	DisableFlagsInUseLine: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		if len(args) == 0 && !instanceStopAll {
 			return errors.New("invalid command")
 		}

--- a/cmd/internal/cli/key.go
+++ b/cmd/internal/cli/key.go
@@ -158,7 +158,7 @@ func init() {
 	})
 }
 
-func checkGlobal(cmd *cobra.Command, args []string) {
+func checkGlobal(cmd *cobra.Command, _ []string) {
 	if !keyGlobalPubKey || os.Geteuid() == 0 || buildcfg.APPTAINER_SUID_INSTALL == 0 {
 		return
 	}
@@ -168,7 +168,7 @@ func checkGlobal(cmd *cobra.Command, args []string) {
 
 // KeyCmd is the 'key' command that allows management of keyrings
 var KeyCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/key_export.go
+++ b/cmd/internal/cli/key_export.go
@@ -66,7 +66,7 @@ var KeyExportCmd = &cobra.Command{
 	Example: docs.KeyExportExample,
 }
 
-func exportRun(cmd *cobra.Command, args []string) {
+func exportRun(_ *cobra.Command, args []string) {
 	var opts []sypgp.HandleOpt
 	path := keyLocalDir
 

--- a/cmd/internal/cli/key_import.go
+++ b/cmd/internal/cli/key_import.go
@@ -45,7 +45,7 @@ var (
 	}
 )
 
-func importRun(cmd *cobra.Command, args []string) {
+func importRun(_ *cobra.Command, args []string) {
 	var opts []sypgp.HandleOpt
 	path := keyLocalDir
 

--- a/cmd/internal/cli/key_list.go
+++ b/cmd/internal/cli/key_list.go
@@ -44,7 +44,7 @@ func init() {
 var KeyListCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(0),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if err := doKeyListCmd(secret); err != nil {
 			sylog.Fatalf("While listing keys: %s", err)
 		}

--- a/cmd/internal/cli/key_newpair.go
+++ b/cmd/internal/cli/key_newpair.go
@@ -92,7 +92,7 @@ type keyNewPairOptions struct {
 	PushToKeyStore bool
 }
 
-func runNewPairCmd(cmd *cobra.Command, args []string) {
+func runNewPairCmd(cmd *cobra.Command, _ []string) {
 	path := keyLocalDir
 	keyring := sypgp.NewHandle(path)
 

--- a/cmd/internal/cli/key_remove.go
+++ b/cmd/internal/cli/key_remove.go
@@ -23,7 +23,7 @@ var KeyRemoveCmd = &cobra.Command{
 	PreRun:                checkGlobal,
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		var opts []sypgp.HandleOpt
 		path := keyLocalDir
 

--- a/cmd/internal/cli/keyserver.go
+++ b/cmd/internal/cli/keyserver.go
@@ -152,7 +152,7 @@ var KeyserverAddCmd = &cobra.Command{
 var KeyserverRemoveCmd = &cobra.Command{
 	Args:   cobra.RangeArgs(1, 2),
 	PreRun: setKeyserver,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		uri := args[0]
 		name := ""
 		if len(args) > 1 {
@@ -182,7 +182,7 @@ func setKeyserver(_ *cobra.Command, _ []string) {
 // KeyserverLoginCmd apptainer keyserver login [option] <registry_url>
 var KeyserverLoginCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.KeyserverLogin(remoteConfig, ObtainLoginArgs(args[0])); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -199,7 +199,7 @@ var KeyserverLoginCmd = &cobra.Command{
 // KeyserverLogoutCmd apptainer keyserver logout [remoteName|serviceURI]
 var KeyserverLogoutCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// default to empty string to signal to KeyserverLogin to use default remote
 		name := ""
 		if len(args) > 0 {
@@ -223,7 +223,7 @@ var KeyserverLogoutCmd = &cobra.Command{
 // KeyserverListCmd apptainer keyserver list
 var KeyserverListCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		remoteName := ""
 		if len(args) > 0 {
 			remoteName = args[0]

--- a/cmd/internal/cli/oci_linux.go
+++ b/cmd/internal/cli/oci_linux.go
@@ -171,7 +171,7 @@ var OciCreateCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.OciCreate(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -203,7 +203,7 @@ var OciStartCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.OciStart(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -235,7 +235,7 @@ var OciKillCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		timeout := int(ociArgs.KillTimeout)
 		killSignal := ""
 		if len(args) > 1 && args[1] != "" {
@@ -261,7 +261,7 @@ var OciStateCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.OciState(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -293,7 +293,7 @@ var OciExecCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.OciExec(args[0], args[1:]); err != nil { //nolint:staticcheck
 			sylog.Fatalf("%s", err)
 		}
@@ -309,7 +309,7 @@ var OciUpdateCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.OciUpdate(args[0], &ociArgs); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -325,7 +325,7 @@ var OciPauseCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.OciPauseResume(args[0], true); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -341,7 +341,7 @@ var OciResumeCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.OciPauseResume(args[0], false); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -357,7 +357,7 @@ var OciMountCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(2),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.OciMount(args[0], args[1]); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -373,7 +373,7 @@ var OciUmountCmd = &cobra.Command{
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	PreRun:                CheckRoot,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.OciUmount(args[0]); err != nil {
 			sylog.Fatalf("%s", err)
 		}

--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -27,7 +27,7 @@ func init() {
 
 // OverlayCmd is the 'overlay' command that allows to manage writable overlay.
 var OverlayCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -64,7 +64,7 @@ var overlayFakerootFlag = cmdline.Flag{
 // OverlayCreateCmd is the 'overlay create' command that allows to create writable overlay.
 var OverlayCreateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		if err := apptainer.OverlayCreate(overlaySize, args[0], overlaySparse, isOverlayFakeroot, overlayDirs...); err != nil {
 			sylog.Fatalf(err.Error())
 		}

--- a/cmd/internal/cli/pgp.go
+++ b/cmd/internal/cli/pgp.go
@@ -149,7 +149,7 @@ func isGlobal(e *openpgp.Entity) bool {
 }
 
 // outputVerify outputs a textual representation of r to stdout.
-func outputVerify(f *sif.FileImage, r integrity.VerifyResult) bool {
+func outputVerify(_ *sif.FileImage, r integrity.VerifyResult) bool {
 	e := r.Entity()
 
 	// Print signing entity info.

--- a/cmd/internal/cli/plugin_compile_linux.go
+++ b/cmd/internal/cli/plugin_compile_linux.go
@@ -43,7 +43,7 @@ func init() {
 //
 // apptainer plugin compile <path> [-o name]
 var PluginCompileCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		sourceDir, err := filepath.Abs(args[0])
 		if err != nil {
 			sylog.Fatalf("While sanitizing input path: %s", err)

--- a/cmd/internal/cli/plugin_create_linux.go
+++ b/cmd/internal/cli/plugin_create_linux.go
@@ -21,7 +21,7 @@ import (
 //
 // apptainer plugin create <directory> <name>
 var PluginCreateCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[1]
 		dir := args[0]
 

--- a/cmd/internal/cli/plugin_disable_linux.go
+++ b/cmd/internal/cli/plugin_disable_linux.go
@@ -24,7 +24,7 @@ import (
 // apptainer plugin disable <name>
 var PluginDisableCmd = &cobra.Command{
 	PreRun: CheckRootOrUnpriv,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		err := apptainer.DisablePlugin(args[0], buildcfg.LIBEXECDIR)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/cmd/internal/cli/plugin_enable_linux.go
+++ b/cmd/internal/cli/plugin_enable_linux.go
@@ -23,7 +23,7 @@ import (
 // apptainer plugin enable <name>
 var PluginEnableCmd = &cobra.Command{
 	PreRun: CheckRootOrUnpriv,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		err := apptainer.EnablePlugin(args[0])
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/cmd/internal/cli/plugin_inspect_linux.go
+++ b/cmd/internal/cli/plugin_inspect_linux.go
@@ -20,7 +20,7 @@ import (
 
 // PluginInspectCmd displays information about a plugin.
 var PluginInspectCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		err := apptainer.InspectPlugin(args[0])
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/cmd/internal/cli/plugin_install_linux.go
+++ b/cmd/internal/cli/plugin_install_linux.go
@@ -22,7 +22,7 @@ import (
 // apptainer plugin install <path>
 var PluginInstallCmd = &cobra.Command{
 	PreRun: CheckRootOrUnpriv,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		err := apptainer.InstallPlugin(args[0])
 		if err != nil {
 			sylog.Fatalf("Failed to install plugin %q: %s.", args[0], err)

--- a/cmd/internal/cli/plugin_linux.go
+++ b/cmd/internal/cli/plugin_linux.go
@@ -36,7 +36,7 @@ func init() {
 //
 // apptainer plugin [...]
 var PluginCmd = &cobra.Command{
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return errors.New("invalid command")
 	},
 	DisableFlagsInUseLine: true,

--- a/cmd/internal/cli/plugin_list_linux.go
+++ b/cmd/internal/cli/plugin_list_linux.go
@@ -18,7 +18,7 @@ import (
 
 // PluginListCmd lists the plugins installed in the system.
 var PluginListCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		err := apptainer.ListPlugins()
 		if err != nil {
 			sylog.Fatalf("Failed to get a list of installed plugins: %s.", err)

--- a/cmd/internal/cli/plugin_uninstall_linux.go
+++ b/cmd/internal/cli/plugin_uninstall_linux.go
@@ -24,7 +24,7 @@ import (
 // apptainer plugin uninstall <name>
 var PluginUninstallCmd = &cobra.Command{
 	PreRun: CheckRootOrUnpriv,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 		err := apptainer.UninstallPlugin(name)
 		if err != nil {

--- a/cmd/internal/cli/registry.go
+++ b/cmd/internal/cli/registry.go
@@ -90,7 +90,7 @@ var RegistryCmd = &cobra.Command{
 // RegistryLoginCmd apptainer registry login [option] <registry_url>
 var RegistryLoginCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		if err := apptainer.RegistryLogin(remoteConfig, ObtainLoginArgs(args[0])); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -107,7 +107,7 @@ var RegistryLoginCmd = &cobra.Command{
 // RegistryLogoutCmd apptainer remote logout [remoteName|serviceURI]
 var RegistryLogoutCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// default to empty string to signal to registryLogin to use default remote
 		name := ""
 		if len(args) > 0 {
@@ -131,7 +131,7 @@ var RegistryLogoutCmd = &cobra.Command{
 // RegistryListCmd apptainer remote list
 var RegistryListCmd = &cobra.Command{
 	Args: cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if err := apptainer.RegistryList(remoteConfig); err != nil {
 			sylog.Fatalf("%s", err)
 		}

--- a/cmd/internal/cli/remote.go
+++ b/cmd/internal/cli/remote.go
@@ -254,7 +254,7 @@ var RemoteGetLoginPasswordCmd = &cobra.Command{
 	Long:    docs.RemoteGetLoginPasswordLong,
 	Example: docs.RemoteGetLoginPasswordExample,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		defaultConfig := ""
 
 		config, err := getLibraryClientConfig(defaultConfig)
@@ -276,7 +276,7 @@ var RemoteGetLoginPasswordCmd = &cobra.Command{
 var RemoteAddCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(2),
 	PreRun: setGlobalRemoteConfig,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 
 		uri := args[1]
@@ -324,7 +324,7 @@ var RemoteAddCmd = &cobra.Command{
 var RemoteRemoveCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 	PreRun: setGlobalRemoteConfig,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 		if err := apptainer.RemoteRemove(remoteConfig, name); err != nil {
 			sylog.Fatalf("%s", err)
@@ -344,7 +344,7 @@ var RemoteRemoveCmd = &cobra.Command{
 var RemoteUseCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 	PreRun: setGlobalRemoteConfig,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		name := args[0]
 		if err := apptainer.RemoteUse(remoteConfig, name, global, remoteUseExclusive); err != nil {
 			sylog.Fatalf("%s", err)
@@ -363,7 +363,7 @@ var RemoteUseCmd = &cobra.Command{
 // RemoteListCmd apptainer remote list
 var RemoteListCmd = &cobra.Command{
 	Args: cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		if err := apptainer.RemoteList(remoteConfig); err != nil {
 			sylog.Fatalf("%s", err)
 		}
@@ -380,7 +380,7 @@ var RemoteListCmd = &cobra.Command{
 // RemoteLoginCmd apptainer remote login [remoteName]
 var RemoteLoginCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		loginArgs := new(apptainer.LoginArgs)
 
 		// default to empty string to signal to RemoteLogin to use default remote
@@ -418,7 +418,7 @@ var RemoteLoginCmd = &cobra.Command{
 // RemoteLogoutCmd apptainer remote logout [remoteName|serviceURI]
 var RemoteLogoutCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// default to empty string to signal to RemoteLogin to use default remote
 		name := ""
 		if len(args) > 0 {
@@ -442,7 +442,7 @@ var RemoteLogoutCmd = &cobra.Command{
 // RemoteStatusCmd apptainer remote status [remoteName]
 var RemoteStatusCmd = &cobra.Command{
 	Args: cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// default to empty string to signal to RemoteStatus to use default remote
 		name := ""
 		if len(args) > 0 {

--- a/cmd/internal/cli/run_help_linux.go
+++ b/cmd/internal/cli/run_help_linux.go
@@ -44,7 +44,7 @@ func init() {
 var RunHelpCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		// Sanity check
 		if _, err := os.Stat(args[0]); err != nil {
 			sylog.Fatalf("container not found: %s", err)

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -64,7 +64,7 @@ Source10: https://github.com/rfjakob/gocryptfs/archive/v%{gocryptfs_version}/goc
 Source11: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squashfuse-%{squashfuse_version}.tar.gz
 %endif
 %if "%{?e2fsprogs_version}" != ""
-# URL: https://github.com/tytso/e2fsprogs/archive/refs/tags/v%{e2fsprogs_version}.tar.gz
+# URL: https://github.com/tytso/e2fsprogs/archive/refs/tags/v%%{e2fsprogs_version}.tar.gz
 Source12: e2fsprogs-%{e2fsprogs_version}.tar.gz
 # URL: https://github.com/tytso/e2fsprogs/commit/5598a96.patch
 Patch121: e2fsprogs-1.patch

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -43,10 +43,10 @@ const (
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote get-login-password
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	RemoteGetLoginPasswordUse     string = `get-login-password`
+	RemoteGetLoginPasswordUse     string = `get-login-password` //nolint:gosec
 	RemoteGetLoginPasswordShort   string = `Retrieves the cli secret for the current logged in user`
 	RemoteGetLoginPasswordLong    string = `The 'remote get-login-password' command allows you to retrieve the cli secret for the current user.`
-	RemoteGetLoginPasswordExample string = `$ apptainer remote get-login-password | docker login -u user --password-stdin`
+	RemoteGetLoginPasswordExample string = `$ apptainer remote get-login-password | docker login -u user --password-stdin` //nolint:gosec
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote add command
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -469,7 +469,7 @@ func (c actionTests) STDPipe(t *testing.T) {
 			e2e.WithCommand(tt.command),
 			e2e.WithArgs(tt.argv...),
 			e2e.WithStdin(&input),
-			e2e.PreRun(func(t *testing.T) {
+			e2e.PreRun(func(_ *testing.T) {
 				input.WriteString(tt.input)
 			}),
 			e2e.ExpectExit(tt.exit),
@@ -2114,7 +2114,7 @@ func (c actionTests) fuseMount(t *testing.T) {
 			e2e.WithStdin(stdinReader),
 			e2e.WithCommand("run"),
 			e2e.WithArgs("--writable", "--no-home", imageDir),
-			e2e.PostRun(func(t *testing.T) {
+			e2e.PostRun(func(_ *testing.T) {
 				stdinReader.Close()
 				stdinWriter.Close()
 			}),

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -303,7 +303,6 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 	files := retrieveFileNames(t, cacheDir)
 	if len(files) != 0 {
 		t.Fatalf("Unexpected cache files: %v", files)
-		t.FailNow()
 	}
 
 	sifname := fmt.Sprintf("%s/build.sif", tempDir)
@@ -370,7 +369,6 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 	files = retrieveFileNames(t, cacheDir)
 	if len(files) != 3 {
 		t.Fatalf("Unexpected cache files: %v", files)
-		t.FailNow()
 	}
 
 	c.env.RunApptainer(
@@ -396,7 +394,6 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 	files = retrieveFileNames(t, cacheDir)
 	if len(files) != 5 {
 		t.Fatalf("Unexpected cache files: %v", files)
-		t.FailNow()
 	}
 
 	// from now on, the cache should be hit when pulling
@@ -457,7 +454,6 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 	files = retrieveFileNames(t, cacheDir)
 	if len(files) != 5 {
 		t.Fatalf("Unexpected cache files: %v", files)
-		t.FailNow()
 	}
 }
 
@@ -497,7 +493,6 @@ func ensureCachedWithSha(t *testing.T, cacheParentDir, shaval string) {
 	cachePath := path.Join(cacheParentDir, "cache", "oci-tmp", shaval)
 	if !e2e.PathExists(t, cachePath) {
 		t.Fatalf("%s cache file does not exit", cachePath)
-		t.FailNow()
 	}
 }
 
@@ -506,7 +501,6 @@ func retrieveFileNames(t *testing.T, cacheParentDir string) []string {
 	infos, err := os.ReadDir(cachePath)
 	if err != nil {
 		t.Fatalf("Failed to read the cache dir: %s", cachePath)
-		t.FailNow()
 	}
 
 	var names []string

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1812,7 +1812,7 @@ func (c imgBuildTests) buildBindMount(t *testing.T) {
 			e2e.WithProfile(e2e.RootProfile),
 			e2e.WithCommand("build"),
 			e2e.WithArgs(args...),
-			e2e.PostRun(func(t *testing.T) {
+			e2e.PostRun(func(_ *testing.T) {
 				os.Remove(defFile)
 			}),
 			e2e.ExpectExit(tt.exit),
@@ -1841,7 +1841,7 @@ func (c imgBuildTests) buildLibraryHost(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("-F", imagePath, defFile),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(defFile)
 		}),
 		e2e.ExpectExit(255,
@@ -1872,7 +1872,7 @@ func (c imgBuildTests) testWritableTmpfs(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("-F", "--writable-tmpfs", imagePath, defFile),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(defFile)
 		}),
 		e2e.ExpectExit(0),
@@ -2105,7 +2105,7 @@ cat /proc/$$/cmdline`
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs("-F", imagePath, defFile),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(defFile)
 		}),
 		e2e.ExpectExit(0,

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -184,7 +184,7 @@ func (c *imgBuildTests) issue4967(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4967.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -204,7 +204,7 @@ func (c *imgBuildTests) issue4969(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4969.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -274,7 +274,7 @@ func (c *imgBuildTests) issue4820(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_4820.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -293,7 +293,7 @@ func (c *imgBuildTests) issue5315(t *testing.T) {
 		e2e.WithProfile(e2e.FakerootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_5315.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -350,7 +350,7 @@ func (c *imgBuildTests) issue5250(t *testing.T) {
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, "testdata/regressions/issue_5250.def"),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(
@@ -472,7 +472,7 @@ From: {{ .From }}
 		e2e.WithProfile(e2e.RootProfile),
 		e2e.WithCommand("build"),
 		e2e.WithArgs(image, f.Name()),
-		e2e.PostRun(func(t *testing.T) {
+		e2e.PostRun(func(_ *testing.T) {
 			os.Remove(image)
 		}),
 		e2e.ExpectExit(0),

--- a/e2e/pull/regressions.go
+++ b/e2e/pull/regressions.go
@@ -89,7 +89,7 @@ func (c ctx) issueSylabs1087(t *testing.T) {
 
 	// Start an http server that serves some output without a content-length
 	data := "DATADATADATADATA"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, data)
 	}))
 	defer srv.Close()

--- a/e2e/security/security.go
+++ b/e2e/security/security.go
@@ -136,7 +136,7 @@ func (c ctx) testSecurityPriv(t *testing.T) {
 	var err error
 	// Get the capability set for root on this system
 	// e.g. "CapEff:	000001ffffffffff"
-	e2e.Privileged(func(t *testing.T) {
+	e2e.Privileged(func(_ *testing.T) {
 		caps, err = capabilities.GetProcessEffective()
 	})(t)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apptainer/apptainer
 
-go 1.20
+go 1.21
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-fuzz-headers v0.0.0-20210312213058-32f4d319f0d2/go.mod h1:VPevheIvXETHZT/ddjwarP3POR5p/cnH9Hy5yoFnQjc=
 github.com/AdamKorcz/go-fuzz-headers v0.0.0-20210319161527-f761c2329661 h1:LxxqfxscKXL1kv7QNh4nggNf4Ais8B0ME8zWMCAsttY=
 github.com/AdamKorcz/go-fuzz-headers v0.0.0-20210319161527-f761c2329661/go.mod h1:VPevheIvXETHZT/ddjwarP3POR5p/cnH9Hy5yoFnQjc=
@@ -12,6 +14,7 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.12.0 h1:rbICA+XZFwrBef2Odk++0LjFvClNCJGRK+fsrP254Ts=
+github.com/Microsoft/hcsshim v0.12.0/go.mod h1:RZV12pcHCXQ42XnlQ3pz6FZfmrC1C+R4gaOHhRNML1g=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
@@ -75,6 +78,7 @@ github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUK
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
+github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/containerd/containerd v1.7.11 h1:lfGKw3eU35sjV0aG2eYZTiwFEY1pCzxdzicHP3SZILw=
 github.com/containerd/containerd v1.7.11/go.mod h1:5UluHxHTX2rdvYuZ5OJTC5m/KJNs0Zs9wVoJm9zf5ZE=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
@@ -116,6 +120,7 @@ github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1S
 github.com/d2g/dhcp4client v1.0.0 h1:suYBsYZIkSlUMEz4TAYCczKf62IA2UWC+O8+KtdOhCo=
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5 h1:+CpLbZIeUn94m02LdEKPcgErLJ347NUwxPKs5u8ieiY=
+github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -149,6 +154,7 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
+github.com/frankban/quicktest v1.14.5/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
@@ -206,7 +212,9 @@ github.com/go-openapi/validate v0.22.1/go.mod h1:rjnrwK57VJ7A8xqfpAOEKRH8yQSGUri
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=
@@ -269,6 +277,7 @@ github.com/google/go-containerregistry v0.19.1/go.mod h1:YCMFNQeeXeLF+dnhhWkqDIt
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20230323073829-e72429f035bd h1:r8yyd+DJDmsUhGrRBxH5Pj7KeFK5l+Y3FsgT8keqKtk=
+github.com/google/pprof v0.0.0-20230323073829-e72429f035bd/go.mod h1:79YE0hCXdHag9sBkw2o+N/YnZtTkXi0UT9Nnixa5eYk=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -283,6 +292,7 @@ github.com/gosimple/slug v1.14.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818J
 github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
 github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 h1:RtRsiaGvWxcwd8y3BiRZxsylPT8hLWZ5SPcfI+3IDNk=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0/go.mod h1:TzP6duP4Py2pHLVPPQp42aoYI92+PCrVotyR5e8Vqlk=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -296,6 +306,7 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmhodges/clock v1.2.0 h1:eq4kys+NI0PLngzaHEe7AmPT90XMGIEySD1JfV1PDIs=
+github.com/jmhodges/clock v1.2.0/go.mod h1:qKjhA7x7u/lQpPB1XAqX1b1lCI/w3/fNuYpI/ZjLynI=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -324,6 +335,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -380,6 +392,7 @@ github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWK
 github.com/moby/sys/user v0.1.0 h1:WmZ93f5Ux6het5iituh9x2zAG7NFY9Aqi49jjE1PaQg=
 github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4T7MmU=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
+github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -391,6 +404,7 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
+github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/networkplumbing/go-nft v0.4.0 h1:kExVMwXW48DOAukkBwyI16h4uhE5lN9iMvQd52lpTyU=
@@ -406,11 +420,13 @@ github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.16.0 h1:7q1w9frJDzninhXxjZd+Y/x54XNjG/UlRLIYPZafsPM=
+github.com/onsi/ginkgo/v2 v2.16.0/go.mod h1:llBI3WDLL9Z6taip6f33H76YcWtJv+7R3HigUjbIBOs=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
+github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
@@ -434,6 +450,7 @@ github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M5
 github.com/opencontainers/umoci v0.4.7 h1:mbIbtMpZ3v9oMpKaLopnWoLykgmnixeLzq51EzAX5nQ=
 github.com/opencontainers/umoci v0.4.7/go.mod h1:lgJ4bnwJezsN1o/5d7t/xdRPvmf8TvBko5kKYJsYvgo=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
+github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
@@ -472,6 +489,7 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.1-0.20230524175051-ec119421bb97 h1:3RPlVWzZ/PDqmVuf/FKHARG5EMid/tl7cv54Sw/QRVY=
+github.com/rogpeppe/go-internal v1.10.1-0.20230524175051-ec119421bb97/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rootless-containers/proto v0.1.0 h1:gS1JOMEtk1YDYHCzBAf/url+olMJbac7MTrgSeP6zh4=
 github.com/rootless-containers/proto v0.1.0/go.mod h1:vgkUFZbQd0gcE/K/ZwtE4MYjZPu0UNHLXIQxhyqAFh8=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -482,6 +500,7 @@ github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6o
 github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
 github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
+github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/seccomp/containers-golang v0.6.0 h1:VWPMMIDr8pAtNjCX0WvLEEK9EQi5lAm4HtJbDtAtFvQ=
 github.com/seccomp/containers-golang v0.6.0/go.mod h1:Dd9mONHvW4YdbSzdm23yf2CFw0iqvqLhO0mEFvPIvm4=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
@@ -491,6 +510,7 @@ github.com/secure-systems-lab/go-securesystemslib v0.8.0 h1:mr5An6X45Kb2nddcFlbm
 github.com/secure-systems-lab/go-securesystemslib v0.8.0/go.mod h1:UH2VZVuJfCYR8WgMlCU1uFsOUU+KeyrTWcSS73NBOzU=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -599,13 +619,17 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0/go.mod h1:
 go.opentelemetry.io/otel v1.19.0 h1:MuS/TNf4/j4IXsZuJegVzI1cwut7Qc00344rgH7p8bs=
 go.opentelemetry.io/otel v1.19.0/go.mod h1:i0QyjOq3UPoTzff0PJB2N66fb4S0+rSbSB15/oyH9fY=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 h1:Mne5On7VWdx7omSrSSZvM4Kw7cS7NQkOOmLcgscI51U=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0/go.mod h1:IPtUMKL4O3tH5y+iXVyAXqpAwMuzC1IrxVS81rummfE=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0 h1:IeMeyr1aBvBiPVYihXIaeIZba6b8E1bYp7lbdxK8CQg=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0/go.mod h1:oVdCUtjq9MK9BlS7TtucsQwUcXcymNiEDjgDD2jMtZU=
 go.opentelemetry.io/otel/metric v1.19.0 h1:aTzpGtV0ar9wlV4Sna9sdJyII5jTVJEvKETPiOKwvpE=
 go.opentelemetry.io/otel/metric v1.19.0/go.mod h1:L5rUsV9kM1IxCj1MmSdS+JQAcVm319EUrDVLrt7jqt8=
 go.opentelemetry.io/otel/sdk v1.19.0 h1:6USY6zH+L8uMH8L3t1enZPR3WFEmSTADlqldyHtJi3o=
+go.opentelemetry.io/otel/sdk v1.19.0/go.mod h1:NedEbbS4w3C6zElbLdPJKOpJQOrGUJ+GfzpjUvI0v1A=
 go.opentelemetry.io/otel/trace v1.19.0 h1:DFVQmlVbfVeOuBRrwdtaehRrWiL1JoVs9CPIQ1Dzxpg=
 go.opentelemetry.io/otel/trace v1.19.0/go.mod h1:mfaSyvGyEJEI0nyV2I4qhNQnbBOUUmYZpYojqMnX2vo=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
+go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
@@ -743,6 +767,7 @@ golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
@@ -772,6 +797,7 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80 h1:KAeGQVN3M9nD0/bQXnr/ClcEMJ968gUXJQ9pwfSynuQ=
 google.golang.org/genproto/googleapis/api v0.0.0-20240123012728-ef4313101c80 h1:Lj5rbfG876hIAYFjqiJnPHfhXbv+nzTWfm04Fg/XSVU=
+google.golang.org/genproto/googleapis/api v0.0.0-20240123012728-ef4313101c80/go.mod h1:4jWUdICTdgc3Ibxmr8nAJiiLHwQBY0UI0XZcEMaFKaA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80 h1:AjyfHzEPEFp/NpvfN5g+KDla3EMojjhRVZc1i7cj+oM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80/go.mod h1:PAREbraiVEVGVdTZsVWjSbbTtSyGbAgIIvni8a8CD5s=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/internal/app/apptainer/oci_delete_linux.go
+++ b/internal/app/apptainer/oci_delete_linux.go
@@ -43,8 +43,7 @@ func OciDelete(ctx context.Context, containerID string) error {
 	hooks := engineConfig.OciConfig.Hooks
 	if hooks != nil {
 		for _, h := range hooks.Poststop {
-			// #nosec G601
-			if err := exec.Hook(ctx, &h, &engineConfig.State.State); err != nil {
+			if err := exec.Hook(ctx, &h, &engineConfig.State.State); err != nil { //nolint:gosec
 				sylog.Warningf("%s", err)
 			}
 		}

--- a/internal/app/apptainer/plugin_compile_linux.go
+++ b/internal/app/apptainer/plugin_compile_linux.go
@@ -217,7 +217,7 @@ func buildPlugin(sourceDir string, bTool buildToolchain) (string, error) {
 // generateManifest takes the path to the plugin source, extracts
 // plugin's manifest by loading it into memory and stores it's json
 // representation in a separate file.
-func generateManifest(sourceDir string, bTool buildToolchain) (string, error) {
+func generateManifest(sourceDir string, _ buildToolchain) (string, error) {
 	in := pluginObjPath(sourceDir)
 	out := pluginManifestPath(sourceDir)
 

--- a/internal/app/apptainer/plugin_disable_linux.go
+++ b/internal/app/apptainer/plugin_disable_linux.go
@@ -12,6 +12,6 @@ package apptainer
 import "github.com/apptainer/apptainer/internal/pkg/plugin"
 
 // DisablePlugin disables the named plugin.
-func DisablePlugin(name, libexecdir string) error {
+func DisablePlugin(name, _ string) error {
 	return plugin.Disable(name)
 }

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -192,8 +192,7 @@ func insertDefinition(b *types.Bundle) error {
 		}
 
 		// name is "Apptainer" concatenated with an index based on number of other files in bootstrap_history
-		len := strconv.Itoa(len(files))
-		histName := "Apptainer" + len
+		histName := "Apptainer" + strconv.Itoa(len(files))
 		// move old definition into bootstrap_history
 		err = os.Rename(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history", histName))
 		if err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -45,7 +45,7 @@ type ArchConveyorPacker struct {
 
 // prepareFakerootEnv prepares a build environment to
 // make fakeroot working with pacstrap.
-func (cp *ArchConveyorPacker) prepareFakerootEnv(ctx context.Context) (func(), error) {
+func (cp *ArchConveyorPacker) prepareFakerootEnv(_ context.Context) (func(), error) {
 	truePath, err := bin.FindBin("true")
 	if err != nil {
 		return nil, fmt.Errorf("while searching true command: %s", err)

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -34,7 +34,7 @@ type BusyBoxConveyorPacker struct {
 }
 
 // Get just stores the source
-func (c *BusyBoxConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
+func (c *BusyBoxConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	// get mirrorURL, OSVerison, and Includes components to definition

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -111,13 +111,13 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 
 	f, err := os.Create(filepath.Join(c.b.RootfsPath, "/bin/busybox"))
 	if err != nil {
-		return
+		return "", err
 	}
 	defer f.Close()
 
 	bytesWritten, err := io.Copy(f, resp.Body)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	// Simple check to make sure file received is the correct size
@@ -127,7 +127,7 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 
 	err = os.Chmod(f.Name(), 0o755)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	return filepath.Join(c.b.RootfsPath, "/bin/busybox"), nil

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -421,17 +421,17 @@ func (cp *OCIConveyorPacker) insertBaseEnv() (err error) {
 	return
 }
 
-func (cp *OCIConveyorPacker) insertRunScript() (err error) {
+func (cp *OCIConveyorPacker) insertRunScript() error {
 	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/runscript")
 	if err != nil {
-		return
+		return err
 	}
 
 	defer f.Close()
 
 	_, err = f.WriteString("#!/bin/sh\n")
 	if err != nil {
-		return
+		return err
 	}
 
 	if len(cp.imgConfig.Entrypoint) > 0 {
@@ -439,12 +439,12 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 			shell.EscapeSingleQuotes(shell.ArgsQuoted(cp.imgConfig.Entrypoint)) +
 			"'\n")
 		if err != nil {
-			return
+			return err
 		}
 	} else {
 		_, err = f.WriteString("OCI_ENTRYPOINT=''\n")
 		if err != nil {
-			return
+			return err
 		}
 	}
 
@@ -453,12 +453,12 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 			shell.EscapeSingleQuotes(shell.ArgsQuoted(cp.imgConfig.Cmd)) +
 			"'\n")
 		if err != nil {
-			return
+			return err
 		}
 	} else {
 		_, err = f.WriteString("OCI_CMD=''\n")
 		if err != nil {
-			return
+			return err
 		}
 	}
 
@@ -491,30 +491,30 @@ func (cp *OCIConveyorPacker) insertRunScript() (err error) {
 
 	_, err = f.WriteString(runscript.String())
 	if err != nil {
-		return
+		return err
 	}
 
 	f.Sync()
 
 	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0o755)
 	if err != nil {
-		return
+		return err
 	}
 
 	return nil
 }
 
-func (cp *OCIConveyorPacker) insertEnv() (err error) {
+func (cp *OCIConveyorPacker) insertEnv() error {
 	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/env/10-docker2singularity.sh")
 	if err != nil {
-		return
+		return err
 	}
 
 	defer f.Close()
 
 	_, err = f.WriteString("#!/bin/sh\n")
 	if err != nil {
-		return
+		return err
 	}
 
 	for _, element := range cp.imgConfig.Env {
@@ -531,7 +531,7 @@ func (cp *OCIConveyorPacker) insertEnv() (err error) {
 		}
 		_, err = f.WriteString(export)
 		if err != nil {
-			return
+			return err
 		}
 	}
 
@@ -539,7 +539,7 @@ func (cp *OCIConveyorPacker) insertEnv() (err error) {
 
 	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/env/10-docker2singularity.sh", 0o755)
 	if err != nil {
-		return
+		return err
 	}
 
 	return nil

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -403,8 +403,7 @@ func (cp *OCIConveyorPacker) extractArchive(src string, dst string) error {
 			defer f.Close()
 
 			// copy over contents
-			// #nosec G110
-			if _, err := io.Copy(f, tr); err != nil {
+			if _, err := io.Copy(f, tr); err != nil { //nolint:gosec
 				return err
 			}
 		}

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -277,7 +277,6 @@ func TestOCIPacker(t *testing.T) {
 	}
 
 	_, err = ocp.Pack(context.Background())
-
 	if err != nil {
 		t.Fatalf("failed to Pack from %s: %v\n", dockerURI, err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_scratch.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch.go
@@ -29,7 +29,7 @@ type ScratchConveyorPacker struct {
 }
 
 // Get just stores the source
-func (c *ScratchConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
+func (c *ScratchConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	return nil

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -48,7 +48,7 @@ type YumConveyorPacker struct {
 }
 
 // Get downloads container information from the specified source
-func (c *YumConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
+func (c *YumConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	// check for dnf or yum on system

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -61,7 +61,7 @@ func machine() (string, error) {
 // Get downloads container information from the specified source
 //
 //nolint:maintidx
-func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) (err error) {
+func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) error {
 	var suseconnectProduct, suseconnectModver string
 	var suseconnectPath string
 	// dependContainer is a container which shares the repos with the host through container-suseconnect
@@ -80,7 +80,7 @@ func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) (err err
 	// check for rpm on system
 	err = rpmPathCheck()
 	if err != nil {
-		return
+		return err
 	}
 
 	include := cp.b.Recipe.Header["include"]

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -61,7 +61,7 @@ func machine() (string, error) {
 // Get downloads container information from the specified source
 //
 //nolint:maintidx
-func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err error) {
+func (cp *ZypperConveyorPacker) Get(_ context.Context, b *types.Bundle) (err error) {
 	var suseconnectProduct, suseconnectModver string
 	var suseconnectPath string
 	// dependContainer is a container which shares the repos with the host through container-suseconnect

--- a/internal/pkg/client/library/pull.go
+++ b/internal/pkg/client/library/pull.go
@@ -123,7 +123,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom *libClient.Ref, 
 }
 
 // PullToFile will pull a library image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo string, pullFrom *libClient.Ref, arch string, tmpDir string, libraryConfig *libClient.Config, co []keyClient.Option) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo string, pullFrom *libClient.Ref, arch string, _ string, libraryConfig *libClient.Config, co []keyClient.Option) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -94,7 +94,6 @@ func DownloadImage(ctx context.Context, filePath string, netURL string) error {
 	pb := client.ProgressBarCallback(ctx)
 
 	err = pb(res.ContentLength, res.Body, out)
-
 	if err != nil {
 		// Delete incomplete image file in the event of failure
 		// we get here e.g. if the context is canceled by Ctrl-C

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -194,7 +194,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom string, tmpDir s
 }
 
 // PullToFile will pull an http(s) image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, _ string) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -114,7 +114,7 @@ func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.Dock
 
 // UploadImage uploads the image specified by path and pushes it to the provided oci reference,
 // it will use credentials if supplied
-func UploadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool) error {
+func UploadImage(_ context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool) error {
 	// ensure that are uploading a SIF
 	if err := ensureSIF(path); err != nil {
 		return err
@@ -186,7 +186,7 @@ func ensureSIF(filepath string) error {
 }
 
 // RefHash returns the digest of the SIF layer of the OCI manifest for supplied ref
-func RefHash(ctx context.Context, ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool) (v1.Hash, error) {
+func RefHash(_ context.Context, ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool) (v1.Hash, error) {
 	im, err := remoteImage(ref, ociAuth, noHTTPS, nil)
 	if err != nil {
 		return v1.Hash{}, err

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -83,7 +83,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 }
 
 // PullToFile will pull an oras image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, _ string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -66,7 +66,7 @@ type ProgressCallback func(int64, io.Reader, io.Writer) error
 func ProgressBarCallback(ctx context.Context) ProgressCallback {
 	if sylog.GetLevel() <= -1 {
 		// If we don't need a bar visible, we just copy data through the callback func
-		return func(totalSize int64, r io.Reader, w io.Writer) error {
+		return func(_ int64, r io.Reader, w io.Writer) error {
 			_, err := CopyWithContext(ctx, w, r)
 			return err
 		}

--- a/internal/pkg/client/shub/pull.go
+++ b/internal/pkg/client/shub/pull.go
@@ -196,7 +196,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 }
 
 // PullToFile will pull a shub image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, tmpDir string, noHTTPS bool) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, _ string, noHTTPS bool) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -190,7 +190,7 @@ func (d *fuseappsDriver) Features() image.DriverFeature {
 }
 
 //nolint:maintidx
-func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc) error {
+func (d *fuseappsDriver) Mount(params *image.MountParams, _ image.MountFunc) error {
 	extraFiles := 0
 	sourceFd := -1
 	if path.Dir(params.Source) == "/proc/self/fd" {
@@ -449,7 +449,7 @@ func (d *fuseappsDriver) Mount(params *image.MountParams, mfunc image.MountFunc)
 	return fmt.Errorf("%v failed to mount %v in %v", f.binName, params.Target, maxTime)
 }
 
-func (d *fuseappsDriver) Start(params *image.DriverParams, containerPid int, hybrid bool) error {
+func (d *fuseappsDriver) Start(_ *image.DriverParams, containerPid int, hybrid bool) error {
 	// start process monitor
 	d.monitor()
 

--- a/internal/pkg/image/packer/gocryptfs.go
+++ b/internal/pkg/image/packer/gocryptfs.go
@@ -69,26 +69,26 @@ func (g *Gocryptfs) init(tmpDir string) (cryptInfo *cryptInfo, err error) {
 	cryptInfo = newCryptInfo()
 	parentDir, err := os.MkdirTemp(tmpDir, "gocryptfs-")
 	if err != nil {
-		return
+		return nil, err
 	}
 	cipherDir := filepath.Join(parentDir, "cipher")
 	plainDir := filepath.Join(parentDir, "plain")
 
 	err = os.Mkdir(cipherDir, 0o700)
 	if err != nil {
-		return
+		return nil, err
 	}
 	cryptInfo.cipherDir = cipherDir
 	err = os.Mkdir(plainDir, 0o700)
 	if err != nil {
-		return
+		return nil, err
 	}
 	cryptInfo.plainDir = plainDir
 
 	buf := make([]byte, 32)
 	_, err = rand.Read(buf)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	switch g.keyInfo.Format {
@@ -100,7 +100,7 @@ func (g *Gocryptfs) init(tmpDir string) (cryptInfo *cryptInfo, err error) {
 		cryptInfo.pass = g.keyInfo.Material
 	default:
 		err = errors.New("cryptkey type is unknown")
-		return
+		return nil, err
 	}
 	cryptInfo.confPath = filepath.Join(cipherDir, "gocryptfs.conf")
 
@@ -112,7 +112,7 @@ func (g *Gocryptfs) init(tmpDir string) (cryptInfo *cryptInfo, err error) {
 	cmd.Stderr = &stderr
 	if err = cmd.Run(); err != nil {
 		err = fmt.Errorf("initialize gocryptfs encounters error, err: %w, stderr: %s", err, &stderr)
-		return
+		return nil, err
 	}
 
 	mountParams := image.MountParams{
@@ -125,11 +125,11 @@ func (g *Gocryptfs) init(tmpDir string) (cryptInfo *cryptInfo, err error) {
 
 	err = g.driver.Start(nil, 0, false)
 	if err != nil {
-		return
+		return nil, err
 	}
 	err = g.driver.Mount(&mountParams, nil)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// Trap SIGINT/SIGTERM signals

--- a/internal/pkg/image/unpacker/squashfs_test.go
+++ b/internal/pkg/image/unpacker/squashfs_test.go
@@ -53,7 +53,7 @@ func TestSquashfs(t *testing.T) {
 	})
 }
 
-func testSquashfs(t *testing.T, tmpParent string) {
+func testSquashfs(t *testing.T, _ string) {
 	s := NewSquashfs()
 
 	if !s.HasUnsquashfs() {

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -202,9 +202,8 @@ func (h *keyserverHandler) login(u *url.URL, username, password string, insecure
 
 	if insecure {
 		client.Transport = &http.Transport{
-			//#nosec G402
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: true, //nolint:gosec
 			},
 		}
 	}

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -189,6 +189,7 @@ func (h *ociHandler) logout(u *url.URL) error {
 // keyserverHandler handle login/logout for keyserver service.
 type keyserverHandler struct{}
 
+//nolint:revive
 func (h *keyserverHandler) login(u *url.URL, username, password string, insecure bool) (*Config, error) {
 	pass, err := ensurePassword(password)
 	if err != nil {
@@ -239,6 +240,7 @@ func (h *keyserverHandler) login(u *url.URL, username, password string, insecure
 	}, nil
 }
 
+//nolint:revive
 func (h *keyserverHandler) logout(u *url.URL) error {
 	return nil
 }

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -338,7 +338,7 @@ func TestSyncFrom(t *testing.T) {
 
 	for _, test := range testsPass {
 		t.Run(test.name, func(t *testing.T) {
-			if err := test.usr.SyncFrom(&test.sys); err != nil {
+			if err := test.usr.SyncFrom(&test.sys); err != nil { //nolint:gosec
 				t.Error("failed to sync from sys")
 			}
 

--- a/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
@@ -43,7 +43,7 @@ import (
 // For better understanding of runtime flow in general refer to
 // https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#lifecycle.
 // CleanupContainer is performing step 8/9 here.
-func (e *EngineOperations) CleanupContainer(ctx context.Context, fatal error, status syscall.WaitStatus) error {
+func (e *EngineOperations) CleanupContainer(ctx context.Context, _ error, _ syscall.WaitStatus) error {
 	sylog.Debugf("Cleanup container")
 	if fd := e.EngineConfig.GetShareNSFd(); fd != -1 && e.EngineConfig.GetShareNSMode() {
 		br := lock.NewByteRange(fd, 0, 0)

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -990,7 +990,6 @@ func (c *container) mountImage(mnt *mount.Point, system *mount.System) error {
 		}
 
 		cryptDev, err = c.rpcOps.Decrypt(offset, path, key, masterPid)
-
 		if err != nil {
 			return fmt.Errorf("unable to decrypt the file system: %s", err)
 		}

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -512,7 +512,7 @@ func (c *container) setupImageDriver(system *mount.System, containerPid int) err
 			return fmt.Errorf("while requesting /dev/fuse file descriptor from RPC: %s", err)
 		}
 		params.FuseFd = fuseFd
-		system.RunAfterTag(mount.SessionTag, func(system *mount.System) error {
+		system.RunAfterTag(mount.SessionTag, func(_ *mount.System) error {
 			defer unix.Close(params.FuseFd)
 
 			uid := os.Getuid()
@@ -573,7 +573,7 @@ func (c *container) setupImageDriver(system *mount.System, containerPid int) err
 		return nil
 	}
 
-	system.RunAfterTag(mount.SessionTag, func(system *mount.System) error {
+	system.RunAfterTag(mount.SessionTag, func(_ *mount.System) error {
 		if params.UsernsFd != -1 {
 			defer unix.Close(params.UsernsFd)
 		}
@@ -591,7 +591,7 @@ func (c *container) setupImageDriver(system *mount.System, containerPid int) err
 // configuration directive, when applied master process
 // won't see mount done by RPC server anymore. Typically
 // called after SharedTag mounts
-func (c *container) setPropagationMount(system *mount.System) error {
+func (c *container) setPropagationMount(_ *mount.System) error {
 	pflags := uintptr(syscall.MS_REC)
 
 	if c.engine.EngineConfig.File.MountSlave {
@@ -609,7 +609,7 @@ func (c *container) setPropagationMount(system *mount.System) error {
 // point preventing this process from accessing /proc/<rpc_pid>/mountinfo
 // without error, so we bind mount /proc/self/mountinfo from RPC process
 // to a session file and read mount information from there.
-func (c *container) addMountInfo(system *mount.System) error {
+func (c *container) addMountInfo(_ *mount.System) error {
 	const (
 		mountinfo = "/mountinfo"
 		self      = "/proc/self/mountinfo"
@@ -627,7 +627,7 @@ func (c *container) addMountInfo(system *mount.System) error {
 	return nil
 }
 
-func (c *container) chdirFinal(system *mount.System) error {
+func (c *container) chdirFinal(_ *mount.System) error {
 	if _, err := c.rpcOps.Chdir(c.session.FinalPath()); err != nil {
 		return err
 	}
@@ -637,7 +637,7 @@ func (c *container) chdirFinal(system *mount.System) error {
 // mount via image driver.  If in privileged mode, mount the target first
 // using a generic fuse mount and pass in the file descriptor instead of
 // making the image driver do the mount.
-func (c *container) mountImageDriver(params *image.MountParams, system *mount.System, mfunc image.MountFunc) error {
+func (c *container) mountImageDriver(params *image.MountParams, _ *mount.System, mfunc image.MountFunc) error {
 	if imageDriver == nil {
 		return fmt.Errorf("no image driver found, programming error")
 	}
@@ -1095,7 +1095,7 @@ func (c *container) addRootfsMount(system *mount.System) error {
 	return nil
 }
 
-func (c *container) overlayUpperWork(system *mount.System) error {
+func (c *container) overlayUpperWork(_ *mount.System) error {
 	ov := c.session.Layer.(*overlay.Overlay)
 
 	createUpperWork := func(path string) error {
@@ -1938,7 +1938,7 @@ func (c *container) addHomeLayer(system *mount.System, source, dest string) erro
 
 // addHomeNoLayer is responsible for staging the home directory and adding the base
 // directory of the staged home into the container when overlay/underlay are unavailable
-func (c *container) addHomeNoLayer(system *mount.System, source, dest string) error {
+func (c *container) addHomeNoLayer(system *mount.System, _, dest string) error {
 	flags := uintptr(syscall.MS_BIND | syscall.MS_REC)
 
 	homeBase := fs.RootDir(dest)

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -340,7 +340,7 @@ func (e *EngineOperations) StartProcess(masterConnFd int) error {
 // and thus no additional privileges can be gained.
 //
 // Here, however, apptainer engine does not escalate privileges.
-func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error {
+func (e *EngineOperations) PostStartProcess(_ context.Context, pid int) error {
 	sylog.Debugf("Post start process")
 
 	callbackType := (apptainercallback.PostStartProcess)(nil)
@@ -717,10 +717,10 @@ func injectEnvHandler(senv map[string]string, noEval bool) interpreter.OpenHandl
 	}
 }
 
-func runtimeVarsHandler(senv map[string]string) interpreter.OpenHandler {
+func runtimeVarsHandler(_ map[string]string) interpreter.OpenHandler {
 	var once sync.Once
 
-	return func(path string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
+	return func(_ string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
 		b := new(bufferCloser)
 
 		once.Do(func() {
@@ -732,7 +732,7 @@ func runtimeVarsHandler(senv map[string]string) interpreter.OpenHandler {
 }
 
 // sylogBuiltin allows to use sylog logger from shell script.
-func sylogBuiltin(ctx context.Context, argv []string) error {
+func sylogBuiltin(_ context.Context, argv []string) error {
 	if len(argv) < 2 {
 		return fmt.Errorf("sylog builtin requires two arguments")
 	}
@@ -752,8 +752,8 @@ func sylogBuiltin(ctx context.Context, argv []string) error {
 }
 
 // getAllEnvBuiltin display all exported variables in the form KEY=VALUE.
-func getAllEnvBuiltin(shell *interpreter.Shell) interpreter.ShellBuiltin {
-	return func(ctx context.Context, argv []string) error {
+func getAllEnvBuiltin(_ *interpreter.Shell) interpreter.ShellBuiltin {
+	return func(ctx context.Context, _ []string) error {
 		hc := interp.HandlerCtx(ctx)
 
 		keyRe := regexp.MustCompile(`^[a-zA-Z_]+[a-zA-Z0-9_]*$`)
@@ -786,7 +786,7 @@ func getAllEnvBuiltin(shell *interpreter.Shell) interpreter.ShellBuiltin {
 
 // fixPathBuiltin takes the current path value to fix it by injecting
 // missing default path and returns value on shell interpreter output.
-func fixPathBuiltin(ctx context.Context, argv []string) error {
+func fixPathBuiltin(ctx context.Context, _ []string) error {
 	hc := interp.HandlerCtx(ctx)
 
 	currentPath := filepath.SplitList(hc.Env.Get("PATH").String())
@@ -812,7 +812,7 @@ func fixPathBuiltin(ctx context.Context, argv []string) error {
 
 // hashBuiltin is a noop function for hash bash builtin, since we don't
 // store resolved path in a hash table, there is nothing to do.
-func hashBuiltin(ctx context.Context, argv []string) error {
+func hashBuiltin(_ context.Context, _ []string) error {
 	return nil
 }
 

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -437,7 +437,6 @@ func (e *EngineOperations) PostStartProcess(_ context.Context, pid int) error {
 		}
 
 		err = file.Update()
-
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
@@ -148,7 +148,7 @@ func (t *Methods) Decrypt(arguments *args.CryptArgs, reply *string) (err error) 
 }
 
 // Mkdir performs a mkdir with the specified arguments.
-func (t *Methods) Mkdir(arguments *args.MkdirArgs, reply *int) (err error) {
+func (t *Methods) Mkdir(arguments *args.MkdirArgs, _ *int) (err error) {
 	mainthread.Execute(func() {
 		oldmask := syscall.Umask(0)
 		err = os.Mkdir(arguments.Path, arguments.Perm)
@@ -158,7 +158,7 @@ func (t *Methods) Mkdir(arguments *args.MkdirArgs, reply *int) (err error) {
 }
 
 // Chroot performs a chroot with the specified arguments.
-func (t *Methods) Chroot(arguments *args.ChrootArgs, reply *int) (err error) {
+func (t *Methods) Chroot(arguments *args.ChrootArgs, _ *int) (err error) {
 	root := arguments.Root
 
 	if root != "." {
@@ -314,12 +314,12 @@ func (t *Methods) LoopDevice(arguments *args.LoopArgs, reply *int) (err error) {
 }
 
 // SetHostname sets hostname with the specified arguments.
-func (t *Methods) SetHostname(arguments *args.HostnameArgs, reply *int) error {
+func (t *Methods) SetHostname(arguments *args.HostnameArgs, _ *int) error {
 	return syscall.Sethostname([]byte(arguments.Hostname))
 }
 
 // Chdir changes current working directory to path.
-func (t *Methods) Chdir(arguments *args.ChdirArgs, reply *int) error {
+func (t *Methods) Chdir(arguments *args.ChdirArgs, _ *int) error {
 	return mainthread.Chdir(arguments.Dir)
 }
 
@@ -348,7 +348,7 @@ func (t *Methods) Access(arguments *args.AccessArgs, reply *args.AccessReply) er
 }
 
 // SendFuseFd send fuse file descriptor over unix socket.
-func (t *Methods) SendFuseFd(arguments *args.SendFuseFdArgs, reply *int) error {
+func (t *Methods) SendFuseFd(arguments *args.SendFuseFdArgs, _ *int) error {
 	usernsFd, err := unix.Open("/proc/self/ns/user", unix.O_RDONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return fmt.Errorf("while opening /proc/self/ns/user: %s", err)
@@ -378,7 +378,7 @@ func (t *Methods) OpenSendFuseFd(arguments *args.OpenSendFuseFdArgs, reply *int)
 }
 
 // Symlink performs a symlink with the specified arguments.
-func (t *Methods) Symlink(arguments *args.SymlinkArgs, reply *int) error {
+func (t *Methods) Symlink(arguments *args.SymlinkArgs, _ *int) error {
 	return os.Symlink(arguments.Old, arguments.New)
 }
 
@@ -401,12 +401,12 @@ func (t *Methods) ReadDir(arguments *args.ReadDirArgs, reply *args.ReadDirReply)
 }
 
 // Chown performs a chown with the specified arguments.
-func (t *Methods) Chown(arguments *args.ChownArgs, reply *int) error {
+func (t *Methods) Chown(arguments *args.ChownArgs, _ *int) error {
 	return os.Chown(arguments.Name, arguments.UID, arguments.GID)
 }
 
 // Lchown performs a lchown with the specified arguments.
-func (t *Methods) Lchown(arguments *args.ChownArgs, reply *int) error {
+func (t *Methods) Lchown(arguments *args.ChownArgs, _ *int) error {
 	return os.Lchown(arguments.Name, arguments.UID, arguments.GID)
 }
 
@@ -429,7 +429,7 @@ func (t *Methods) Umask(arguments *args.UmaskArgs, reply *int) (err error) {
 }
 
 // WriteFile creates an empty file if it doesn't exist or a file with the provided data.
-func (t *Methods) WriteFile(arguments *args.WriteFileArgs, reply *int) error {
+func (t *Methods) WriteFile(arguments *args.WriteFileArgs, _ *int) error {
 	f, err := os.OpenFile(arguments.Filename, os.O_CREATE|os.O_WRONLY|os.O_EXCL, arguments.Perm)
 	if err != nil {
 		if !os.IsExist(err) {
@@ -447,7 +447,7 @@ func (t *Methods) WriteFile(arguments *args.WriteFileArgs, reply *int) error {
 }
 
 // NvCCLI will call nvidia-container-cli to configure GPU(s) for the container.
-func (t *Methods) NvCCLI(arguments *args.NvCCLIArgs, reply *int) (err error) {
+func (t *Methods) NvCCLI(arguments *args.NvCCLIArgs, _ *int) (err error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 

--- a/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/rpc/server/server_linux.go
@@ -184,7 +184,7 @@ func (t *Methods) Chroot(arguments *args.ChrootArgs, _ *int) (err error) {
 
 	oldEffective, err = capabilities.SetProcessEffective(caps)
 	if err != nil {
-		return
+		return err
 	}
 	defer func() {
 		_, e := capabilities.SetProcessEffective(oldEffective)

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -45,7 +45,7 @@ type EngineOperations struct {
 //
 // Since this method simply stores config.Common, it does not matter
 // whether or not there are any elevated privileges during this call.
-func (e *EngineOperations) InitConfig(cfg *config.Common, privStageOne bool) {
+func (e *EngineOperations) InitConfig(cfg *config.Common, _ bool) {
 	e.CommonConfig = cfg
 }
 
@@ -263,7 +263,7 @@ func fakerootSeccompProfile() *specs.LinuxSeccomp {
 //
 // This will be executed as a fake root user in a new user
 // namespace (PrepareConfig will set both).
-func (e *EngineOperations) StartProcess(masterConnFd int) error {
+func (e *EngineOperations) StartProcess(_ int) error {
 	const (
 		mountInfo    = "/proc/self/mountinfo"
 		selinuxMount = "/sys/fs/selinux"
@@ -392,7 +392,7 @@ func (e *EngineOperations) CleanupContainer(context.Context, error, syscall.Wait
 }
 
 // PostStartProcess does nothing for the fakeroot engine.
-func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error {
+func (e *EngineOperations) PostStartProcess(_ context.Context, _ int) error {
 	return nil
 }
 

--- a/internal/pkg/runtime/engine/oci/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/oci/cleanup_linux.go
@@ -31,7 +31,7 @@ import (
 // Specifically in oci engine, no additional privileges are gained here. However,
 // most likely this still will be executed as root since `apptainer oci`
 // command set requires privileged execution.
-func (e *EngineOperations) CleanupContainer(ctx context.Context, fatal error, status syscall.WaitStatus) error {
+func (e *EngineOperations) CleanupContainer(_ context.Context, fatal error, status syscall.WaitStatus) error {
 	// close the connection between apptainer and apptheus
 	if e.CommonConfig.ApptheusSocket != nil {
 		if err := e.CommonConfig.ApptheusSocket.Close(); err != nil {

--- a/internal/pkg/runtime/engine/oci/create_linux.go
+++ b/internal/pkg/runtime/engine/oci/create_linux.go
@@ -162,7 +162,7 @@ var statusChan = make(chan string, 1)
 // command set requires privileged execution.
 //
 //nolint:maintidx
-func (e *EngineOperations) CreateContainer(ctx context.Context, pid int, rpcConn net.Conn) error {
+func (e *EngineOperations) CreateContainer(_ context.Context, pid int, rpcConn net.Conn) error {
 	var err error
 
 	if e.CommonConfig.EngineName != Name {
@@ -881,7 +881,7 @@ func (c *container) addReadonlyPathsMount(system *mount.System) error {
 	return nil
 }
 
-func (c *container) mount(point *mount.Point, system *mount.System) error {
+func (c *container) mount(point *mount.Point, _ *mount.System) error {
 	source := point.Source
 	dest := point.Destination
 	flags, opts := mount.ConvertOptions(point.Options)

--- a/internal/pkg/runtime/engine/oci/engine_linux.go
+++ b/internal/pkg/runtime/engine/oci/engine_linux.go
@@ -27,7 +27,7 @@ type EngineOperations struct {
 //
 // Since this method simply stores config.Common, it does not matter
 // whether or not there are any elevated privileges during this call.
-func (e *EngineOperations) InitConfig(cfg *config.Common, privStageOne bool) {
+func (e *EngineOperations) InitConfig(cfg *config.Common, _ bool) {
 	e.CommonConfig = cfg
 }
 

--- a/internal/pkg/runtime/engine/oci/process_linux.go
+++ b/internal/pkg/runtime/engine/oci/process_linux.go
@@ -263,7 +263,7 @@ func (e *EngineOperations) PreStartProcess(ctx context.Context, pid int, masterC
 //
 // Most likely this still will be executed as root since `apptainer oci`
 // command set requires privileged execution.
-func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error {
+func (e *EngineOperations) PostStartProcess(ctx context.Context, _ int) error {
 	if err := e.updateState(ociruntime.Running); err != nil {
 		return err
 	}

--- a/internal/pkg/runtime/engine/oci/rpc/server/server_linux.go
+++ b/internal/pkg/runtime/engine/oci/rpc/server/server_linux.go
@@ -27,7 +27,7 @@ type Methods struct {
 }
 
 // MkdirAll performs a mkdir with the specified arguments.
-func (t *Methods) MkdirAll(arguments *args.MkdirArgs, reply *int) (err error) {
+func (t *Methods) MkdirAll(arguments *args.MkdirArgs, _ *int) (err error) {
 	mainthread.Execute(func() {
 		oldmask := syscall.Umask(0)
 		err = os.MkdirAll(arguments.Path, arguments.Perm)
@@ -37,6 +37,6 @@ func (t *Methods) MkdirAll(arguments *args.MkdirArgs, reply *int) (err error) {
 }
 
 // Touch performs a touch with the specified arguments.
-func (t *Methods) Touch(arguments *ociargs.TouchArgs, reply *int) (err error) {
+func (t *Methods) Touch(arguments *ociargs.TouchArgs, _ *int) (err error) {
 	return fs.Touch(arguments.Path)
 }

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -1115,7 +1115,7 @@ func (l *Launcher) setCgroups(instanceName string) error {
 // PrepareImage performs any image preparation required before execution.
 // This is currently limited to extraction or FUSE mount when using the user namespace,
 // and activating any image driver plugins that might handle the image mount.
-func (l *Launcher) prepareImage(c context.Context, insideUserNs bool, image string) error {
+func (l *Launcher) prepareImage(_ context.Context, insideUserNs bool, image string) error {
 	// initialize internal image drivers
 	var desiredFeatures imgutil.DriverFeature
 	if fs.IsFile(image) {

--- a/internal/pkg/security/seccomp/seccomp_unsupported.go
+++ b/internal/pkg/security/seccomp/seccomp_unsupported.go
@@ -24,12 +24,12 @@ func Enabled() bool {
 }
 
 // LoadSeccompConfig loads seccomp configuration filter for the current process.
-func LoadSeccompConfig(config *specs.LinuxSeccomp, noNewPrivs bool, errNo int16) error {
+func LoadSeccompConfig(_ *specs.LinuxSeccomp, _ bool, _ int16) error {
 	return fmt.Errorf("can't load seccomp filter: not enabled at compilation time")
 }
 
 // LoadProfileFromFile loads seccomp rules from json file and fill in provided OCI configuration.
-func LoadProfileFromFile(profile string, generator *generate.Generator) error {
+func LoadProfileFromFile(_ string, generator *generate.Generator) error {
 	if generator.Config.Linux == nil {
 		generator.Config.Linux = &specs.Linux{}
 	}

--- a/internal/pkg/security/security_test.go
+++ b/internal/pkg/security/security_test.go
@@ -123,7 +123,7 @@ func TestConfigure(t *testing.T) {
 			var err error
 
 			mainthread.Execute(func() {
-				err = Configure(&s.spec)
+				err = Configure(&s.spec) //nolint:gosec
 			})
 
 			if err != nil && !s.expectFailure {

--- a/internal/pkg/signature/verify_test.go
+++ b/internal/pkg/signature/verify_test.go
@@ -105,7 +105,7 @@ type mockHKP struct {
 	e *openpgp.Entity
 }
 
-func (m mockHKP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (m mockHKP) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/pgp-keys")
 
 	wr, err := armor.Encode(w, openpgp.PublicKeyType, nil)
@@ -552,7 +552,7 @@ func TestVerify(t *testing.T) { //nolint:maintidx
 		t.Run(tt.name, func(t *testing.T) {
 			i := 0
 
-			cb := func(f *sif.FileImage, r integrity.VerifyResult) bool {
+			cb := func(_ *sif.FileImage, r integrity.VerifyResult) bool {
 				defer func() { i++ }()
 
 				if i >= len(tt.wantVerified) {
@@ -752,7 +752,7 @@ func TestVerifyFingerPrint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			i := 0
 
-			cb := func(f *sif.FileImage, r integrity.VerifyResult) bool {
+			cb := func(_ *sif.FileImage, r integrity.VerifyResult) bool {
 				defer func() { i++ }()
 
 				if i >= len(tt.wantVerified) {

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -124,7 +124,7 @@ func checkWhiteList(v *integrity.Verifier, egroup *Execgroup, unvalidatedFingerp
 	// get signing entities fingerprints that have signed all selected objects
 	keyfps, err := v.AllSignedBy()
 	if err != nil {
-		return
+		return false, err
 	}
 
 	// were the selected objects signed by an authorized entity?

--- a/internal/pkg/sypgp/sypgp.go
+++ b/internal/pkg/sypgp/sypgp.go
@@ -902,7 +902,7 @@ func date(s string) string {
 }
 
 // FetchPubkey pulls a public key from the Key Service.
-func FetchPubkey(ctx context.Context, fingerprint string, noPrompt bool, opts ...client.Option) (openpgp.EntityList, error) {
+func FetchPubkey(ctx context.Context, fingerprint string, _ bool, opts ...client.Option) (openpgp.EntityList, error) {
 	// Decode fingerprint and ensure proper length.
 	var fp []byte
 	fp, err := hex.DecodeString(fingerprint)

--- a/internal/pkg/sypgp/sypgp.go
+++ b/internal/pkg/sypgp/sypgp.go
@@ -843,9 +843,9 @@ func SearchPubkey(ctx context.Context, search string, longOutput bool, opts ...c
 			return fmt.Errorf("unauthorized or missing token")
 		} else if ok && httpError.Code() == http.StatusNotFound {
 			return fmt.Errorf("no matching keys found for fingerprint")
-		} else {
-			return fmt.Errorf("failed to get key: %v", err)
 		}
+
+		return fmt.Errorf("failed to get key: %v", err)
 	}
 
 	kcount, keyList, err := formatMROutput(keyText, longOutput)
@@ -931,9 +931,9 @@ func FetchPubkey(ctx context.Context, fingerprint string, noPrompt bool, opts ..
 			return nil, fmt.Errorf("unauthorized or missing token")
 		} else if ok && httpError.Code() == http.StatusNotFound {
 			return nil, fmt.Errorf("no matching keys found for fingerprint")
-		} else {
-			return nil, fmt.Errorf("failed to get key: %v", err)
 		}
+
+		return nil, fmt.Errorf("failed to get key: %v", err)
 	}
 
 	el, err := openpgp.ReadArmoredKeyRing(strings.NewReader(keyText))

--- a/internal/pkg/sypgp/sypgp_test.go
+++ b/internal/pkg/sypgp/sypgp_test.go
@@ -42,7 +42,7 @@ type mockPKSLookup struct {
 	el   openpgp.EntityList
 }
 
-func (ms *mockPKSLookup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (ms *mockPKSLookup) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(ms.code)
 	if ms.code == http.StatusOK {
 		w.Header().Set("Content-Type", "application/pgp-keys")

--- a/internal/pkg/util/auth/auth_test.go
+++ b/internal/pkg/util/auth/auth_test.go
@@ -15,9 +15,8 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/test"
 )
 
-// #nosec G101
 const (
-	testToken     = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"
+	testToken     = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM" // #nosec G101
 	testTokenPath = "test_data/test_token"
 )
 

--- a/internal/pkg/util/env/create_test.go
+++ b/internal/pkg/util/env/create_test.go
@@ -768,7 +768,7 @@ func TestSetContainerEnv(t *testing.T) {
 
 // equal tells whether a and b contain the same elements in the
 // same order. A nil argument is equivalent to an empty slice.
-func equal(t *testing.T, a, b []string) bool {
+func equal(_ *testing.T, a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/internal/pkg/util/fs/helper.go
+++ b/internal/pkg/util/fs/helper.go
@@ -466,7 +466,6 @@ func ForceRemoveAll(path string) error {
 		}
 		return nil
 	})
-
 	// Catastrophic error during the permission walk
 	if err != nil {
 		sylog.Errorf("Unable to set permissions to remove %q: %s", path, err)

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -578,9 +578,8 @@ func (p *Points) Import(points map[AuthorizedTag]PointList) error {
 			if flags&syscall.MS_BIND != 0 {
 				if err = p.AddBind(tag, point.Source, point.Destination, flags); err == nil {
 					continue
-				} else {
-					return err
 				}
+				return err
 			}
 
 			for _, option := range point.InternalOptions {

--- a/internal/pkg/util/fs/mount/system_linux_test.go
+++ b/internal/pkg/util/fs/mount/system_linux_test.go
@@ -33,6 +33,7 @@ func TestSystem(t *testing.T) {
 	after := false
 	mnt := false
 
+	//nolint:unparam,revive
 	mountFn := func(point *Point, system *System) error {
 		mnt = true
 		return nil

--- a/internal/pkg/util/fs/overlay/overlay_linux_test.go
+++ b/internal/pkg/util/fs/overlay/overlay_linux_test.go
@@ -178,7 +178,7 @@ func TestCheckLowerUpper(t *testing.T) {
 
 		// mock statfs
 		if tt.fsType > 0 {
-			statfs = func(path string, st *unix.Statfs_t) error {
+			statfs = func(_ string, st *unix.Statfs_t) error {
 				st.Type = tt.fsType
 				return nil
 			}

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -315,7 +315,7 @@ func EvaluateEnv(ctx context.Context, script []byte, args []string, envs []strin
 		c := strings.Join(args, " ")
 		return fmt.Errorf("could not execute %q: execution is disabled", c)
 	}
-	openHandler := func(ctx context.Context, path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
+	openHandler := func(_ context.Context, path string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
 		return nil, fmt.Errorf("could not open/create/modify %q: file feature is disabled", path)
 	}
 

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -150,7 +150,6 @@ func New(r io.Reader, name string, args []string, envs []string, runnerOptions .
 	}
 	opts = append(opts, runnerOptions...)
 	s.runner, err = interp.New(opts...)
-
 	if err != nil {
 		return nil, fmt.Errorf("while creating shell interpreter: %s", err)
 	}

--- a/internal/pkg/util/shell/interpreter/interpreter_test.go
+++ b/internal/pkg/util/shell/interpreter/interpreter_test.go
@@ -134,7 +134,7 @@ func TestInterpreter(t *testing.T) {
 			expectOut: "argument",
 			shellBuiltin: &testShellBuiltin{
 				builtin: "testing",
-				fn: func(shell *Shell) ShellBuiltin {
+				fn: func(_ *Shell) ShellBuiltin {
 					return func(ctx context.Context, args []string) error {
 						hc := interp.HandlerCtx(ctx)
 						fmt.Fprintf(hc.Stdout, "%s\n", args[0])
@@ -148,8 +148,8 @@ func TestInterpreter(t *testing.T) {
 			script: "export FOO=bar && exec /bin/true",
 			shellBuiltin: &testShellBuiltin{
 				builtin: "exec",
-				fn: func(shell *Shell) ShellBuiltin {
-					return func(ctx context.Context, args []string) error {
+				fn: func(_ *Shell) ShellBuiltin {
+					return func(ctx context.Context, _ []string) error {
 						hc := interp.HandlerCtx(ctx)
 						for _, env := range GetEnv(hc) {
 							if env == "FOO=bar" {
@@ -167,8 +167,8 @@ func TestInterpreter(t *testing.T) {
 			expectOut: "a virtual file",
 			openHandler: &testOpenHandler{
 				path: "/virtual/file",
-				fn: func(shell *Shell) OpenHandler {
-					return func(path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
+				fn: func(_ *Shell) OpenHandler {
+					return func(_ string, _ int, _ os.FileMode) (io.ReadWriteCloser, error) {
 						bc := new(bufferCloser)
 						bc.WriteString("echo 'a virtual file'\n")
 						return bc, nil

--- a/mconfig
+++ b/mconfig
@@ -25,7 +25,7 @@ hstranlib=
 hstobjcopy=
 hstgo=
 hstgo_version="1.21"
-hstgo_preferred_version="1.20.9"
+hstgo_preferred_version="1.21.9"
 
 tgtcc=
 tgtcc_opts=$hstcc_opts

--- a/mconfig
+++ b/mconfig
@@ -24,8 +24,8 @@ hstld=
 hstranlib=
 hstobjcopy=
 hstgo=
-hstgo_version="1.20"
-hstgo_preferred_version="1.20.10"
+hstgo_version="1.21"
+hstgo_preferred_version="1.20.9"
 
 tgtcc=
 tgtcc_opts=$hstcc_opts

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -434,6 +434,7 @@ func ParseDefinitionFile(r io.Reader) (d types.Definition, err error) {
 	s.Split(scanDefinitionFile)
 
 	// advance scanner until it returns a useful token or errors
+	//nolint:revive
 	for s.Scan() && s.Text() == "" && s.Err() == nil {
 	}
 

--- a/pkg/build/types/parser/deffile_test.go
+++ b/pkg/build/types/parser/deffile_test.go
@@ -54,6 +54,7 @@ func TestScanDefinitionFile(t *testing.T) {
 
 			s := bufio.NewScanner(r)
 			s.Split(scanDefinitionFile)
+			//nolint:revive
 			for s.Scan() && s.Text() == "" && s.Err() == nil {
 			}
 
@@ -140,6 +141,7 @@ func TestDoSections(t *testing.T) {
 	s1.Split(scanDefinitionFile)
 
 	// advance scanner until it returns a useful token
+	//nolint:revive
 	for s1.Scan() && s1.Text() == "" {
 		// Nothing to do
 	}
@@ -155,6 +157,7 @@ func TestDoSections(t *testing.T) {
 	s2.Split(scanDefinitionFile)
 
 	// Advance the scanner until it returns a useful token
+	//nolint:revive
 	for s2.Scan() && s2.Text() == "" {
 		// Nothing to do
 	}

--- a/pkg/cmdline/cmd.go
+++ b/pkg/cmdline/cmd.go
@@ -63,7 +63,7 @@ func (c CommandError) Error() string {
 	return string(c)
 }
 
-func onError(cmd *cobra.Command, err error) error {
+func onError(_ *cobra.Command, err error) error {
 	return FlagError(err.Error())
 }
 

--- a/pkg/cmdline/flag.go
+++ b/pkg/cmdline/flag.go
@@ -247,9 +247,8 @@ func (m *flagManager) updateCmdFlagFromEnv(cmd *cobra.Command, precedence int, f
 						sylog.Warningf("%s and %s have different values, using the latter", prefix+key, env.ApptainerPrefixes[0]+key)
 					}
 					continue
-				} else {
-					sylog.Infof("Environment variable %v is set, but %v is preferred", prefix+key, env.ApptainerPrefixes[0]+key)
 				}
+				sylog.Infof("Environment variable %v is set, but %v is preferred", prefix+key, env.ApptainerPrefixes[0]+key)
 			}
 			if !withoutPrefix {
 				foundKeys[key] = val

--- a/pkg/image/sandbox.go
+++ b/pkg/image/sandbox.go
@@ -32,10 +32,10 @@ func (f *sandboxFormat) initializer(img *Image, fi os.FileInfo) error {
 	return nil
 }
 
-func (f *sandboxFormat) openMode(writable bool) int {
+func (f *sandboxFormat) openMode(_ bool) int {
 	return os.O_RDONLY
 }
 
-func (f *sandboxFormat) lock(img *Image) error {
+func (f *sandboxFormat) lock(_ *Image) error {
 	return nil
 }

--- a/pkg/image/squashfs.go
+++ b/pkg/image/squashfs.go
@@ -41,7 +41,7 @@ type squashfsInfo struct {
 	Compression uint16
 	BlockLog    uint16
 	Flags       uint16
-	NoIds       uint16
+	NoIDs       uint16
 	Major       uint16
 	Minor       uint16
 }
@@ -174,10 +174,10 @@ func (f *squashfsFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	return nil
 }
 
-func (f *squashfsFormat) openMode(writable bool) int {
+func (f *squashfsFormat) openMode(_ bool) int {
 	return os.O_RDONLY
 }
 
-func (f *squashfsFormat) lock(img *Image) error {
+func (f *squashfsFormat) lock(_ *Image) error {
 	return nil
 }

--- a/pkg/util/fs/proc/proc_linux_test.go
+++ b/pkg/util/fs/proc/proc_linux_test.go
@@ -437,7 +437,7 @@ func TestSetOOMScoreAdj(t *testing.T) {
 	}
 
 	for _, l := range list {
-		err := SetOOMScoreAdj(l.pid, &l.score)
+		err := SetOOMScoreAdj(l.pid, &l.score) //nolint:gosec
 		if l.fail && err == nil {
 			t.Errorf("writing %d in /proc/%d/oom_score_adj should have failed", l.score, l.pid)
 		} else if !l.fail && err != nil {

--- a/pkg/util/loop/loop.go
+++ b/pkg/util/loop/loop.go
@@ -292,7 +292,7 @@ func getRetryStatusFn(imageFd uintptr, imageInfo *syscall.Stat_t) retryStatusFn 
 	}
 }
 
-func flushCache(imageFd uintptr, imageInfo *syscall.Stat_t) error {
+func flushCache(_ uintptr, imageInfo *syscall.Stat_t) error {
 	devStr := fmt.Sprintf("%d:%d", unix.Major(imageInfo.Dev), unix.Minor(imageInfo.Dev))
 	entries, err := proc.GetMountInfoEntry("/proc/self/mountinfo")
 	if err != nil {

--- a/scripts/download-dependencies
+++ b/scripts/download-dependencies
@@ -25,7 +25,7 @@ SUBS="$(sed -n "s/.*%global //p" $SPEC)"
 # Expected format for sources that have a different base path than the URL
 # is a line beginning "# URL:" followed by the URL, then the source with just
 # the base path.
-sed -n -e 's/^# URL:/URL:/p' -e 's/^Source[1-9][0-9]*: //p' -e 's/^Patch[1-9][0-9]*: //p' $SPEC | while read -r LINE; do
+sed -n -e '/^# URL:/{s/^# //;s/%%/%/g;p}' -e 's/^Source[1-9][0-9]*: //p' -e 's/^Patch[1-9][0-9]*: //p' $SPEC | while read -r LINE; do
     # first apply substitutions
     LINE=$(echo "$SUBS" | (while read -r FROM TO; do
             LINE="${LINE//%\{$FROM\}/$TO}"


### PR DESCRIPTION
This updates the minimum golang to version 1.21.  That version will not be supported on el7 before its end of life the end of next week, so drop el7 support.