### PR TITLE
Allow bind mount on r/o NFS filesystems to fix #2350

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `--writable-tmpfs`.
 - If an error "no descriptor found for reference" is seen while getting
   an oci container, retry the operation up to five times.
-- Make fakeroot Recommended for suse rpm
+- Make fakeroot Recommended for SUSE rpms.
+- Allow bind mounts onto existing files on r/o NFS filesystems.
 
 ## v1.3.3 - \[2024-07-03\]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

When opening a file on a r/o NFS filesystem with `O_WRONLY|O_CREAT|O_EXCL` flags, and the flag is not in the kernel's cache, it will fail with `EROFS (Read-only file system)` instead of `EEXIST (File exists)`, even when the file exists. When apptainer encounters any error except for `EEXIST`, it will fail bind mount on that file. 

This fix introduces a new check for the file's existence, if opening it failed with any error except for `EEXIST`.


### This fixes or addresses the following GitHub issues:

 - Fixes #2350

