### PR TITLE
update node ver.: 18 -> 20, from sylabs 2380

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   lint_markdown:
     name: lint_markdown
     runs-on: ubuntu-22.04
-    container: node:18-slim
+    container: node:20-slim
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This pulls in sylabs PR
 * sylabs/singularity#2380


The original PR description was:

> Update the version of node used in CircleCI from 18 to 20.
