### PR TITLE
Add a warning when yum bootstrap is used with "fake" fakeroot (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
   the `--underlay` flag when overlay is implied for bind mounts but the
   kernel is too old to support fuse mounts in user namespaces and so
   tries to use fusermount.
-- Allow a writable `--overlay` to be used with `--nvccli` instead of `--writable-tmpfs`
+- When someone uses a `yum` bootstrap to build a container without using
+  subuid-based fakeroot or root, warn that it is unlikely to work.
+- Allow a writable `--overlay` to be used with `--nvccli` instead of
+  `--writable-tmpfs`.
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -36,6 +36,7 @@ var buildArgs struct {
 	webURL              string
 	encrypt             bool
 	fakeroot            bool
+	fakefakeroot        bool
 	fixPerms            bool
 	isJSON              bool
 	noCleanUp           bool

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -165,6 +165,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		}
 		// Try fakeroot command
 		os.Unsetenv("_APPTAINER_FAKEFAKEROOT")
+		buildArgs.fakefakeroot = true
 		buildArgs.fakeroot = false
 		if buildArgs.ignoreFakerootCmd {
 			err = errors.New("fakeroot command is ignored because of --ignore-fakeroot-command")
@@ -182,7 +183,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 			}
 			sylog.Infof("Installing some packages may fail")
 		} else {
-			sylog.Infof("The %%post section will be run under fakeroot")
+			sylog.Infof("The %%post section will be run under the fakeroot command")
 			if !buildArgs.fixPerms && uid != 0 {
 				sylog.Infof("Using --fix-perms because building from a definition file")
 				sylog.Infof(" without either root user or unprivileged user namespaces")
@@ -288,6 +289,10 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 	hasSIF := false
 
 	for _, d := range defs {
+		if d.Header["bootstrap"] == "yum" && buildArgs.fakefakeroot {
+			sylog.Warningf("yum bootstrap is unlikely to work without root or subuid-based fakeroot")
+		}
+
 		// If there's a library source we need the library client, and it'll be a SIF
 		if d.Header["bootstrap"] == "library" {
 			hasLibrary = true


### PR DESCRIPTION
Cherry-pick #2444 to the release-1.3 branch.