### PR TITLE
cgroups: rework checks for cgroup support, from sylabs #2569

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
   by squashfuse_ll.
 - Add automated tests for OpenSUSE Leap and Tumbleweed and Debian Bookworm.
 - Fixed typo in `nvliblist.conf` (`libnvoptix.so.1` -> `libnvoptix.so`)
+- Containers and instances can now be successfully
+  started as a non-root user on cgroups v2 systems when both:
+  - The system configuration / environment does not provide the correct
+    information necessary to communicate with systemd via dbus.
+  - Resource limits (e.g. `--cpus`) have not been requested.
+  The container / instance will be started in the current cgroup, and information
+  about the configuration issue displayed to the user as warnings.
 
 ## Changes for v1.3.x
 

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -133,10 +133,12 @@ func (m *Manager) UpdateFromSpec(resources *specs.LinuxResources) (err error) {
 		},
 	}
 
+	uid := os.Geteuid()
+
 	opts := &lcspecconv.CreateOpts{
 		CgroupName:       m.group,
 		UseSystemdCgroup: false,
-		RootlessCgroups:  os.Getuid() != 0,
+		RootlessCgroups:  uid != 0,
 		Spec:             spec,
 	}
 
@@ -232,25 +234,15 @@ func (m *Manager) Destroy() (err error) {
 	return m.cgroup.Destroy()
 }
 
-// checkRootless identifies if rootless cgroups are required / supported
-func checkRootless(group string, systemd bool) (rootless bool, err error) {
-	if os.Getuid() == 0 {
+// useRootless identifies whether rootless cgroups are required, and verifies the requested cgroup name is valid.
+func useRootless(group string, systemd bool) (rootless bool, err error) {
+	if os.Geteuid() == 0 {
 		if systemd {
 			if !strings.HasPrefix(group, "system.slice:") {
 				return false, fmt.Errorf("systemd cgroups require a cgroups path beginning with 'system.slice:'")
 			}
 		}
 		return false, nil
-	}
-
-	if !lccgroups.IsCgroup2HybridMode() && !lccgroups.IsCgroup2UnifiedMode() {
-		return false, fmt.Errorf("rootless cgroups requires cgroups v2")
-	}
-	if !systemd {
-		return false, fmt.Errorf("rootless cgroups require 'systemd cgroups' to be enabled in apptainer.conf")
-	}
-	if os.Getenv("XDG_RUNTIME_DIR") == "" || os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
-		return false, fmt.Errorf("rootless cgroups require a D-Bus session - check that XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS are set")
 	}
 
 	if !strings.HasPrefix(group, "user.slice:") {
@@ -275,7 +267,7 @@ func newManager(resources *specs.LinuxResources, group string, systemd bool) (ma
 		return nil, fmt.Errorf("a cgroup name/path is required")
 	}
 
-	rootless, err := checkRootless(group, systemd)
+	rootless, err := useRootless(group, systemd)
 	if err != nil {
 		return nil, err
 	}
@@ -352,6 +344,10 @@ func newManager(resources *specs.LinuxResources, group string, systemd bool) (ma
 // If a group name is supplied, it will be used by the manager.
 // If group = "" then "/apptainer/<pid>" is used as a default.
 func NewManagerWithSpec(spec *specs.LinuxResources, pid int, group string, systemd bool) (manager *Manager, err error) {
+	if !CanUseCgroups(systemd, true) {
+		return nil, fmt.Errorf("system configuration does not support cgroup management")
+	}
+
 	if pid == 0 {
 		return nil, fmt.Errorf("a pid is required to create a new cgroup")
 	}

--- a/internal/pkg/cgroups/util.go
+++ b/internal/pkg/cgroups/util.go
@@ -11,8 +11,12 @@ package cgroups
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
-	lccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"golang.org/x/sys/unix"
 )
 
 const unifiedMountPoint = "/sys/fs/cgroup"
@@ -25,14 +29,14 @@ func pidToPath(pid int) (path string, err error) {
 	}
 
 	pidCGFile := fmt.Sprintf("/proc/%d/cgroup", pid)
-	paths, err := lccgroups.ParseCgroupFile(pidCGFile)
+	paths, err := cgroups.ParseCgroupFile(pidCGFile)
 	if err != nil {
 		return "", fmt.Errorf("cannot read %s: %w", pidCGFile, err)
 	}
 
 	// cgroups v2 path is always given by the unified "" subsystem
 	ok := false
-	if lccgroups.IsCgroup2UnifiedMode() {
+	if cgroups.IsCgroup2UnifiedMode() {
 		path, ok := paths[""]
 		if !ok {
 			return "", fmt.Errorf("could not find cgroups v2 unified path")
@@ -50,4 +54,96 @@ func pidToPath(pid int) (path string, err error) {
 		return "", fmt.Errorf("could not find cgroups v1 path (using devices subsystem)")
 	}
 	return path, nil
+}
+
+// HasDbus checks if DBUS_SESSION_BUS_ADDRESS is set, and sane.
+// Logs unset var / non-existent target at DEBUG level.
+func HasDbus() (bool, error) {
+	dbusEnv := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
+	if dbusEnv == "" {
+		return false, fmt.Errorf("DBUS_SESSION_BUS_ADDRESS is not set")
+	}
+
+	if !strings.HasPrefix(dbusEnv, "unix:") {
+		return false, fmt.Errorf("DBUS_SESSION_BUS_ADDRESS %q is not a 'unix:' socket", dbusEnv)
+	}
+
+	return true, nil
+}
+
+// HasXDGRuntimeDir checks if XDG_Runtime_Dir is set, and sane.
+// Logs unset var / non-existent target at DEBUG level.
+func HasXDGRuntimeDir() (bool, error) {
+	xdgRuntimeEnv := os.Getenv("XDG_RUNTIME_DIR")
+	if xdgRuntimeEnv == "" {
+		return false, fmt.Errorf("XDG_RUNTIME_DIR is not set")
+	}
+
+	fi, err := os.Stat(xdgRuntimeEnv)
+	if err != nil {
+		return false, fmt.Errorf("XDG_RUNTIME_DIR %q not accessible: %v", xdgRuntimeEnv, err)
+	}
+
+	if !fi.IsDir() {
+		return false, fmt.Errorf("XDG_RUNTIME_DIR %q is not a directory", xdgRuntimeEnv)
+	}
+
+	if err := unix.Access(xdgRuntimeEnv, unix.W_OK); err != nil {
+		return false, fmt.Errorf("XDG_RUNTIME_DIR %q is not writable", xdgRuntimeEnv)
+	}
+
+	return true, nil
+}
+
+// CanUseCgroups checks whether it's possible to use the cgroups manager.
+// - Host root can always use cgroups.
+// - Rootless needs cgroups v2.
+// - Rootless needs systemd manager.
+// - Rootless needs DBUS_SESSION_BUS_ADDRESS and XDG_RUNTIME_DIR set properly.
+// warn controls whether configuration problems preventing use of cgroups will be logged as warnings, or debug messages.
+func CanUseCgroups(systemd bool, warn bool) bool {
+	uid := os.Geteuid()
+	if uid == 0 {
+		return true
+	}
+
+	rootlessOK := true
+
+	if !cgroups.IsCgroup2UnifiedMode() {
+		rootlessOK = false
+		if warn {
+			sylog.Warningf("Rootless cgroups require the system to be configured for cgroups v2 in unified mode.")
+		} else {
+			sylog.Debugf("Rootless cgroups require 'systemd cgroups' to be enabled in apptainer.conf")
+		}
+	}
+
+	if !systemd {
+		rootlessOK = false
+		if warn {
+			sylog.Warningf("Rootless cgroups require 'systemd cgroups' to be enabled in apptainer.conf")
+		} else {
+			sylog.Debugf("Rootless cgroups require 'systemd cgroups' to be enabled in apptainer.conf")
+		}
+	}
+
+	if ok, err := HasXDGRuntimeDir(); !ok {
+		rootlessOK = false
+		if warn {
+			sylog.Warningf("%s", err)
+		} else {
+			sylog.Debugf("%s", err)
+		}
+	}
+
+	if ok, err := HasDbus(); !ok {
+		rootlessOK = false
+		if warn {
+			sylog.Warningf("%s", err)
+		} else {
+			sylog.Debugf("%s", err)
+		}
+	}
+
+	return rootlessOK
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/2569

which had an original description of
> Rework the location of checks for cgroup management support, and add fall-back logic, so that when all of the following apply:
A system is using cgroups v2
Singularity is configured to use systemd for cgroups management
The system configuration / environment doesn't set usable XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS env vars
The user has not explicitly requested resource limits (e.g --cpus)
... It is still possible to:
Start an instance as non-root (without the cgroup needed for instance stats)
run / shell / exec a container as non-root in OCI-Mode

### This fixes or addresses the following GitHub issues:

Addresses multiple of the PRs in

- https://github.com/apptainer/apptainer/issues/2126

#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
