### PR TITLE
fix the unfunctional issue when using --nvccli along with --overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   the `--underlay` flag when overlay is implied for bind mounts but the
   kernel is too old to support fuse mounts in user namespaces and so
   tries to use fusermount.
+- Allow a writable `--overlay` to be used with `--nvccli` instead of `--writable-tmpfs`
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -866,7 +866,16 @@ func (l *Launcher) setNvCCLIConfig() (err error) {
 	}
 	l.engineConfig.SetNvCCLIEnv(nvCCLIEnv)
 
-	if !l.cfg.Writable && !l.cfg.WritableTmpfs {
+	overlayExist := false
+	for _, path := range l.cfg.OverlayPaths {
+		if !strings.HasSuffix(path, ":ro") {
+			overlayExist = true
+			sylog.Verbosef("Detected writable overlay images, skipping setting --writable-tmpfs (otherwise required by --nvccli)")
+			break
+		}
+	}
+
+	if !l.cfg.Writable && !l.cfg.WritableTmpfs && !overlayExist {
 		sylog.Infof("Setting --writable-tmpfs (required by nvidia-container-cli)")
 		l.cfg.WritableTmpfs = true
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix the unfunctional issue when using --nvccli along with --overlay


### This fixes or addresses the following GitHub issues:

 - Fixes #2398


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
