### PR TITLE
fix broken apparmor profile and add ci tests (release-1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,24 @@ jobs:
           GO_ARCH: linux-amd64
         run: ./scripts/ci-docker-run
 
+  ubuntu-2310:
+    name: debbuild-ubuntu23
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      # fetch tags as checkout@v2 doesn't do that by default
+      - run: git fetch --prune --unshallow --tags --force
+
+      - name: Build and test deb under docker
+        env:
+          OS_TYPE: ubuntu
+          OS_VERSION: '23.10'
+          GO_ARCH: linux-amd64
+        run: ./scripts/ci-docker-run
+  
   ubuntu-2404:
     name: debbuild-ubuntu24
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       # fetch tags as checkout@v2 doesn't do that by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## Changes for v1.3.x
 
-- Fix sif-embedded overlay partitions for containers that are larger
+- Fixed sif-embedded overlay partitions for containers that are larger
   than 2 gigabytes.
+- Fixed the apparmor profile that was added in v1.3.3 but didn't work.
+  An apparmor profile is applied in all Debian-based apptainer packaging,
+  but is only needed to enable user namespaces for apptainer on a
+  default-configured Ubuntu 23.10 or newer.
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -199,10 +199,11 @@ Then to compile and install do this:
 sudo ./scripts/install-dependencies
 ```
 
-## Apparmor Profile (Ubuntu 24.04+)
+## Apparmor Profile (Ubuntu 23.10+)
 
-Beginning with the 24.04 LTS release, Ubuntu does not permit applications to
-create unprivileged user namespaces by default.
+Beginning with the 23.10 release and including the 24.04 LTS release,
+Ubuntu does not permit applications to create unprivileged user
+namespaces by default.
 
 If you install Apptainer from a GitHub release `.deb` package then an
 apparmor profile will be installed that permits Apptainer to create
@@ -218,7 +219,7 @@ sudo tee /etc/apparmor.d/apptainer << 'EOF'
 abi <abi/4.0>,
 include <tunables/global>
 profile apptainer /usr/local/libexec/apptainer/bin/starter{,-suid} 
-flags=(unconfined) {
+    flags=(unconfined) {
   userns,
   # Site-specific additions and overrides. See local/README for details.
   include if exists <local/apptainer>

--- a/dist/debian/apparmor-placeholder
+++ b/dist/debian/apparmor-placeholder
@@ -1,8 +1,8 @@
 # Permit unprivileged user namespace creation for apptainer starter, placeholder
-abi <abi/4.0>,
+abi <abi/3.0>,
 include <tunables/global>
  
-profile apptainer /usr/lib/@{multiarch}/apptainer/bin/starter{,-suid} flags=(unconfined) {
+profile apptainer /usr/libexec/apptainer/bin/starter{,-suid} flags=(unconfined) {
   # Site-specific additions and overrides. See local/README for details.
   include if exists <local/apptainer>
 }

--- a/dist/debian/apparmor-userns
+++ b/dist/debian/apparmor-userns
@@ -2,7 +2,7 @@
 abi <abi/4.0>,
 include <tunables/global>
 
-profile apptainer /usr/lib/@{multiarch}/apptainer/bin/starter{,-suid} flags=(unconfined) {
+profile apptainer /usr/libexec/apptainer/bin/starter{,-suid} flags=(unconfined) {
   userns,
 
   # Site-specific additions and overrides. See local/README for details.

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -5,6 +5,7 @@ pkgver = $(shell LC_ALL=C dpkg-parsechangelog --show-field Version )
 
 OS_MAJOR := $(shell grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI' | cut -d'.' -f1)
 OS_NAME := $(shell grep ^NAME /etc/os-release | cut -d '=' -f2 | sed 's/\"//gI')
+OS_VERSION := $(shell grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI')
 
 # Needed by debchange to set Name and EMAIL in changelog
 # DEBFULLNAME is filtered out by debuild
@@ -97,8 +98,8 @@ override_dh_auto_install:
 	@dh_auto_install -Smakefile -D$(DEB_SC_BUILDDIR)
 	@./scripts/install-dependencies $(pkgdir)/usr/libexec
 # Apparmor userns profile needed on Ubuntu 24.04, or unconfined placeholder for older versions.	
-	if [ $(OS_MAJOR) -gt 23 ] && [[ $(OS_NAME) = "Ubuntu" ]]; then \
-		echo "Ubuntu 24.04 or newer - installing apparmor userns profile"; \
+	if ([ $(OS_MAJOR) -gt 23 ] || [ "$(OS_VERSION)" = "23.10" ]) && [ "$(OS_NAME)" = "Ubuntu" ]; then \
+		echo "Ubuntu 23.10 or newer - installing apparmor userns profile"; \
 		install -D -m 644 dist/debian/apparmor-userns $(pkgdir)/etc/apparmor.d/apptainer; \
 	else \
 		echo "other debian/ubuntu distros - installing apparmor placeholder profile"; \

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -8,6 +8,7 @@
 
 OS_MAJOR=$(grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI' | cut -d'.' -f1)
 OS_NAME=$(grep ^NAME /etc/os-release | cut -d '=' -f2 | sed 's/\"//gI')
+OS_VERSION=$(grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI')
 
 # install dependencies
 apt-get update
@@ -45,7 +46,7 @@ mv .??* !(src) src
 # switch to an unprivileged user with sudo privileges
 apt-get install -y sudo
 
-if [[ $OS_NAME = "Ubuntu" ]] && [ $OS_MAJOR -gt 23 ]; then
+if [[ $OS_NAME = "Ubuntu" ]] && { [ $OS_MAJOR -gt 23 ] || [[ $OS_VERSION = "23.10" ]]; }; then
 # uid 1000 is occupied by user 'ubuntu' in ubuntu 24.04, here using a different uid = 1001
     useradd -u 1001 --create-home -s /bin/bash testuser
 else
@@ -82,5 +83,8 @@ su testuser -c '
   debuild --prepend-path $PATH --build=binary --no-sign --lintian-opts --display-info --show-overrides
   sudo dpkg -i ../apptainer*.deb
 
+  cat /etc/apparmor.d/apptainer
   apptainer exec oras://ghcr.io/apptainer/alpine:3.15.0 /bin/true
+  apptainer exec --userns oras://ghcr.io/apptainer/alpine:3.15.0 /bin/true
+  apptainer exec --fakeroot oras://ghcr.io/apptainer/alpine:3.15.0 /bin/true
 '


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry picking commit d6c192b3bfd7b45e2328b74c8144f489b4d3b687 from PR https://github.com/apptainer/apptainer/pull/2364


### This fixes or addresses the following GitHub issues:

 - Fixes #2360


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
