### PR TITLE
fix: store docker.io credential like index.docker.io, from sylabs #2777

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   - Resource limits (e.g. `--cpus`) have not been requested.
   The container / instance will be started in the current cgroup, and information
   about the configuration issue displayed to the user as warnings.
+- Fix storage of credentials for `docker.io` to behave the same as for
+  `index.docker.io`.
 
 ## Changes for v1.3.x
 

--- a/e2e/internal/e2e/dockerhub_auth.go
+++ b/e2e/internal/e2e/dockerhub_auth.go
@@ -32,6 +32,10 @@ func SetupDockerHubCredentials(t *testing.T) {
 		return
 	}
 
+	if username != "" && pass == "" {
+		t.Fatalf("E2E_DOCKER_USERNAME was set, but E2E_DOCKER_PASSWORD is empty. Please check env vars.")
+	}
+
 	unprivUser = CurrentUser(t)
 	writeDockerHubCredentials(t, unprivUser.Dir, username, pass)
 	Privileged(func(t *testing.T) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/2777

which had an original description of
> For historical reasons, the auth file key for docker hub (which can be accessed as index.docker.io or docker.io) is stored by docker as: 
https://index.docker.io/v1/
We were successfully doing this for logins to index.docker.io, but docker.io can also be used as an alias... and was not being mutated to the above string.
When a ggcr Registry struct is created, against which operations will be performed, the NewRegistry func modifyies a docker.io address to index.docker.io. This means we need to have a docker.io credential stored against the correct mutated https://index.docker.io/v1/ key in the auth file for it to be effective as intended.
(ref.. https://github.com/google/go-containerregistry/blob/8b3c3036d612bcb3c1147fe11c2d1818dc432329/pkg/name/registry.go#L127)
We now have the relevant constants in our code, as they are not all exported by ggcr - some are private there.
PR also adds a check that E2E_DOCKER_PASSWORD is not empty if E2E_DOCKER_USERNAME is set. This tripped me up while chasing down the underlying issue of E2E tests using auth on "docker.io" not working as expected.
Fixes https://github.com/sylabs/singularity/issues/2778


### This fixes or addresses the following GitHub issues:

Addresses multiple of the PRs in

- https://github.com/apptainer/apptainer/issues/2126

#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
