### PR TITLE
fix an issue that apptainer won't default docker credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   garbage collection to avoid "bad file descriptor" errors at startup.
 - Fixed a segmentation violation issue when running Apptainer checkpoint.
 - Add apparmor profiles for ubuntu 24.04 or higher distros.
+- Fixed an issue that Apptainer won't read default docker credentials.
 
 ## v1.3.2 - \[2024-05-28\]
 

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -160,7 +160,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		DockerAuthConfig:         cp.b.Opts.DockerAuthConfig,
 		DockerDaemonHost:         cp.b.Opts.DockerDaemonHost,
 		OSChoice:                 "linux",
-		AuthFilePath:             syfs.DockerConf(),
+		AuthFilePath:             syfs.SearchDockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
 		BigFilesTemporaryDir:     b.TmpDir,
 	}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -47,7 +47,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 	sysCtx := &ocitypes.SystemContext{
 		OCIInsecureSkipTLSVerify: opts.NoHTTPS,
 		DockerAuthConfig:         opts.OciAuth,
-		AuthFilePath:             syfs.DockerConf(),
+		AuthFilePath:             syfs.SearchDockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
 		BigFilesTemporaryDir:     opts.TmpDir,
 	}

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -149,3 +149,12 @@ func DefaultLocalKeyDirPath() string {
 	}
 	return filepath.Join(ConfigDir(), defaultLocalKeyDirName)
 }
+
+func SearchDockerConf() string {
+	apptainerDockerConf := DockerConf()
+	if _, err := os.Stat(apptainerDockerConf); err != nil && os.IsNotExist(err) {
+		return FallbackDockerConf()
+	}
+
+	return apptainerDockerConf
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix an issue that apptainer won't default docker credentials


### This fixes or addresses the following GitHub issues:

 - Fixes #2228


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
