### PR TITLE
Add message suggesting workarounds for fakeroot mode 3 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   an oci container, retry the operation up to five times.
 - Make fakeroot Recommended for SUSE rpms.
 - Allow bind mounts onto existing files on r/o NFS filesystems.
+- If an error is seen in the %post section when building a container
+  using fakeroot mode 3 (with the fakeroot command) then show a message
+  suggesting using `--ignore-fakeroot-command` and referring to the
+  documentation about how to install and use it inside the container
+  definition file.
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -374,6 +374,11 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 	}
 
 	if err = b.Full(ctx); err != nil {
+		if fakerootPath != "" && strings.Contains(err.Error(), " %post section") && os.Getuid() == 0 {
+			sylog.Infof("If error was from fakeroot, try --ignore-fakeroot-command and")
+			sylog.Infof("  maybe use fakeroot inside the %%post section as described at")
+			sylog.Infof("  https://apptainer.org/docs/user/latest/fakeroot.html#fakeroot-inside-def")
+		}
 		sylog.Fatalf("While performing build: %v", err)
 	}
 }

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -142,6 +142,9 @@ func (s *stage) runPostScript(sessionResolv, sessionHosts string) error {
 		if len(fakerootBinds) > 0 {
 			s.cleanFakerootBindpoints(fakerootBinds)
 		}
+		if err != nil {
+			return fmt.Errorf("while running %%post section: %s", err)
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
This adds a message suggesting how to work around fakeroot command errors when using fakeroot mode 3 (root mapped user namespace with fakeroot command bound in from host) if there's an error from the %post script.  Ideally it would parse for error messages including `fakeroot:` but that error output is sent straight to stderr and I don't think it's worth the complication and disruption to capture that and pass it up to the caller.

- Fixes #783