### PR TITLE
e2e: Add test for instance start --app, from sylabs2515

### DIFF
--- a/e2e/instance/instance.go
+++ b/e2e/instance/instance.go
@@ -64,7 +64,38 @@ func (c *ctx) testBasicEchoServer(t *testing.T) {
 				return
 			}
 			// Try to contact the instance.
-			echo(t, instanceStartPort)
+			echo(t, instanceStartPort, false)
+			c.stopInstance(t, instanceName)
+		}),
+		e2e.ExpectExit(0),
+	)
+}
+
+// Test that a basic reverse-echo server defined in an appstart script can be started,
+// communicated with, and stopped.
+func (c *ctx) testAppEchoServer(t *testing.T) {
+	const instanceName = "echoApp"
+
+	args := []string{
+		"--app",
+		"foo",
+		c.env.ImagePath,
+		instanceName,
+		strconv.Itoa(instanceStartPort),
+	}
+
+	// Start the instance.
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(c.profile),
+		e2e.WithCommand("instance start"),
+		e2e.WithArgs(args...),
+		e2e.PostRun(func(t *testing.T) {
+			if t.Failed() {
+				return
+			}
+			// Try to contact the instance.
+			echo(t, instanceStartPort, true)
 			c.stopInstance(t, instanceName)
 		}),
 		e2e.ExpectExit(0),
@@ -107,7 +138,7 @@ func (c *ctx) testInstanceRun(t *testing.T) {
 				t.Fatal(err)
 			}
 			s := string(b)
-			echo(t, instanceStartPort)
+			echo(t, instanceStartPort, false)
 			c.stopInstance(t, instanceName)
 			if !strings.Contains(s, "Running command: true") {
 				t.Fatal()
@@ -132,7 +163,7 @@ func (c *ctx) testCreateManyInstances(t *testing.T) {
 			e2e.WithCommand("instance start"),
 			e2e.WithArgs(c.env.ImagePath, instanceName, strconv.Itoa(port)),
 			e2e.PostRun(func(t *testing.T) {
-				echo(t, port)
+				echo(t, port, false)
 			}),
 			e2e.ExpectExit(0),
 		)
@@ -557,6 +588,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 				function func(*testing.T)
 			}{
 				{"BasicEchoServer", c.testBasicEchoServer},
+				{"AppEchoServer", c.testAppEchoServer},
 				{"BasicOptions", c.testBasicOptions},
 				{"Contain", c.testContain},
 				{"InstanceFromURI", c.testInstanceFromURI},

--- a/e2e/instance/instance_utils.go
+++ b/e2e/instance/instance_utils.go
@@ -105,10 +105,18 @@ func (c *ctx) expectInstance(t *testing.T, name string, nb int, showAll bool) {
 	)
 }
 
-// Sends a deterministic message to an echo server and expects the same message
-// in response.
-func echo(t *testing.T, port int) {
-	const message = "b40cbeaaea293f7e8bd40fb61f389cfca9823467\n"
+// Sends a deterministic message to an echo server and expects the same, or a
+// reversed, message in response.
+func echo(t *testing.T, port int, reverse bool) {
+	const (
+		message         = "b40cbeaaea293f7e8bd40fb61f389cfca9823467\n"
+		reversedMessage = "7643289acfc983f16bf04db8e7f392aeaaebc04b\n"
+	)
+
+	expectResponse := message
+	if reverse {
+		expectResponse = reversedMessage
+	}
 
 	// give it some time for responding, attempt 10 times by
 	// waiting 100 millisecond between each try
@@ -125,8 +133,9 @@ func echo(t *testing.T, port int) {
 		fmt.Fprint(sock, message)
 
 		response, responseErr := bufio.NewReader(sock).ReadString('\n')
-		if responseErr != nil || response != message {
-			t.Errorf("Bad response: err = %v, response = %v", responseErr, response)
+
+		if responseErr != nil || response != expectResponse {
+			t.Errorf("Bad response: err = %v, response %q != %q", responseErr, response, expectResponse)
 		}
 		break
 	}

--- a/e2e/testdata/Apptainer
+++ b/e2e/testdata/Apptainer
@@ -59,9 +59,11 @@ export HELLOTHISIS
 
 %appstart foo
     echo "STARTING FOO"
-    exec nc -l -k -p $1 -e /bin/cat
+    # Echo back reverse of strings sent on port $1
+    exec nc -l -k -p $1 -e /bin/rev
 
 %startscript
+    # Echo back strings sent on port $1
     exec nc -l -k -p $1 -e /bin/cat
 
 %runscript


### PR DESCRIPTION
This pulls in one of the commits from
- sylabs/singularity#2515

which addressed
- sylabs/singularity#1944

The relevant portion of the original PR description was:
> Add an e2e test for `instance start --app`. Use the same echo server pattern that's implemented for testing `instance start`, but make `%appstart foo` a string reversing echo server, so we can tell that we started the right thing.

This is one of the PRs listed in
- #2126