### PR TITLE
Suggest using underlay when kernel doesn't support fuse in user namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   /etc/resolv.conf.
 - Fix failing builds from local images that have symbolic links for paths that
   are part of the base container environment (e.g. /var/tmp -> /tmp).
+- Show info messages suggesting to use `enable underlay = preferred` or
+  the `--underlay` flag when overlay is implied for bind mounts but the
+  kernel is too old to support fuse mounts in user namespaces and so
+  tries to use fusermount.
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -305,6 +305,14 @@ func create(ctx context.Context, engine *EngineOperations, rpcOps *client.RPC, p
 		select {
 		case err := <-driverMountErr:
 			if err != nil {
+				if strings.Contains(err.Error(), "overlayfs") &&
+					strings.Contains(err.Error(), "fusermount") &&
+					c.engine.EngineConfig.GetOverlayImplied() {
+					// This can happen when a kernel is too old to
+					// support fuse mounts in user namespaces
+					sylog.Infof("You may have better success with the `--underlay` option or with")
+					sylog.Infof(" the equivalent configuration `enable underlay = preferred`")
+				}
 				return errors.Wrap(err, "image driver mount failure")
 			}
 		case err := <-mountAllErr:

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1098,6 +1098,7 @@ func (e *EngineOperations) setSessionLayer(img *image.Image) error {
 	if e.EngineConfig.File.EnableOverlay != "no" {
 		sylog.Debugf("Using overlay because it is not disabled")
 		e.EngineConfig.SetSessionLayer(apptainerConfig.OverlayLayer)
+		e.EngineConfig.SetOverlayImplied(true)
 		return nil
 	}
 	if e.EngineConfig.File.EnableUnderlay != "no" {

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -153,6 +153,7 @@ type JSONConfig struct {
 	Underlay              bool              `json:"underlay,omitempty"`
 	UserInfo              UserInfo          `json:"userInfo,omitempty"`
 	WritableOverlay       bool              `json:"writableOverlay,omitempty"`
+	OverlayImplied        bool              `json:"overlayImplied,omitempty"`
 	ShareNSMode           bool              `json:"sharensMode,omitempty"`
 	ShareNSFd             int               `json:"sharensFd,omitempty"`
 	RunscriptTimeout      string            `json:"runscriptTimeout,omitempty"`
@@ -944,6 +945,17 @@ func (e *EngineConfig) SetWritableOverlay(writableOverlay bool) {
 // GetWritableOverlay gets the value of whether the overlay is writable or not
 func (e *EngineConfig) GetWritableOverlay() bool {
 	return e.JSON.WritableOverlay
+}
+
+// SetOverlayImplied sets whether the overlay was implied
+// as opposed to explicitly requested
+func (e *EngineConfig) SetOverlayImplied(overlayImplied bool) {
+	e.JSON.OverlayImplied = overlayImplied
+}
+
+// GetOverlayImplied gets the value of whether the overlay was implied
+func (e *EngineConfig) GetOverlayImplied() bool {
+	return e.JSON.OverlayImplied
 }
 
 // SetShareNSMode sets whether container should run in shared namespace mode


### PR DESCRIPTION
When overlay is implied but fuse-overlayfs fails with a fusermount error because the kernel is too old for fuse in user namespaces, suggest using underlay.

- Fixes #2324