### PR TITLE
build: Skip staging /etc/resolv.conf if there is an explicit bind option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   but is only needed to enable user namespaces for apptainer on a
   default-configured Ubuntu 23.10 or newer.
 - Fixed the failure when starting apptainer with `instance --fakeroot`.
+- `apptainer build -B ...` can now be used to mount custom resolv.conf
+  and hosts files from non-standard outside locations. This can be
+  used to run `apptainer build` in a nix-build sandbox that has no
+  /etc/resolv.conf.
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -360,6 +360,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 				EncryptionKeyInfo: keyInfo,
 				FixPerms:          buildArgs.fixPerms,
 				SandboxTarget:     sandboxTarget,
+				Binds:             buildArgs.bindPaths,
 				Unprivilege:       unprivilege,
 			},
 		})


### PR DESCRIPTION

By default, "apptainer build" mounts the host's /etc/resolv.conf. To mount a different resolv.conf file, you can now use:

  apptainer build -B /some/other/resolv.conf:/etc/resolv.conf ...

One use case is when apptainer is used to build containers in a sandbox that has no /etc/resolv.conf (e.g. nix-build).

## Description of the Pull Request (PR):

This is a follow-up to https://github.com/apptainer/apptainer/pull/1284 which was not merged. @DrDaveD suggested to implement this using --bind or --no-mount.

It's also a follow-up to https://github.com/apptainer/apptainer/pull/1312 that wasn't merged either. @DrDaveD suggested to try an implementation based on --no-mount.

This implementation uses the existing --bind option as suggested in PR1284. --no-mount is not a build argument, but only implemented for exec/run/etc. Also, --bind seems to be the more general approach.

The goal is to run "apptainer build" in a sandbox that does not have an /etc/resolv.conf file. This currently fails with:

```
FATAL   [U=0,P=28]         runBuildLocal()               While performing build: failed to read /etc/resolv.conf: open /etc/resolv.conf: no such file or directory
```

With this change, one can create a custom resolv.conf somewhere inside the nix sandbox and pass it to apptainer build using -B. The build then skips normal staging of /etc/resolv.conf and succeeds.


### This fixes or addresses the following GitHub issues:

 - Fixes "build" in nix sandbox.

