### PR TITLE
Add libsubid support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   (`$HOME/.apptainer/docker-config.json`). The commands `pull`, `push`, `run`,
   `exec`, `shell` and `instance start` can now also be passed a `--authfile
   <path>` option, to read OCI registry credentials from this custom file.
+- Add support for libsubid
 
 ## Changes for v1.3.x
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@
 - Alexander Grund <alexander.grund@tu-dresden.de>
 - Amanda Duffy <aduffy@lenovo.com>
 - Ana Guerrero Lopez <aguerrero@suse.com>
+- Andrew Bruno <aebruno2@buffalo.edu>
 - Ángel Bejarano <abejarano@ontropos.com>
 - Apuã Paquola <apuapaquola@gmail.com>
 - Aron Öfjörð Jóhannesson <aron1991@gmail.com>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,6 +30,12 @@ sudo apt-get install -y \
     curl wget git
 ```
 
+Including for libsubid support (requires at least Ubuntu Noble or Debian Bookworm):
+
+```sh
+sudo apt-get install -y libsubid-dev
+```
+
 On RHEL or its derivatives:
 
 ```sh
@@ -46,6 +52,13 @@ sudo dnf install -y \
     wget git
 ```
 
+Including for libsubid support, use --enablerepo=devel for el8 and el9 but not
+for fedora:
+
+```sh
+sudo dnf --enablerepo=devel install shadow-utils-subid-devel
+```
+
 On SLE/openSUSE
 
 ```sh
@@ -56,6 +69,12 @@ sudo zypper install -y \
   openssl-devel \
   cryptsetup sysuser-tools \
   gcc go
+```
+
+For libsubid support (requires openSUSE Tumbleweed):
+
+```sh
+sudo zypper -y install libsubid5  libsubid-devel
 ```
 
 ## Install Go

--- a/dist/debian/DEBIAN_PACKAGE.md
+++ b/dist/debian/DEBIAN_PACKAGE.md
@@ -15,6 +15,15 @@ cp -r dist/debian .
 Next, make sure all the dependencies are met. See
 [INSTALL.md](../../INSTALL.md#install-system-dependencies)
 for the basic apt-get install list.
+
+To build with libsubid support add the following to the control file (requires
+at least Ubuntu Noble or Debian Bookworm):
+
+```dsc
+Build-Depends:
+ libsubid-dev
+```
+
 Also install the extra required packages needed for
 [dependent FUSE-based packages](../../INSTALL.md#compiling-dependent-fuse-based-packages),
 and these additional dependencies for the packaging:
@@ -56,6 +65,8 @@ See `mconfig --help` for details about the configuration options.
 `export DEB_NONETWORK=1` adds --without-network
 
 `export DEB_NOSECCOMP=1` adds --without-seccomp
+
+`export DEB_NOLIBSUBID=1` adds --without-libsubid
 
 `export DEB_NOALL=1`     adds all of the above
 

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -45,16 +45,19 @@ DEB_SC_BUILDDIR ?= builddir
 
 # see mconfig for options
 # set environment variables to disable options
-# NOALL, NONETWORK, NOSECCOMP
+# NOALL, NONETWORK, NOSECCOMP, NOLIBSUBID
 SC_OPTIONS =
 ifdef DEB_NOALL
-SC_OPTIONS = --without-network --without-seccomp
+SC_OPTIONS = --without-network --without-seccomp --without-libsubid
 else
 ifdef DEB_NONETWORK
 SC_OPTIONS += --without-network
 endif
 ifdef DEB_NOSECCOMP
 SC_OPTIONS += --without-seccomp
+endif
+ifdef DEB_NOLIBSUBID
+SC_OPTIONS += --without-libsubid
 endif
 endif
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -106,7 +106,11 @@ Provides: bundled(fuse-overlayfs) = %{fuse_overlayfs_version}
 %if "%{_target_vendor}" == "suse"
 BuildRequires: binutils-gold
 BuildRequires: go
+%if 0%{?suse_version} > 1600
+BuildRequires: libsubid-devel
+%endif
 %else
+BuildRequires: shadow-utils-subid-devel
 BuildRequires: golang
 %endif
 BuildRequires: git

--- a/internal/pkg/fakeroot/idtools_supported.go
+++ b/internal/pkg/fakeroot/idtools_supported.go
@@ -1,0 +1,125 @@
+//go:build linux && cgo && libsubid
+// +build linux,cgo,libsubid
+
+// Portions of this code was adopted from github.com/containers/storage
+// Copyright (C) The Linux Foundation and its contributors.
+// Original source released under: Apache 2.0 license
+// See: https://github.com/containers/storage/blob/main/pkg/idtools/idtools_supported.go
+//
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package fakeroot
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/apptainer/apptainer/internal/pkg/util/user"
+)
+
+/*
+#cgo LDFLAGS: -l subid
+
+#include <shadow/subid.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+struct subid_range apptainer_get_range(struct subid_range *ranges, int i)
+{
+	return ranges[i];
+}
+
+#if !defined(SUBID_ABI_MAJOR) || (SUBID_ABI_MAJOR < 4)
+# define subid_get_uid_ranges get_subuid_ranges
+# define subid_get_gid_ranges get_subgid_ranges
+#endif
+*/
+import "C"
+
+func readSubid(user *user.User, isUser bool) ([]*Entry, error) {
+	ret := make([]*Entry, 0)
+	uidstr := fmt.Sprintf("%d", user.UID)
+
+	if user.Name == "ALL" {
+		return nil, errors.New("username ALL not supported")
+	}
+
+	cUsername := C.CString(user.Name)
+	defer C.free(unsafe.Pointer(cUsername))
+
+	cuidstr := C.CString(uidstr)
+	defer C.free(unsafe.Pointer(cuidstr))
+
+	var nRanges C.int
+	var cRanges *C.struct_subid_range
+	if isUser {
+		nRanges = C.subid_get_uid_ranges(cUsername, &cRanges)
+		if nRanges <= 0 {
+			nRanges = C.subid_get_uid_ranges(cuidstr, &cRanges)
+		}
+	} else {
+		nRanges = C.subid_get_gid_ranges(cUsername, &cRanges)
+		if nRanges <= 0 {
+			nRanges = C.subid_get_gid_ranges(cuidstr, &cRanges)
+		}
+	}
+	if nRanges < 0 {
+		return nil, errors.New("cannot read subids")
+	}
+	defer C.free(unsafe.Pointer(cRanges))
+
+	for i := 0; i < int(nRanges); i++ {
+		r := C.apptainer_get_range(cRanges, C.int(i))
+		line := fmt.Sprintf("%d:%d:%d", user.UID, r.start, r.count)
+		ret = append(
+			ret,
+			&Entry{
+				UID:      user.UID,
+				Start:    uint32(r.start),
+				Count:    uint32(r.count),
+				disabled: false,
+				line:     line,
+			})
+	}
+	return ret, nil
+}
+
+func readSubuid(user *user.User) ([]*Entry, error) {
+	return readSubid(user, true)
+}
+
+func readSubgid(user *user.User) ([]*Entry, error) {
+	return readSubid(user, false)
+}
+
+func (c *Config) getMappingEntries(user *user.User) ([]*Entry, error) {
+	entries := make([]*Entry, 0)
+	for _, entry := range c.entries {
+		if entry.UID == user.UID {
+			entries = append(entries, entry)
+		}
+	}
+
+	var subidEntries []*Entry
+	var err error
+	if strings.Contains(c.file.Name(), "gid") {
+		subidEntries, err = readSubgid(user)
+	} else {
+		subidEntries, err = readSubuid(user)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return append(entries, subidEntries...), nil
+}

--- a/internal/pkg/fakeroot/idtools_unsupported.go
+++ b/internal/pkg/fakeroot/idtools_unsupported.go
@@ -1,0 +1,27 @@
+//go:build !linux || !libsubid || !cgo
+// +build !linux !libsubid !cgo
+
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package fakeroot
+
+import (
+	"github.com/apptainer/apptainer/internal/pkg/util/user"
+)
+
+func (c *Config) getMappingEntries(user *user.User) ([]*Entry, error) {
+	entries := make([]*Entry, 0)
+	for _, entry := range c.entries {
+		if entry.UID == user.UID {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries, nil
+}

--- a/mconfig
+++ b/mconfig
@@ -62,6 +62,7 @@ fi
 with_network=1
 with_suid=-1
 with_seccomp_check=1
+with_libsubid=1
 do_go_version_check=1
 
 builddir=
@@ -117,11 +118,12 @@ usage_args () {
 	echo "     -h   this help"
 	echo
 	echo "  Apptainer options:"
-	echo "     --without-suid    do not install SUID binary (default, linux only)"
-	echo "     --with-suid       do install SUID binary (linux only)"
-	echo "     --without-network do not compile/install network plugins (linux only)"
-	echo "     --without-seccomp do not compile/install seccomp support even if available"
-	echo "     --only-rpm        only configure for rpm (lower host go version check)"
+	echo "     --without-suid     do not install SUID binary (default, linux only)"
+	echo "     --with-suid        do install SUID binary (linux only)"
+	echo "     --without-libsubid do not compile libsubid support even if available (linux only)"
+	echo "     --without-network  do not compile/install network plugins (linux only)"
+	echo "     --without-seccomp  do not compile/install seccomp support even if available"
+	echo "     --only-rpm         only configure for rpm (lower host go version check)"
 	echo
 	echo "  Path modification options:"
 	echo "     --prefix         install project in \`prefix'"
@@ -377,6 +379,8 @@ while [ $# -ne 0 ]; do
    with_suid=0; shift;;
   --with-suid)
    with_suid=1; shift;;
+  --without-libsubid)
+   with_libsubid=0; shift;;
   --without-network)
    with_network=0; shift;;
   --without-seccomp)
@@ -791,6 +795,11 @@ fi
 if [ "$appsec" = "1" ]; then
 	drawline $makeit_fragsdir/go_appsec_opts.mk
 	cat $makeit_fragsdir/go_appsec_opts.mk >> $makeit_makefile
+fi
+
+if [ "$libsubid" = "1" ]; then
+	drawline $makeit_fragsdir/go_libsubid_opts.mk
+	cat $makeit_fragsdir/go_libsubid_opts.mk >> $makeit_makefile
 fi
 
 if [ "$build_runtime" = "1" ]; then

--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -326,3 +326,40 @@ if [ "$with_seccomp_check" = "1" ];then
 fi
 
 config_add_footer
+
+########################
+# libsubid
+########################
+if [ "$with_libsubid" = "1" ];then
+    printf " checking: libsubid support... "
+    testprog=$makeit_testprogdir/test_libsubid
+    cat > ${testprog}.c << "EOF"
+    #include <shadow/subid.h>
+    #include <stdio.h>
+    #include <stdlib.h>
+
+    const char *Prog = "test";
+    FILE *shadow_logfd = NULL;
+
+    int main() {
+        struct subid_range *ranges = NULL;
+    #if SUBID_ABI_MAJOR >= 4
+        subid_get_uid_ranges("root", &ranges);
+    #else
+        get_subuid_ranges("root", &ranges);
+    #endif
+        free(ranges);
+        return 0;
+    }
+EOF
+    if ! $tgtcc -x c -o $testprog ${testprog}.c -l subid >/dev/null 2>&1; then
+        echo "no"
+    else
+        if ! $testprog; then
+            echo "no"
+        else
+            echo "yes"
+            libsubid=1
+        fi
+    fi
+fi

--- a/mlocal/frags/go_libsubid_opts.mk
+++ b/mlocal/frags/go_libsubid_opts.mk
@@ -1,0 +1,2 @@
+GO_TAGS += libsubid
+GO_TAGS_SUID += libsubid

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -38,6 +38,11 @@ apt-get install -y \
 # for squashfuse_ll build
 apt-get install -y autoconf automake libtool pkg-config libfuse3-dev zlib1g-dev
 
+# for libsubid support in Ubuntu 24.04
+if [[ $OS_NAME = "Ubuntu" ]] && [ $OS_MAJOR -gt 23 ]; then
+    apt-get install -y libsubid4 libsubid-dev
+fi
+
 # move source code down a level because debuild writes into parent dir
 shopt -s extglob
 mkdir src

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -9,6 +9,7 @@
 # install dependencies
 dnf install -y rpm-build make yum-utils gcc binutils util-linux-ng which git
 dnf install -y libseccomp-devel cryptsetup
+dnf --enablerepo=devel install -y shadow-utils-subid-devel
 if [ $OS_TYPE != fedora ]; then
   dnf install -y epel-release
 fi

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -330,7 +330,7 @@ if [ "$DIST" = el7 ]; then
 		EPELUTILS="$EPELUTILS fuse2fs"
 	fi
 elif [ "$DIST" = el8 ]; then
-	OSUTILS="$OSUTILS lzo squashfs-tools libzstd fuse3-libs"
+	OSUTILS="$OSUTILS lzo squashfs-tools libzstd fuse3-libs libsepol bzip2-libs audit-libs libcap-ng libattr libacl pcre2 libxcrypt libselinux libsemanage shadow-utils-subid"
 	if $NEEDSFUSE2FS; then
 		OSUTILS="$OSUTILS fuse-libs e2fsprogs-libs e2fsprogs"
 	fi
@@ -349,7 +349,7 @@ elif [ "$DIST" = "suse15" ]; then
 	EPELUTILS=""
 else
 	# el9 & fc*
-	OSUTILS="$OSUTILS lzo squashfs-tools libzstd"
+	OSUTILS="$OSUTILS lzo squashfs-tools libzstd libsepol bzip2-libs audit-libs libcap-ng libattr libacl pcre2 libxcrypt libselinux libsemanage shadow-utils-subid"
 	if $NEEDSFUSE2FS; then
 		OSUTILS="$OSUTILS fuse-libs e2fsprogs-libs e2fsprogs"
 	fi
@@ -421,6 +421,7 @@ rmdir lib 2>/dev/null || true
 # move everything needed out of tmp to utils
 mkdir -p utils/bin utils/lib utils/libexec
 mv tmp/usr/lib*/* utils/lib
+mv tmp/lib*/* utils/lib 2>/dev/null || true # optional
 mv tmp/usr/*bin/*squashfs utils/libexec
 mv tmp/usr/*bin/fuse* utils/libexec 2>/dev/null || true # optional
 mv tmp/usr/bin/fake*sysv utils/bin


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds support for reading subuid/subgid mappings using libsubid. Tried to make this as minimally invasive as possible. Static id mappings in `/etc/subuid` files take precedent and the code added to fakeroot in this PR will only run if no mappings are found. I'm guessing  the fakeroot pkg could be re-factored to only use libsubid, instead of the current code that parses `/etc/subuid` manually, but that felt like a much larger change.

Added `--with-libsubid` option to `mconfig` to enable compiling libsubid support which defaults to off for now. The rationale is that libsubid support is completely off by default and only enabled if the switch is set explicitly. In the future, this can be changed to enabled by default once the code has been deemed stable.

We're mostly interested in the debian packages, so this PR also adds a DEB env variable to turn this on libsubid compiling.  

The libsubid code was adopted directly from podman and modified to fit the apptainer API. Original podman [source file here](https://github.com/containers/storage/blob/main/pkg/idtools/idtools_supported.go). 

### This fixes or addresses the following GitHub issues:

 - Fixes #2422