### PR TITLE
fix an issue that apptainer won't default docker credentials (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   garbage collection to avoid "bad file descriptor" errors at startup.
 - Fixed a segmentation violation issue when running Apptainer checkpoint.
 - Add apparmor profiles for ubuntu 24.04 or higher distros.
+- Fixed an issue that Apptainer won't read default docker credentials.
 
 ## v1.3.2 - \[2024-05-28\]
 

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -2264,7 +2264,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 4967":                             c.issue4967,                            // https://github.com/apptainer/singularity/issues/4967
 		"issue 4969":                             c.issue4969,                            // https://github.com/apptainer/singularity/issues/4969
 		"issue 5166":                             c.issue5166,                            // https://github.com/apptainer/singularity/issues/5166
-		"issue 5250":                             c.issue5250,                            // https://github.com/apptainer/singularity/issues/5250
 		"issue 5315":                             c.issue5315,                            // https://github.com/apptainer/singularity/issues/5315
 		"issue 5435":                             c.issue5435,                            // https://github.com/apptainer/singularity/issues/5435
 		"issue 5668":                             c.issue5668,                            // https://github.com/apptainer/singularity/issues/5435

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -338,27 +338,6 @@ func (c *imgBuildTests) issue5435(t *testing.T) {
 	)
 }
 
-// This test will yum reinstall the 'setup' package in a centos 7 container during %post.
-// On a CentOS/RHEL/Fedora host this yum reinstall errors unless the bound in /etc/hosts in the build is modified from
-// the package default, so that yum does not attempt to remove->replace it (which is not possible as it is bound in).
-// See the workaround in build.createStageFile
-func (c *imgBuildTests) issue5250(t *testing.T) {
-	image := filepath.Join(c.env.TestDir, "issue_5250.sif")
-
-	c.env.RunApptainer(
-		t,
-		e2e.WithProfile(e2e.RootProfile),
-		e2e.WithCommand("build"),
-		e2e.WithArgs(image, "testdata/regressions/issue_5250.def"),
-		e2e.PostRun(func(t *testing.T) {
-			os.Remove(image)
-		}),
-		e2e.ExpectExit(
-			0,
-		),
-	)
-}
-
 // Check that unsquashfs (SIF -> sandbox) works on a tmpfs, that will not support
 // user xattrs. Our home dir in the e2e test is a tmpfs bound over our real home dir
 // so we can use that.

--- a/e2e/testdata/regressions/issue_5250.def
+++ b/e2e/testdata/regressions/issue_5250.def
@@ -1,5 +1,0 @@
-BootStrap: oras
-From: ghcr.io/apptainer/centos:7
-
-%post
-    yum -y reinstall setup

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -159,7 +159,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		DockerAuthConfig:         cp.b.Opts.DockerAuthConfig,
 		DockerDaemonHost:         cp.b.Opts.DockerDaemonHost,
 		OSChoice:                 "linux",
-		AuthFilePath:             syfs.DockerConf(),
+		AuthFilePath:             syfs.SearchDockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
 		BigFilesTemporaryDir:     b.TmpDir,
 	}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -47,7 +47,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 	sysCtx := &ocitypes.SystemContext{
 		OCIInsecureSkipTLSVerify: opts.NoHTTPS,
 		DockerAuthConfig:         opts.OciAuth,
-		AuthFilePath:             syfs.DockerConf(),
+		AuthFilePath:             syfs.SearchDockerConf(),
 		DockerRegistryUserAgent:  useragent.Value(),
 		BigFilesTemporaryDir:     opts.TmpDir,
 	}

--- a/pkg/syfs/syfs.go
+++ b/pkg/syfs/syfs.go
@@ -149,3 +149,12 @@ func DefaultLocalKeyDirPath() string {
 	}
 	return filepath.Join(ConfigDir(), defaultLocalKeyDirName)
 }
+
+func SearchDockerConf() string {
+	apptainerDockerConf := DockerConf()
+	if _, err := os.Stat(apptainerDockerConf); err != nil && os.IsNotExist(err) {
+		return FallbackDockerConf()
+	}
+
+	return apptainerDockerConf
+}

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -78,11 +78,7 @@ if [ -z "$ARCH" ]; then
 fi
 
 if [ -z "$DIST" ]; then
-	if [ "$ARCH" = x86_64 ]; then
-		DIST=el7
-	else
-		DIST=el8
-	fi
+	DIST=el8
 fi
 
 if ! $NOOPENSUSE && [[ "$DIST" != *suse* ]]; then


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry pick de680236128184ab754c0c3952bac461bba21ead from PR https://github.com/apptainer/apptainer/pull/2319


### This fixes or addresses the following GitHub issues:

 - Fixes #2228


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
