### PR TITLE
Support greater than 2Gbyte offset for embedded overlay partitions (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes for v1.3.x
+
+- Fix sif-embedded overlay partitions for containers that are larger
+  than 2 gigabytes.
+
 ## v1.3.3 - \[2024-07-03\]
 
 - Updated the minimum golang version to 1.21.

--- a/tools/offsetpreload.c
+++ b/tools/offsetpreload.c
@@ -24,7 +24,7 @@
 #include <dlfcn.h>
 
 static int offsetfd = -3;
-static int offsetval;
+static long offsetval;
 
 ssize_t pread64(int fd, void *buf, size_t count, off_t offset) {
 	static off_t (*original_pread64)(int, void *, size_t, off_t) = NULL;
@@ -59,7 +59,7 @@ static int ___open64(int (*original_open64)(const char *, int, int, int), const 
 		offsetpath = getenv("OFFSETPRELOAD_FILE");
 		char *valenv = getenv("OFFSETPRELOAD_OFFSET");
 		if (valenv != NULL) {
-			offsetval = atoi(valenv);
+			offsetval = atol(valenv);
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick #2336 to the release-1.3 branch.