### PR TITLE
`nvliblist.conf` has a probable typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   include the libraries needed for maximum support of compression algorithms
   by squashfuse_ll.
 - Add automated tests for OpenSUSE Leap and Tumbleweed and Debian Bookworm.
+- Fixed typo in `nvliblist.conf` (`libnvoptix.so.1` -> `libnvoptix.so`)
 
 ## Changes for v1.3.x
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@
 - Adam Hughes <adam@sylabs.io>, <stickmanica@gmail.com>
 - Adam Simpson <asimpson@nvidia.com>, <adambsimpson@gmail.com>
 - Afif Elghraoui <afif.elghraoui@nih.gov>
+- Alan O'Cais <alan.ocais@cecam.org>
 - Alexander Grund <alexander.grund@tu-dresden.de>
 - Amanda Duffy <aduffy@lenovo.com>
 - Ana Guerrero Lopez <aguerrero@suse.com>

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -53,7 +53,7 @@ libnvidia-ptxjitcompiler.so
 libnvidia-rtcore.so
 libnvidia-tls.so
 libnvidia-wfb.so
-libnvoptix.so.1
+libnvoptix.so
 libOpenCL.so
 libOpenGL.so
 libvdpau_nvidia.so


### PR DESCRIPTION
## Description of the Pull Request (PR):

At the beginning of `nvliblist.conf` it says that all shared library names should end in `.so` but there is one in the list that doesn't. 

If it is a typo, I don't mind if this is not merged but fixed directly by an existing contributor.

### This fixes or addresses the following GitHub issues:

No related issues

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see CONTRIBUTING.md).
  - There are currently no tests that sanity check the contents of `nvliblist.conf` that I can find
- [x] Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md)
