### PR TITLE
Skip mounting inaccessible mount points with `mount hostfs = yes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   about the configuration issue displayed to the user as warnings.
 - Fix storage of credentials for `docker.io` to behave the same as for
   `index.docker.io`.
+- Skip attempting to bind inaccessible mount points when handling the
+  `mount hostfs = yes` configuration option.
 
 ## Changes for v1.3.x
 

--- a/internal/app/starter/master_linux.go
+++ b/internal/app/starter/master_linux.go
@@ -58,7 +58,6 @@ func createContainer(ctx context.Context, rpcSocket int, containerPid int, e *en
 			err = errors.New("failed to decrypt, ensure you have supplied appropriate key material")
 		}
 
-		// continue with warnings rather than fatal errors
 		if strings.Contains(err.Error(), "mount hook function failure") && strings.Contains(err.Error(), "permission denied") {
 			sylog.Infof("Try appending ':ro' to your overlay image or using '--fakeroot'")
 		}

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -1743,7 +1743,11 @@ func (c *container) addHostMount(system *mount.System) error {
 		} else if strings.HasPrefix(child, "/var") {
 			sylog.Debugf("Skipping /var based file system")
 			continue
+		} else if _, err = os.Stat(child); err != nil {
+			sylog.Debugf("Skipping %s because %v", child, err)
+			continue
 		}
+
 		sylog.Debugf("Adding %s to mount list\n", child)
 		if err := system.Points.AddBind(mount.HostfsTag, child, child, flags); err != nil {
 			return fmt.Errorf("unable to add %s to mount list: %s", child, err)


### PR DESCRIPTION
This does a stat on mountpoints found for `mount hostfs = yes` and skips including them if the stat gets an error.

- Fixes #2466