### PR TITLE
Re-implement bars when fetching remote OCI images via ggcr

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -128,6 +128,7 @@ type OCIConveyorPacker struct {
 
 // Get downloads container information from the specified source
 func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err error) {
+	sylog.Infof("Fetching OCI image...")
 	cp.b = b
 
 	cp.topts = &ociimage.TransportOptions{
@@ -190,11 +191,13 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 
 // Pack puts relevant objects in a Bundle.
 func (cp *OCIConveyorPacker) Pack(ctx context.Context) (*sytypes.Bundle, error) {
+	sylog.Infof("Extracting OCI image...")
 	err := cp.unpackRootfs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("while unpacking rootfs: %v", err)
 	}
 
+	sylog.Infof("Inserting Apptainer configuration...")
 	err = cp.insertBaseEnv()
 	if err != nil {
 		return nil, fmt.Errorf("while inserting base environment: %v", err)

--- a/internal/pkg/client/progress.go
+++ b/internal/pkg/client/progress.go
@@ -29,29 +29,22 @@ var defaultOption = []mpb.BarOption{
 	),
 }
 
+var unknownSizeOption = []mpb.BarOption{
+	mpb.PrependDecorators(
+		decor.Current(decor.SizeB1024(0), "%.1f / ???"),
+	),
+	mpb.AppendDecorators(
+		decor.AverageSpeed(decor.SizeB1024(0), " % .1f "),
+	),
+}
+
 func initProgressBar(totalSize int64) (*mpb.Progress, *mpb.Bar) {
 	p := mpb.New()
 
 	if totalSize > 0 {
-		return p, p.AddBar(totalSize,
-			mpb.PrependDecorators(
-				decor.Counters(decor.SizeB1024(0), "%.1f / %.1f"),
-			),
-			mpb.AppendDecorators(
-				decor.Percentage(),
-				decor.AverageSpeed(decor.SizeB1024(0), " % .1f "),
-				decor.AverageETA(decor.ET_STYLE_GO),
-			),
-		)
+		return p, p.AddBar(totalSize, defaultOption...)
 	}
-	return p, p.AddBar(totalSize,
-		mpb.PrependDecorators(
-			decor.Current(decor.SizeB1024(0), "%.1f / ???"),
-		),
-		mpb.AppendDecorators(
-			decor.AverageSpeed(decor.SizeB1024(0), " % .1f "),
-		),
-	)
+	return p, p.AddBar(totalSize, unknownSizeOption...)
 }
 
 // See: https://ixday.github.io/post/golang-cancel-copy/

--- a/internal/pkg/client/progress_roundtrip.go
+++ b/internal/pkg/client/progress_roundtrip.go
@@ -28,6 +28,15 @@ type RoundTripper struct {
 	sizes []int64
 }
 
+// NewRoundTripper wraps inner (or http.DefaultTransport if inner is nil) with
+// progress bar functionality. A separate bar will be displayed for every GET
+// request that returns a body >64KiB, updated as the response body is read. The
+// caller is responsible for calling rt.ProgressWait / rt.ProgressShutdown when
+// all requests are completed, so that the mpb progress container exits
+// correctly. Note that if requests are made, but the response body is not
+// read, the progress bar will remain 'stuck', preventing rt.ProgressWait
+// from returning. rt.ProgressComplete is provided to override all bars to be
+// 100% complete, to satisfy rt.ProgressWait where appropriate.
 func NewRoundTripper(ctx context.Context, inner http.RoundTripper) *RoundTripper {
 	if inner == nil {
 		inner = http.DefaultTransport


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/2407

which had an original description of
> Add back progress bars when remote OCI images are fetch via the new ggcr code.
Because ggcr doesn't have its own progress functionality for reads from a remote, we implement bars on GET requests through a RoundTripper.
The existing RoundTripper code that was implemented for ORAS fetch only has been revised to accommodate multiple bars for multiple GETs, and ensure a more graceful exit.

![Code_FKJ0HlXDNa](https://github.com/user-attachments/assets/8ffb849d-4349-438b-933f-e4500ae2e412)


### This fixes or addresses the following GitHub issues:

Addresses multiple of the PRs in

- https://github.com/apptainer/apptainer/issues/2126


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
