### PR TITLE
Change default distribution for install-unprivileged to el8

### DIFF
--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -78,11 +78,7 @@ if [ -z "$ARCH" ]; then
 fi
 
 if [ -z "$DIST" ]; then
-	if [ "$ARCH" = x86_64 ]; then
-		DIST=el7
-	else
-		DIST=el8
-	fi
+	DIST=el8
 fi
 
 if ! $NOOPENSUSE && [[ "$DIST" != *suse* ]]; then


### PR DESCRIPTION
Now that el7 is End of Life, change the default distribution that install-unprivileged.sh installs from to be el8 for all architectures.