### PR TITLE
Release 1.3: Ensure opened/kept file descriptors in stage 1 are not closed by the Go garbage collector (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Updated the minimum golang version to 1.21.
 - Remove support for EL7.
 - Added libcudadebugger.so to nvliblist.conf to support cuda-gdb in CUDA 12+.
+- Ensure opened/kept file descriptors in stage 1 are not closed during the Go
+  garbage collection to avoid "bad file descriptor" errors at startup.
 
 ## v1.3.2 - \[2024-05-28\]
 

--- a/internal/pkg/util/hack/file_finalizer.go
+++ b/internal/pkg/util/hack/file_finalizer.go
@@ -1,0 +1,18 @@
+package hack
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"runtime"
+)
+
+// UnsetFileFinalizer unsets the finalizer for the os.File object
+func UnsetFileFinalizer(obj *os.File) error {
+	v := reflect.ValueOf(obj).Elem().FieldByName("file")
+	if !v.IsValid() {
+		return fmt.Errorf("*os.File file field not found: code update is required")
+	}
+	runtime.SetFinalizer(*(**interface{})(v.Addr().UnsafePointer()), nil)
+	return nil
+}

--- a/internal/pkg/util/hack/file_finalizer_test.go
+++ b/internal/pkg/util/hack/file_finalizer_test.go
@@ -1,0 +1,61 @@
+package hack
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"gotest.tools/v3/assert"
+)
+
+func openThisFile() (*os.File, error) {
+	_, file, _, ok := runtime.Caller(1)
+	if ok {
+		return os.Open(filepath.Base(file))
+	}
+	return nil, fmt.Errorf("unable to determine test filename")
+}
+
+func TestUnsetFileFinalizer(t *testing.T) {
+	// open the file and reset the finalizer
+	f, err := openThisFile()
+	assert.NilError(t, err)
+
+	fd := f.Fd()
+
+	// if something has changed in the os.File struct, this test will fail
+	// and the code in UnsetFileFinalizer will need to be updated
+	err = UnsetFileFinalizer(f)
+	assert.NilError(t, err)
+
+	// force garbage collection to run finalizer
+	runtime.GC()
+
+	time.Sleep(500 * time.Millisecond)
+
+	// check the file descriptor is still open
+	_, err = unix.FcntlInt(fd, unix.F_GETFL, 0)
+	assert.NilError(t, err)
+	assert.NilError(t, f.Close())
+
+	// open the file without resetting the finalizer
+	f, err = openThisFile()
+	assert.NilError(t, err)
+
+	fd = f.Fd()
+	runtime.GC()
+
+	// check the file descriptor is closed
+	for {
+		_, err = unix.FcntlInt(fd, unix.F_GETFL, 0)
+		if err == nil {
+			continue
+		}
+		assert.Error(t, err, "bad file descriptor")
+		break
+	}
+}


### PR DESCRIPTION
This is a cherry-pick of #2284.

### This fixes or addresses the following GitHub issues:

 - Fixes #2166 
