### PR TITLE
Make install-unprivileged.sh more robust for failures

### DIFF
--- a/scripts/ci-unpriv-test
+++ b/scripts/ci-unpriv-test
@@ -26,7 +26,7 @@ su testuser -c '
   set -x
   set -e
   rm -rf ins image*.sif overlay.img
-  tools/install-unprivileged.sh -v apptainer-[1-9]*.$(arch).rpm ins
+  tools/install-unprivileged.sh -e -v apptainer-[1-9]*.$(arch).rpm ins
   (
   echo Bootstrap: docker
   echo From: '"$CONTAINER_VERS"'


### PR DESCRIPTION
This is because since we switched to el8 we've been seeing quite a few failures with extracting.  Adds up to 3 retries when downloading each rpm.  Adds connect timeouts and a minimum required download speed of 1 megabit (125 kilobytes) per second each 10 seconds.  Adds a new "-e" option that gets curl to print the error it sees along with a "Retrying" message if it is retrying.

I think downloading from these mirrors has always been unreliable, but previously I had gotten around it by directing el7 downloads to come only from the fnal.gov mirror, which causes its own problems when that mirror is down.