### PR TITLE
Fix mconfig -s to build static binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   subuid-based fakeroot or root, warn that it is unlikely to work.
 - Allow a writable `--overlay` to be used with `--nvccli` instead of
   `--writable-tmpfs`.
+- Fix the `mconfig -s` option to build the apptainer and starter
+  binaries statically as documented.
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/mconfig
+++ b/mconfig
@@ -562,6 +562,12 @@ if [ $lang_go -eq 1 ]; then
 fi
 echo
 
+if [ "$hststatic" = "1" ]; then
+	export CGO_ENABLED=0
+	export CGO_LDFLAGS="-static"
+	with_seccomp_check=0 
+fi
+
 #######################################################################
 # mlocal/checks/project-pre.chk -- executes before standard base checks
 #######################################################################
@@ -724,8 +730,8 @@ if [ "$found_modules" != "" ]; then
 	echo >> $makeit_makefile_base
 fi
 
-# init LDFLAGS if static builds are supported
-if [ "$hststatic" = "1" -a "$tgtstatic" = "1" ]; then
+# init LDFLAGS with or without static
+if [ "$tgtstatic" = "1" ]; then
 	echo "LDFLAGS := -static $ldflags" >> $makeit_makefile_base
 else
 	echo "LDFLAGS := $ldflags" >> $makeit_makefile_base
@@ -771,6 +777,11 @@ cat $makeit_fragsdir/common_opts.mk >> $makeit_makefile
 
 drawline $makeit_fragsdir/go_common_opts.mk
 cat $makeit_fragsdir/go_common_opts.mk >> $makeit_makefile
+
+if [ "$hststatic" = "1" ]; then
+	drawline $makeit_fragsdir/go_static_opts.mk
+	cat $makeit_fragsdir/go_static_opts.mk >> $makeit_makefile
+fi
 
 if [ -f "$makeit_fragsdir/go_${host}_opts.mk" ]; then
 	drawline $makeit_fragsdir/go_${host}_opts.mk

--- a/mlocal/frags/go_static_opts.mk
+++ b/mlocal/frags/go_static_opts.mk
@@ -1,0 +1,2 @@
+GO_TAGS += no_openssl
+GO_TAGS_SUID += no_openssl


### PR DESCRIPTION
- Fixes #2395

However, it does result in a bunch of build-time warnings that some library call `requires at runtime the shared libraries from the glibc version used for linking`, and also I often see segmentation violation crashes in the garbage collector.   Here's a sample [build output](https://github.com/user-attachments/files/16682758/buildoutput.txt) and a sample [crash output](https://github.com/user-attachments/files/16682766/apptainercrash.txt).

