### PR TITLE
Fix when starting apptainer failed with `instance --fakeroot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   An apparmor profile is applied in all Debian-based apptainer packaging,
   but is only needed to enable user namespaces for apptainer on a
   default-configured Ubuntu 23.10 or newer.
+- Fixed the failure when starting apptainer with `instance --fakeroot`.
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -480,6 +480,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 				{"CheckpointInstance", c.testCheckpointInstance},
 				{"InstanceWithConfigDir", c.testInstanceWithConfigDir},
 				{"ShareNSMode", c.testShareNSMode},
+				{"issue 2189", c.issue2189},
 			}
 
 			profiles := []e2e.Profile{

--- a/e2e/instance/regressions.go
+++ b/e2e/instance/regressions.go
@@ -43,3 +43,20 @@ func (c *ctx) issue5033(t *testing.T) {
 
 	c.stopInstance(t, instanceName)
 }
+
+func (c *ctx) issue2189(t *testing.T) {
+	e2e.EnsureDebianImage(t, c.env)
+
+	c.profile = e2e.FakerootProfile
+
+	instanceName := randomName(t)
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(c.profile),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs("--ignore-subuid", c.env.ImagePath, instanceName),
+		e2e.ExpectExit(0),
+	)
+	c.stopInstance(t, instanceName)
+}

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -103,7 +103,13 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 		if (l.uid == 0) && namespaces.IsUnprivileged() {
 			// Already running root-mapped unprivileged
 			l.cfg.Fakeroot = false
-			l.cfg.Namespaces.User = true
+			// Setting the following line with `false` value
+			// will prevent Apptainer from allocating an additional user namespace.
+			// Here, Apptainer is already running inside a root-mapped namespace,
+			// i.e., similar to running with `unshare -r`, setting the following
+			// line with `true` value will make Apptainer run inside a nested
+			// root-mapped namespace, similar to `unshare -r unshare -r`
+			l.cfg.Namespaces.User = false
 			sylog.Debugf("running root-mapped unprivileged")
 			var err error
 			if l.cfg.IgnoreFakerootCmd {
@@ -314,7 +320,10 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 		l.cfg.Namespaces.User = !l.cfg.IgnoreUserns
 	}
 
-	l.setCgroups(instanceName)
+	err = l.setCgroups(instanceName)
+	if err != nil {
+		sylog.Fatalf("Error while setting cgroups, err: %s", err)
+	}
 
 	// --boot flag requires privilege, so check for this.
 	err = withPrivilege(l.uid, l.cfg.Boot, "--boot", func() error { return nil })
@@ -1073,9 +1082,10 @@ func (l *Launcher) setCgroups(instanceName string) error {
 	hidePid := hidepidProc()
 	// If we are an instance, always use a cgroup if possible, to enable stats.
 	// root can always create a cgroup.
-	useCG := l.uid == 0
+	sylog.Debugf("During setting cgroups configuration, uid: %d, namespace.user: %t, fakeroot: %t, unprivileged: %t", l.uid, l.cfg.Namespaces.User, l.cfg.Fakeroot, namespaces.IsUnprivileged())
+	useCG := l.uid == 0 && !namespaces.IsUnprivileged()
 	// non-root needs cgroups v2 unified mode + systemd as cgroups manager.
-	if !useCG && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups && !l.cfg.Fakeroot && !hidePid {
+	if !useCG && lccgroups.IsCgroup2UnifiedMode() && l.engineConfig.File.SystemdCgroups && !namespaces.IsUnprivileged() && !l.cfg.Fakeroot && !hidePid {
 		if os.Getenv("XDG_RUNTIME_DIR") == "" || os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
 			sylog.Infof("Instance stats will not be available because XDG_RUNTIME_DIR")
 			sylog.Infof("  or DBUS_SESSION_BUS_ADDRESS is not set")
@@ -1085,6 +1095,7 @@ func (l *Launcher) setCgroups(instanceName string) error {
 	}
 
 	if useCG {
+		sylog.Debugf("Using cgroup manager during setting cgroups configuration")
 		cg := cgroups.Config{}
 		cgJSON, err := cg.MarshalJSON()
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

current situation is that we have a trial fix but it is not perfect because of other issues.
1. fakeroot mode is problematic for alpine distros, should work fine for other distros
```
[vagrant@localhost test]$ apptainer instance start --fakeroot --ignore-subuid docker://ubuntu:latest a1
INFO:    Using cached SIF image
INFO:    User not listed in /etc/subuid, trying root-mapped namespace
INFO:    Using cached SIF image
INFO:    Using fakeroot command combined with root-mapped namespace
INFO:    Instance stats will not be available - requires cgroups v2 with systemd as manager.
INFO:    squashfuse not found, will not be able to mount SIF or other squashfs files
INFO:    gocryptfs not found, will not be able to use gocryptfs
INFO:    Converting SIF file to temporary sandbox...
INFO:    instance started successfully
```

2. issue arises in this fix, because the created instance is not managed corrected by the CLI, as inside the newly created namespace, the user becomes root, and all instance info is saved into the root path rather than the normal user path ( ~/.apptainer/instances/app/localhost.localdomain/root rather than  ~/.apptainer/instances/app/localhost.localdomain/$USER). As shown above the instance is started correctly, but can not be listed by `apptainer instance list` command.  
```
[vagrant@localhost test]$ apptainer instance list
INSTANCE NAME    PID    IP    IMAGE
```
3. So I have to disable the root-mapped, which will make the uid to 0 inside container. 


### This fixes or addresses the following GitHub issues:

 - Fixes #2189


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
