### PR TITLE
Retry when conveyor fails to get descriptor for reference (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   subuid-based fakeroot or root, warn that it is unlikely to work.
 - Allow a writable `--overlay` to be used with `--nvccli` instead of
   `--writable-tmpfs`.
+- If an error "no descriptor found for reference" is seen while getting
+  an oci container, retry the operation up to five times.
 
 ## v1.3.3 - \[2024-07-03\]
 


### PR DESCRIPTION
Cherry-pick #2451 to the release-1.3 branch.