### PR TITLE
lint: enable prealloc + corresponding fixes, from sylabs 2068

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - maintidx
     - misspell
     - nakedret
+    - prealloc
     - reassign
     - revive
     - staticcheck

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -503,7 +503,7 @@ func retrieveFileNames(t *testing.T, cacheParentDir string) []string {
 		t.Fatalf("Failed to read the cache dir: %s", cachePath)
 	}
 
-	var names []string
+	names := make([]string, 0, len(infos))
 	for _, info := range infos {
 		names = append(names, info.Name())
 	}

--- a/internal/pkg/build/files/files.go
+++ b/internal/pkg/build/files/files.go
@@ -50,7 +50,8 @@ func expandPath(path string) ([]string, error) {
 	}
 
 	// parse expanded output and ignore empty strings from consecutive null bytes
-	var paths []string
+	paths := make([]string, 0, len(strings.Split(output.String(), "\\0")))
+
 	for _, s := range strings.Split(output.String(), "\\0") {
 		if s == "" {
 			continue

--- a/internal/pkg/checkpoint/dmtcp/checkpoint.go
+++ b/internal/pkg/checkpoint/dmtcp/checkpoint.go
@@ -97,7 +97,7 @@ func (checkpointManager) List() ([]*Entry, error) {
 		return nil, err
 	}
 
-	var entries []*Entry
+	entries := make([]*Entry, 0, len(fis))
 	for _, fi := range fis {
 		if !fi.IsDir() {
 			continue

--- a/internal/pkg/checkpoint/dmtcp/dmtcp.go
+++ b/internal/pkg/checkpoint/dmtcp/dmtcp.go
@@ -67,7 +67,7 @@ func GetPaths() ([]string, []string, error) {
 		return nil, nil, err
 	}
 
-	var usrBins []string
+	usrBins := make([]string, 0, len(bins))
 	for _, bin := range bins {
 		usrBin := filepath.Join("/usr/bin", filepath.Base(bin))
 		usrBins = append(usrBins, strings.Join([]string{bin, usrBin}, ":"))

--- a/internal/pkg/plugin/binary.go
+++ b/internal/pkg/plugin/binary.go
@@ -92,7 +92,7 @@ func List() ([]*Meta, error) {
 		return nil, fmt.Errorf("cannot list plugins in directory %q", rootDir)
 	}
 
-	var metas []*Meta
+	metas := make([]*Meta, 0, len(entries))
 	for _, entry := range entries {
 		fi, err := os.Stat(entry)
 		if err != nil {

--- a/internal/pkg/runtime/engine/config/oci/generate/generate.go
+++ b/internal/pkg/runtime/engine/config/oci/generate/generate.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/apptainer/apptainer/pkg/util/capabilities"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/samber/lo"
 	"golang.org/x/sys/unix"
 )
 
@@ -251,10 +252,7 @@ func (g *Generator) SetupPrivileged(privileged bool) {
 	// Add all capabilities, we don't need to check for the
 	// latest capability available as it's handled automatically
 	// by the starter
-	var allCapability []string
-	for capStr := range capabilities.Map {
-		allCapability = append(allCapability, capStr)
-	}
+	allCapability := lo.Keys(capabilities.Map)
 
 	g.initLinux()
 	g.initProcessCapabilities()

--- a/pkg/build/types/parser/deffile.go
+++ b/pkg/build/types/parser/deffile.go
@@ -456,8 +456,6 @@ func ParseDefinitionFile(r io.Reader) (d types.Definition, err error) {
 // and parses it into a slice of Definition structs or returns error if
 // an error is encounter while parsing
 func All(r io.Reader) ([]types.Definition, error) {
-	var stages []types.Definition
-
 	raw, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("while attempting to read definition file: %v", err)
@@ -485,6 +483,7 @@ func All(r io.Reader) ([]types.Definition, error) {
 		return nil, errEmptyDefinition
 	}
 
+	stages := make([]types.Definition, 0, len(splitBuf))
 	for _, stage := range splitBuf {
 		if len(stage) == 0 {
 			continue

--- a/pkg/image/sif_test.go
+++ b/pkg/image/sif_test.go
@@ -28,8 +28,7 @@ func createSIF(t *testing.T, corrupted bool, fns ...func() (sif.DescriptorInput,
 	}
 	sifFile.Close()
 
-	var opts []sif.CreateOpt
-
+	opts := make([]sif.CreateOpt, 0, len(fns))
 	for _, fn := range fns {
 		di, err := fn()
 		if err != nil {

--- a/pkg/runtime/engine/apptainer/config/bind.go
+++ b/pkg/runtime/engine/apptainer/config/bind.go
@@ -203,12 +203,13 @@ func ParseBindPath(paths []string) ([]BindPath, error) {
 }
 
 func splitBy(str string, sep byte) []string {
-	var list []string
-
 	re := regexp.MustCompile(fmt.Sprintf(`(?m)([^\\]%c)`, sep))
+	indexes := re.FindAllStringIndex(str, -1)
+
+	list := make([]string, 0, len(indexes)+1)
+
 	cursor := 0
 
-	indexes := re.FindAllStringIndex(str, -1)
 	for i, index := range indexes {
 		list = append(list, str[cursor:index[1]-1])
 		cursor = index[1]


### PR DESCRIPTION
This pulls in sylabs PR
  * sylabs/singularity#2068

 
Original PR description:
> Enable the `prealloc` linter in golangci-lint, and perform fixes, as appropriate, in code.

