### PR TITLE
Make fakeroot Recommended for suse in the rpm spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   `--writable-tmpfs`.
 - If an error "no descriptor found for reference" is seen while getting
   an oci container, retry the operation up to five times.
+- Make fakeroot Recommended for suse rpm
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 - Ángel Bejarano <abejarano@ontropos.com>
 - Apuã Paquola <apuapaquola@gmail.com>
 - Aron Öfjörð Jóhannesson <aron1991@gmail.com>
+- Avikam Rozenfeld (avikam.roze@gmail.com)
 - Bart Oldeman <bart.oldeman@calculquebec.ca>
 - Bernard Li <bernardli@lbl.gov>
 - Brian Bockelman <bbockelm@cse.unl.edu>

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -124,10 +124,11 @@ BuildRequires: zlib-devel
 %endif
 %if "%{_target_vendor}" == "suse"
 Requires: squashfs
+Recommends: fakeroot
 %else
 Requires: squashfs-tools
-%endif
 Requires: fakeroot
+%endif
 
 %description
 Apptainer provides functionality to make portable


### PR DESCRIPTION
## Description of the Pull Request (PR):

apptainer doesn't actually need the `fakeroot` command to work; if it can't find the command, it will just use root-mapped namespace. suse dists don't even provide this tool. Thus changing the `fakeroot` in the rpm spec file from `Required` to `Recommended`. If `fakeroot` exists in the hosts repository it will be installed, and if it doesn't, apptainer will still get installed successfully. 


### This fixes or addresses the following GitHub issues:

 - Fixes #2348 


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
