### PR TITLE
refactor: minimise containers/image imports

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/internal/pkg/client/shub"
 	"github.com/apptainer/apptainer/internal/pkg/instance"
+	"github.com/apptainer/apptainer/internal/pkg/ocitransport"
 	"github.com/apptainer/apptainer/internal/pkg/runtime/launch"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
@@ -79,7 +80,7 @@ func actionPreRun(cmd *cobra.Command, args []string) {
 }
 
 func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, pullFrom string) (string, error) {
-	ociAuth, err := makeDockerCredentials(cmd)
+	ociAuth, err := makeOCICredentials(cmd)
 	if err != nil {
 		sylog.Fatalf("While creating Docker credentials: %v", err)
 	}
@@ -96,7 +97,7 @@ func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, 
 }
 
 func handleOras(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, pullFrom string) (string, error) {
-	ociAuth, err := makeDockerCredentials(cmd)
+	ociAuth, err := makeOCICredentials(cmd)
 	if err != nil {
 		return "", fmt.Errorf("while creating docker credentials: %v", err)
 	}
@@ -157,7 +158,7 @@ func replaceURIWithImage(ctx context.Context, cmd *cobra.Command, args []string)
 		image, err = handleOras(ctx, imgCache, cmd, args[0])
 	case uri.Shub:
 		image, err = handleShub(ctx, imgCache, args[0])
-	case oci.IsSupported(t):
+	case ocitransport.SupportedTransport(t):
 		image, err = handleOCI(ctx, imgCache, cmd, args[0])
 	case uri.HTTP:
 		image, err = handleNet(ctx, imgCache, args[0])

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -40,7 +40,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 	keyClient "github.com/apptainer/container-key-client/client"
 	libClient "github.com/apptainer/container-library-client/client"
-	ocitypes "github.com/containers/image/v5/types"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -56,9 +56,9 @@ var CurrentUser = getCurrentUser()
 var currentRemoteEndpoint *endpoint.Config
 
 var (
-	dockerAuthConfig ocitypes.DockerAuthConfig
-	dockerLogin      bool
-	dockerHost       string
+	authConfig  authn.AuthConfig
+	dockerLogin bool
+	dockerHost  string
 
 	encryptionPEMPath   string
 	promptForPassphrase bool
@@ -138,7 +138,7 @@ var singVerboseFlag = cmdline.Flag{
 // --docker-username
 var dockerUsernameFlag = cmdline.Flag{
 	ID:            "dockerUsernameFlag",
-	Value:         &dockerAuthConfig.Username,
+	Value:         &authConfig.Username,
 	DefaultValue:  "",
 	Name:          "docker-username",
 	Usage:         "specify a username for docker authentication",
@@ -150,7 +150,7 @@ var dockerUsernameFlag = cmdline.Flag{
 // --docker-password
 var dockerPasswordFlag = cmdline.Flag{
 	ID:            "dockerPasswordFlag",
-	Value:         &dockerAuthConfig.Password,
+	Value:         &authConfig.Password,
 	DefaultValue:  "",
 	Name:          "docker-password",
 	Usage:         "specify a password for docker authentication",

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -269,7 +269,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 		sylog.Fatalf("Could not check build sections: %v", err)
 	}
 
-	authConf, err := makeDockerCredentials(cmd)
+	authConf, err := makeOCICredentials(cmd)
 	if err != nil {
 		sylog.Fatalf("While creating Docker credentials: %v", err)
 	}
@@ -369,7 +369,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 				LibraryAuthToken:  authToken,
 				FakerootPath:      fakerootPath,
 				KeyServerOpts:     ko,
-				DockerAuthConfig:  authConf,
+				OCIAuthConfig:     authConf,
 				DockerDaemonHost:  dockerHost,
 				EncryptionKeyInfo: keyInfo,
 				FixPerms:          buildArgs.fixPerms,

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/client/oci"
 	"github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/internal/pkg/client/shub"
+	"github.com/apptainer/apptainer/internal/pkg/ocitransport"
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
 	"github.com/apptainer/apptainer/pkg/cmdline"
@@ -263,7 +264,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While pulling shub image: %v\n", err)
 		}
 	case OrasProtocol:
-		ociAuth, err := makeDockerCredentials(cmd)
+		ociAuth, err := makeOCICredentials(cmd)
 		if err != nil {
 			sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 		}
@@ -277,8 +278,8 @@ func pullRun(cmd *cobra.Command, args []string) {
 		if err != nil {
 			sylog.Fatalf("While pulling from image from http(s): %v\n", err)
 		}
-	case oci.IsSupported(transport):
-		ociAuth, err := makeDockerCredentials(cmd)
+	case ocitransport.SupportedTransport(transport):
+		ociAuth, err := makeOCICredentials(cmd)
 		if err != nil {
 			sylog.Fatalf("While creating Docker credentials: %v", err)
 		}

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -163,7 +163,7 @@ var PushCmd = &cobra.Command{
 			if cmd.Flag(pushDescriptionFlag.Name).Changed {
 				sylog.Warningf("Description is not supported for push to oras. Ignoring it.")
 			}
-			ociAuth, err := makeDockerCredentials(cmd)
+			ociAuth, err := makeOCICredentials(cmd)
 			if err != nil {
 				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 			}

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/cache"
+	"github.com/apptainer/apptainer/internal/pkg/ocitransport"
 	"github.com/apptainer/apptainer/internal/pkg/test"
 	buildTypes "github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/containers/image/v5/oci/layout"
@@ -273,7 +274,8 @@ func TestConvertReference(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ConvertReference(context.Background(), imgCache, tt.ref, tt.ctx)
+			// nolint: staticcheck
+			_, err := ConvertReference(context.Background(), imgCache, tt.ref, ocitransport.TransportOptionsFromSystemContext(tt.ctx))
 			if tt.shouldPass == true && err != nil {
 				t.Fatalf("test expected to succeeded but failed: %s\n", err)
 			}
@@ -344,7 +346,8 @@ func TestImageNameAndImageSHA(t *testing.T) {
 	for _, tt := range tests {
 		testName := "ParseImageName - " + tt.name
 		t.Run(testName, func(t *testing.T) {
-			_, err := ParseImageName(context.Background(), imgCache, tt.uri, tt.ctx)
+			// nolint:staticcheck
+			_, err := ParseImageName(context.Background(), imgCache, tt.uri, ocitransport.TransportOptionsFromSystemContext(tt.ctx))
 			if tt.shouldPass == true && err != nil {
 				t.Fatalf("test expected to succeeded but failed: %s\n", err)
 			}
@@ -355,7 +358,8 @@ func TestImageNameAndImageSHA(t *testing.T) {
 
 		testName = "ImageSHA - " + tt.name
 		t.Run(testName, func(t *testing.T) {
-			_, err := ImageDigest(context.Background(), tt.uri, tt.ctx)
+			// nolint: staticcheck
+			_, err := ImageDigest(context.Background(), tt.uri, ocitransport.TransportOptionsFromSystemContext(tt.ctx))
 			if tt.shouldPass == true && err != nil {
 				t.Fatal("test expected to succeeded but failed")
 			}

--- a/internal/pkg/build/sources/conveyorPacker_oras.go
+++ b/internal/pkg/build/sources/conveyorPacker_oras.go
@@ -33,7 +33,7 @@ func (cp *OrasConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 	// full uri for name determination and output
 	fullRef := "oras:" + ref
 
-	imagePath, err := oras.Pull(ctx, b.Opts.ImgCache, fullRef, b.Opts.TmpDir, b.Opts.DockerAuthConfig, b.Opts.NoHTTPS, b.Opts.ReqAuthFile)
+	imagePath, err := oras.Pull(ctx, b.Opts.ImgCache, fullRef, b.Opts.TmpDir, b.Opts.OCIAuthConfig, b.Opts.NoHTTPS, b.Opts.ReqAuthFile)
 	if err != nil {
 		return fmt.Errorf("while fetching library image: %v", err)
 	}

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/image"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
-	ocitypes "github.com/containers/image/v5/types"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -34,7 +34,7 @@ import (
 )
 
 // DownloadImage downloads a SIF image specified by an oci reference to a file using the included credentials
-func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, reqAuthFile string) error {
+func DownloadImage(ctx context.Context, path, ref string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) error {
 	rt := client.NewRoundTripper(ctx, nil)
 	im, err := remoteImage(ref, ociAuth, noHTTPS, rt, reqAuthFile)
 	if err != nil {
@@ -115,7 +115,7 @@ func DownloadImage(ctx context.Context, path, ref string, ociAuth *ocitypes.Dock
 
 // UploadImage uploads the image specified by path and pushes it to the provided oci reference,
 // it will use credentials if supplied
-func UploadImage(_ context.Context, path, ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, reqAuthFile string) error {
+func UploadImage(_ context.Context, path, ref string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) error {
 	// ensure that are uploading a SIF
 	if err := ensureSIF(path); err != nil {
 		return err
@@ -187,7 +187,7 @@ func ensureSIF(filepath string) error {
 }
 
 // RefHash returns the digest of the SIF layer of the OCI manifest for supplied ref
-func RefHash(_ context.Context, ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, reqAuthFile string) (v1.Hash, error) {
+func RefHash(_ context.Context, ref string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) (v1.Hash, error) {
 	im, err := remoteImage(ref, ociAuth, noHTTPS, nil, reqAuthFile)
 	if err != nil {
 		return v1.Hash{}, err
@@ -246,7 +246,7 @@ func sha256sum(r io.Reader) (result string, nBytes int64, err error) {
 }
 
 // remoteImage returns a v1.Image for the provided remote ref.
-func remoteImage(ref string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, rt *client.RoundTripper, reqAuthFile string) (v1.Image, error) {
+func remoteImage(ref string, ociAuth *authn.AuthConfig, noHTTPS bool, rt *client.RoundTripper, reqAuthFile string) (v1.Image, error) {
 	ref = strings.TrimPrefix(ref, "oras://")
 	ref = strings.TrimPrefix(ref, "//")
 

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -17,11 +17,11 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/sylog"
-	ocitypes "github.com/containers/image/v5/types"
+	"github.com/google/go-containerregistry/pkg/authn"
 )
 
 // pull will pull an oras image into the cache if directTo="", or a specific file if directTo is set.
-func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, reqAuthFile string) (imagePath string, err error) {
+func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) (imagePath string, err error) {
 	hash, err := RefHash(ctx, pullFrom, ociAuth, noHTTPS, reqAuthFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to get checksum for %s: %s", pullFrom, err)
@@ -67,7 +67,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 }
 
 // Pull will pull an oras image to the cache or direct to a temporary file if cache is disabled
-func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, reqAuthFile string) (imagePath string, err error) {
+func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) (imagePath string, err error) {
 	directTo := ""
 
 	if imgCache.IsDisabled() {
@@ -83,7 +83,7 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 }
 
 // PullToFile will pull an oras image to the specified location, through the cache, or directly if cache is disabled
-func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, _ string, ociAuth *ocitypes.DockerAuthConfig, noHTTPS bool, reqAuthFile string) (imagePath string, err error) {
+func PullToFile(ctx context.Context, imgCache *cache.Handle, pullTo, pullFrom, _ string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) (imagePath string, err error) {
 	directTo := ""
 	if imgCache.IsDisabled() {
 		directTo = pullTo

--- a/internal/pkg/ocitransport/ocitransport.go
+++ b/internal/pkg/ocitransport/ocitransport.go
@@ -1,0 +1,223 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package ocitransport
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/apptainer/apptainer/pkg/util/slice"
+	"github.com/containers/image/v5/docker"
+	dockerarchive "github.com/containers/image/v5/docker/archive"
+	dockerdaemon "github.com/containers/image/v5/docker/daemon"
+	ociarchive "github.com/containers/image/v5/oci/archive"
+	ocilayout "github.com/containers/image/v5/oci/layout"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/types"
+	"github.com/google/go-containerregistry/pkg/authn"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+var ociTransports = []string{"docker", "docker-archive", "docker-daemon", "oci", "oci-archive"}
+
+// SupportedTransport returns whether or not the transport given is supported. To fit within a switch/case
+// statement, this function will return transport if it is supported
+func SupportedTransport(transport string) string {
+	if slice.ContainsString(ociTransports, transport) {
+		return transport
+	}
+	return ""
+}
+
+// TransportOptions provides authentication, platform etc. configuration for
+// interactions with image transports.
+type TransportOptions struct {
+	// AuthConfig provides optional credentials to be used when interacting with
+	// an image transport.
+	AuthConfig *authn.AuthConfig
+	// AuthFilePath provides an optional path to a file containing credentials
+	// to be used when interacting with an image transport.
+	AuthFilePath string
+	// Insecure should be set to true in order to interact with a registry via
+	// http, or without TLS certificate verification.
+	Insecure bool
+	// DockerDaemonHost provides the URI to use when interacting with a Docker
+	// daemon.
+	DockerDaemonHost string
+	// Platform specifies the OS / Architecture / Variant that the pulled images
+	// should satisfy.
+	Platform v1.Platform
+	// UserAgent will be set on HTTP(S) request made by transports.
+	UserAgent string
+	// TmpDir is a location in which a transport can create temporary files.
+	TmpDir string
+}
+
+// SystemContext returns a containers/image/v5 types.SystemContext struct for
+// compatibility with operations that still use containers/image.
+//
+// Deprecated: for containers/image compatibility only. To be removed in the future
+func (t *TransportOptions) SystemContext() types.SystemContext {
+	sc := types.SystemContext{
+		AuthFilePath:            t.AuthFilePath,
+		BigFilesTemporaryDir:    t.TmpDir,
+		DockerRegistryUserAgent: t.UserAgent,
+		OSChoice:                t.Platform.OS,
+		ArchitectureChoice:      t.Platform.Architecture,
+		VariantChoice:           t.Platform.Variant,
+		DockerDaemonHost:        t.DockerDaemonHost,
+	}
+
+	if t.AuthConfig != nil {
+		sc.DockerAuthConfig = &types.DockerAuthConfig{
+			Username:      t.AuthConfig.Username,
+			Password:      t.AuthConfig.Password,
+			IdentityToken: t.AuthConfig.IdentityToken,
+		}
+	}
+
+	if t.Insecure {
+		sc.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)
+		sc.DockerDaemonInsecureSkipTLSVerify = true
+		sc.OCIInsecureSkipTLSVerify = true
+	}
+
+	if sc.OSChoice == "" || sc.ArchitectureChoice == "" {
+		// set default architecture and variant
+		defaultSys := defaultSysCtx()
+		if sc.OSChoice == "" {
+			sc.OSChoice = defaultSys.OSChoice
+		}
+		if sc.ArchitectureChoice == "" {
+			sc.ArchitectureChoice = defaultSys.ArchitectureChoice
+			sc.VariantChoice = defaultSys.VariantChoice
+		}
+	}
+
+	return sc
+}
+
+// TransportOptionsFromSystemContext returns a TransportOptions struct
+// initialized from a containers/image SystemContext.
+//
+// Deprecated: for containers/image compatibility only. To be removed in future
+func TransportOptionsFromSystemContext(sc *types.SystemContext) *TransportOptions {
+	if sc == nil {
+		sc = defaultSysCtx()
+	}
+
+	if sc.OSChoice == "" || sc.ArchitectureChoice == "" {
+		// set default architecture and variant
+		defaultSys := defaultSysCtx()
+		if sc.OSChoice == "" {
+			sc.OSChoice = defaultSys.OSChoice
+		}
+		if sc.ArchitectureChoice == "" {
+			sc.ArchitectureChoice = defaultSys.ArchitectureChoice
+			sc.VariantChoice = defaultSys.VariantChoice
+		}
+	}
+
+	tOpts := TransportOptions{
+		AuthFilePath: sc.AuthFilePath,
+		TmpDir:       sc.BigFilesTemporaryDir,
+		UserAgent:    sc.DockerRegistryUserAgent,
+		Platform: v1.Platform{
+			OS:           sc.OSChoice,
+			Architecture: sc.ArchitectureChoice,
+			Variant:      sc.VariantChoice,
+		},
+		Insecure: sc.DockerInsecureSkipTLSVerify == types.OptionalBoolTrue || sc.DockerDaemonInsecureSkipTLSVerify || sc.OCIInsecureSkipTLSVerify,
+	}
+
+	if sc.DockerAuthConfig != nil {
+		tOpts.AuthConfig = &authn.AuthConfig{
+			Username:      sc.DockerAuthConfig.Username,
+			Password:      sc.DockerAuthConfig.Password,
+			IdentityToken: sc.DockerAuthConfig.IdentityToken,
+		}
+	}
+
+	return &tOpts
+}
+
+// SystemContextFromTransportOptions returns a containers/image SystemContext
+// initialized from a TransportOptions struct. If the TrasnportOptions is nil,
+// then nil is returned.
+//
+// Deprecated: for containers/image compatibility only. To be removed in future
+func SystemContextFromTransportOptions(tOpts *TransportOptions) *types.SystemContext {
+	if tOpts == nil {
+		return nil
+	}
+	sc := tOpts.SystemContext()
+	return &sc
+}
+
+// defaultPolicy is Apptainer's default containers/image OCI signature verification policy - accept anything.
+func DefaultPolicy() (*signature.PolicyContext, error) {
+	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	return signature.NewPolicyContext(policy)
+}
+
+// parseImageRef parses a uri-like OCI image reference into a containers/image types.ImageReference.
+func ParseImageRef(imageRef string) (types.ImageReference, error) {
+	parts := strings.SplitN(imageRef, ":", 2)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("could not parse image ref: %s", imageRef)
+	}
+
+	var srcRef types.ImageReference
+	var err error
+
+	switch parts[0] {
+	case "docker":
+		srcRef, err = docker.ParseReference(parts[1])
+	case "docker-archive":
+		srcRef, err = dockerarchive.ParseReference(parts[1])
+	case "docker-daemon":
+		srcRef, err = dockerdaemon.ParseReference(parts[1])
+	case "oci":
+		srcRef, err = ocilayout.ParseReference(parts[1])
+	case "oci-archive":
+		srcRef, err = ociarchive.ParseReference(parts[1])
+	default:
+		return nil, fmt.Errorf("cannot create an OCI container from %s source", parts[0])
+	}
+	if err != nil {
+		return nil, fmt.Errorf("invalid image source: %v", err)
+	}
+
+	return srcRef, nil
+}
+
+func defaultSysCtx() *types.SystemContext {
+	sysCtx := &types.SystemContext{
+		OSChoice: "linux",
+	}
+	switch runtime.GOARCH {
+	case "arm64":
+		sysCtx.ArchitectureChoice = runtime.GOARCH
+		sysCtx.VariantChoice = "v8"
+	case "arm":
+		if variance, ok := os.LookupEnv("GOARM"); ok {
+			sysCtx.ArchitectureChoice = runtime.GOARCH
+			sysCtx.VariantChoice = "v" + variance
+		} else {
+			// by default, we are using arm32v7
+			sysCtx.ArchitectureChoice = runtime.GOARCH
+			sysCtx.VariantChoice = "v7"
+		}
+	default:
+	}
+	return sysCtx
+}

--- a/internal/pkg/ocitransport/ocitransport_test.go
+++ b/internal/pkg/ocitransport/ocitransport_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package ocitransport
+
+import (
+	"testing"
+)
+
+func TestSupportedTransport(t *testing.T) {
+	// We individually check all the known transports. This is a
+	// very naive test since mimicking the actual code but still ensures
+	// that everything is consistent
+	for _, transport := range ociTransports {
+		if SupportedTransport(transport) == "" {
+			t.Fatalf("transport %s reported as not supported", transport)
+		}
+	}
+
+	// Now error cases
+	tests := []struct {
+		name      string
+		transport string
+	}{
+		{
+			name:      "empty",
+			transport: "",
+		},
+		{
+			name:      "random",
+			transport: "fake",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if SupportedTransport(tt.transport) != "" {
+				t.Fatalf("invalid transport %s reported as supported", tt.transport)
+			}
+		})
+	}
+}

--- a/internal/pkg/util/ociauth/ociauth.go
+++ b/internal/pkg/util/ociauth/ociauth.go
@@ -20,7 +20,6 @@ import (
 	fsutil "github.com/apptainer/apptainer/internal/pkg/util/fs"
 	"github.com/apptainer/apptainer/pkg/syfs"
 	"github.com/apptainer/apptainer/pkg/sylog"
-	ocitypes "github.com/containers/image/v5/types"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/types"
@@ -186,16 +185,9 @@ func getCredentialsFromFile(reqAuthFile string) (*configfile.ConfigFile, error) 
 	return cf, nil
 }
 
-func AuthOptn(ociAuth *ocitypes.DockerAuthConfig, reqAuthFile string) remote.Option {
+func AuthOptn(ociAuth *authn.AuthConfig, reqAuthFile string) remote.Option {
 	if ociAuth != nil {
-		// Explicit credentials given on command-line; use those.
-		optn := remote.WithAuth(authn.FromConfig(authn.AuthConfig{
-			Username:      ociAuth.Username,
-			Password:      ociAuth.Password,
-			IdentityToken: ociAuth.IdentityToken,
-		}))
-
-		return optn
+		return remote.WithAuth(authn.FromConfig(*ociAuth))
 	}
 
 	return remote.WithAuthFromKeychain(&apptainerKeychain{reqAuthFile: reqAuthFile})

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -21,6 +21,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/cryptkey"
 	keyClient "github.com/apptainer/container-key-client/client"
 	ocitypes "github.com/containers/image/v5/types"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"golang.org/x/sys/unix"
 )
 
@@ -52,7 +53,10 @@ type Options struct {
 	FakerootPath string `json:"fakerootPath"`
 	// KeyServerOpts contains options for keyserver used for SIF fingerprint verification in builds.
 	KeyServerOpts []keyClient.Option
-	// contains docker credentials if specified.
+	// If non-nil, provides credentials to be used when authenticating to OCI registries.
+	OCIAuthConfig *authn.AuthConfig
+	// If non-nil, provides credentials to be used when authenticating to OCI registries.
+	// Deprecated: Use OCIAuthConfig, which takes precedence if both are set.
 	DockerAuthConfig *ocitypes.DockerAuthConfig
 	// Custom docker Daemon host
 	DockerDaemonHost string


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implemented sylabs PRs https://github.com/sylabs/singularity/pull/2376

which had an original description of
> Refactor code so that we minimise the number of times that we import from containers/image, without yet rewriting the image pulling & caching code that uses containers/image. 
Use the ggcr AuthConfig over the containers/image DockerAuthconfig.
Use our own TransportOptions over the containers/image SystemContext.
Where we still have functional containers/image code, translate to its types as near as possible.
A first step for https://github.com/sylabs/singularity/issues/2022

### This fixes or addresses the following GitHub issues:

Addresses multiple of the PRs in

- https://github.com/apptainer/apptainer/issues/2126


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
