### PR TITLE
fix the failure when starting instance with --fakeroot flag (release-1.3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   An apparmor profile is applied in all Debian-based apptainer packaging,
   but is only needed to enable user namespaces for apptainer on a
   default-configured Ubuntu 23.10 or newer.
+- Fixed the failure when starting apptainer with `instance --fakeroot`.
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -480,6 +480,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 				{"CheckpointInstance", c.testCheckpointInstance},
 				{"InstanceWithConfigDir", c.testInstanceWithConfigDir},
 				{"ShareNSMode", c.testShareNSMode},
+				{"issue 2189", c.issue2189},
 			}
 
 			profiles := []e2e.Profile{

--- a/e2e/instance/regressions.go
+++ b/e2e/instance/regressions.go
@@ -43,3 +43,20 @@ func (c *ctx) issue5033(t *testing.T) {
 
 	c.stopInstance(t, instanceName)
 }
+
+func (c *ctx) issue2189(t *testing.T) {
+	e2e.EnsureDebianImage(t, c.env)
+
+	c.profile = e2e.FakerootProfile
+
+	instanceName := randomName(t)
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(c.profile),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs("--ignore-subuid", c.env.ImagePath, instanceName),
+		e2e.ExpectExit(0),
+	)
+	c.stopInstance(t, instanceName)
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry picking the commit 181b0ae56bc6828c1f9e9e8f3a7adde6d673a327 from PR: https://github.com/apptainer/apptainer/pull/2329


### This fixes or addresses the following GitHub issues:

 - Fixes #2189 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
