### PR TITLE
Show a better error message when attempting to use fakeroot subuid without user namespaces (release-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   suggesting using `--ignore-fakeroot-command` and referring to the
   documentation about how to install and use it inside the container
   definition file.
+- Show a more helpful error message when using fakeroot in suid mode
+  and there's an /etc/subuid mapping even though user namespaces are
+  not available (user namespaces are required for /etc/subuid mapping).
 
 ## v1.3.3 - \[2024-07-03\]
 

--- a/internal/app/apptainer/overlay_create.go
+++ b/internal/app/apptainer/overlay_create.go
@@ -232,9 +232,7 @@ func OverlayCreate(size int, imgPath string, overlaySparse bool, isFakeroot bool
 			//  the fakeroot command (in suid flow with no user
 			//  namespaces), using the --fakeroot option here
 			//  prevents overlay from working, most unfortunately.
-			err = fakeroot.UnshareRootMapped([]string{"/bin/true"}, false)
-			if err != nil {
-				sylog.Debugf("UnshareRootMapped failed: %v", err)
+			if !fakeroot.UserNamespaceAvailable() {
 				if isFakeroot {
 					sylog.Infof("User namespaces are not available, so using --fakeroot here would")
 					sylog.Infof("  actually interfere with fakeroot command overlay operation")


### PR DESCRIPTION
Cherry-pick #2478 to the release-1.3 branch