### PR TITLE
Support greater than 2Gbyte offset for embedded overlay partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.3.x
 
+- Fix sif-embedded overlay partitions for containers that are larger
+  than 2 gigabytes.
+
 ## v1.3.3 - \[2024-07-03\]
 
 - Updated the minimum golang version to 1.21.

--- a/tools/offsetpreload.c
+++ b/tools/offsetpreload.c
@@ -24,7 +24,7 @@
 #include <dlfcn.h>
 
 static int offsetfd = -3;
-static int offsetval;
+static long offsetval;
 
 ssize_t pread64(int fd, void *buf, size_t count, off_t offset) {
 	static off_t (*original_pread64)(int, void *, size_t, off_t) = NULL;
@@ -59,7 +59,7 @@ static int ___open64(int (*original_open64)(const char *, int, int, int), const 
 		offsetpath = getenv("OFFSETPRELOAD_FILE");
 		char *valenv = getenv("OFFSETPRELOAD_OFFSET");
 		if (valenv != NULL) {
-			offsetval = atoi(valenv);
+			offsetval = atol(valenv);
 		}
 	}
 


### PR DESCRIPTION
Change the offset value in the fuse2fs preloader to be an int instead of a long, to support sizes greater than 2 gigabytes.

- Fixes #2335