### PR TITLE
fix: Address layer / image extraction issues in user namespaces, from sylabs #2699

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   by squashfuse_ll.
 - Add automated tests for OpenSUSE Leap and Tumbleweed and Debian Bookworm.
 - Fixed typo in `nvliblist.conf` (`libnvoptix.so.1` -> `libnvoptix.so`)
+- Fix extraction of OCI layers when run in a root mapped user namespace
+  (e.g.. `unshare -r`).
+- Use user namespace for wrapping of `unsquashfs` when running with
+  `--userns / -u` flag. Fixes temporary sandbox extraction of images in non-root
+  mapped user namespace (e.g. `unshare -c`).
 
 ## Changes for v1.3.x
 

--- a/internal/pkg/build/sources/oci_unpack.go
+++ b/internal/pkg/build/sources/oci_unpack.go
@@ -81,7 +81,8 @@ func UnpackRootfs(_ context.Context, srcImage v1.Image, destDir string) (err err
 	}
 
 	// Allow unpacking as non-root
-	if namespaces.IsUnprivileged() {
+	insideUserNS, _ := namespaces.IsInsideUserNamespace(os.Getpid())
+	if namespaces.IsUnprivileged() || insideUserNS {
 		sylog.Debugf("setting umoci rootless mode")
 		mapOptions.Rootless = true
 

--- a/internal/pkg/build/sources/packer_sif.go
+++ b/internal/pkg/build/sources/packer_sif.go
@@ -55,7 +55,7 @@ func unpackSIF(b *types.Bundle, img *image.Image) (err error) {
 			return fmt.Errorf("could not extract root filesystem: %s", err)
 		}
 
-		s := unpacker.NewSquashfs()
+		s := unpacker.NewSquashfs(false)
 
 		// extract root filesystem
 		if err := s.ExtractAll(reader, b.RootfsPath); err != nil {

--- a/internal/pkg/build/sources/packer_squashfs.go
+++ b/internal/pkg/build/sources/packer_squashfs.go
@@ -33,7 +33,7 @@ func (p *SquashfsPacker) Pack(context.Context) (*types.Bundle, error) {
 		return nil, fmt.Errorf("could not extract root filesystem: %s", err)
 	}
 
-	s := unpacker.NewSquashfs()
+	s := unpacker.NewSquashfs(false)
 
 	// extract root filesystem
 	if err := s.ExtractAll(reader, p.b.RootfsPath); err != nil {

--- a/internal/pkg/image/unpacker/squashfs_apptainer.go
+++ b/internal/pkg/image/unpacker/squashfs_apptainer.go
@@ -223,7 +223,7 @@ func parseLibraryBinds(buf io.Reader) ([]libBind, error) {
 
 // unsquashfsSandboxCmd is the command instance for executing unsquashfs command
 // in a sandboxed environment with apptainer.
-func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filter string, opts ...string) (*exec.Cmd, error) {
+func unsquashfsSandboxCmd(squashfs *Squashfs, dest string, filename string, filter string, opts ...string) (*exec.Cmd, error) {
 	const (
 		// will contain both dest and filename inside the sandbox
 		rootfsImageDir = "/image"
@@ -267,9 +267,6 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 		}
 	}
 
-	// the decision to use user namespace is left to apptainer
-	// which will detect automatically depending of the configuration
-	// what workflow it could use
 	args := []string{
 		"exec",
 		"--no-home",
@@ -281,16 +278,20 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 		"-B", fmt.Sprintf("%s:%s", tmpdir, rootfsImageDir),
 	}
 
+	if squashfs.ForceUserns {
+		args = append(args, "--userns")
+	}
+
 	if filename != stdinFile {
 		filename = filepath.Join(rootfsImageDir, filepath.Base(filename))
 	}
 
 	roFiles := []string{
-		unsquashfs,
+		squashfs.UnsquashfsPath,
 	}
 
 	// get the library dependencies of unsquashfs
-	libs, err := getLibraryBinds(unsquashfs)
+	libs, err := getLibraryBinds(squashfs.UnsquashfsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +344,7 @@ func unsquashfsSandboxCmd(unsquashfs string, dest string, filename string, filte
 	args = append(args, rootfs)
 
 	// unsquashfs execution arguments
-	args = append(args, unsquashfs)
+	args = append(args, squashfs.UnsquashfsPath)
 	args = append(args, opts...)
 
 	if overwrite {

--- a/internal/pkg/image/unpacker/squashfs_test.go
+++ b/internal/pkg/image/unpacker/squashfs_test.go
@@ -54,7 +54,7 @@ func TestSquashfs(t *testing.T) {
 }
 
 func testSquashfs(t *testing.T, tmpParent string) {
-	s := NewSquashfs()
+	s := NewSquashfs(false)
 
 	if !s.HasUnsquashfs() {
 		t.Skip("unsquashfs not found")

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -65,7 +65,7 @@ func checkPartition(t *testing.T, reader io.Reader) error {
 	extracted := "/bin/busybox"
 	dir := t.TempDir()
 
-	s := unpacker.NewSquashfs()
+	s := unpacker.NewSquashfs(false)
 	if s.HasUnsquashfs() {
 		if err := s.ExtractFiles([]string{extracted}, reader, dir); err != nil {
 			return fmt.Errorf("extraction failed: %s", err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/2699

which had an original description of
> Note - there are no e2e tests for the nested containers / nested namespaces situations that are fixed by the commits in this PR. However, our e2e tests do confirm the changes don't cause regressions in non-nested cases.
The e2e framework doesn't offer a great way of executing singularity nested, and I've opened an issue (https://github.com/sylabs/singularity/issues/2700) to address this to verify functionality more generally than a messy one-off for this PR would handle.
fix: use rootless umoci inside user namespace
If we are running from within a user namespace, then use rootless OCI layer extrraction with umoci.
This permits the extraction to complete when singularity is run under unshare -r.
fix: honor --userns in unsquashfs wrapping
If singularity is executed with --userns/-u then it should also use a user namespace where it executes unsquashfs in a wrapped manner.
Previously the unsquashfs wrapping was without --userns/-u in a setuid installation. This caused extraction to fail from within a non-root-mapped user namespace (e.g. unshare -c).


### This fixes or addresses the following GitHub issues:

Addresses multiple of the PRs in

- https://github.com/apptainer/apptainer/issues/2126


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
