### PR TITLE
Suppress unneeded warnings and pass message level value to post script instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   no `--encrypt` from implying fakeroot.
 - Support parsing nested variables defined inside `%arguments` section of
   definition file.
+- Suppress unneeded warnings and remove default silent message level for the
+  post script instance.
 
 ## Changes for v1.3.x
 

--- a/internal/pkg/build/stage.go
+++ b/internal/pkg/build/stage.go
@@ -83,7 +83,7 @@ func (s *stage) runHostScript(name string, script types.Script) error {
 
 func (s *stage) runPostScript(sessionResolv, sessionHosts string) error {
 	if s.b.Recipe.BuildData.Post.Script != "" {
-		cmdArgs := []string{"-s", "--build-config", "exec", "--pwd", "/", "--writable"}
+		cmdArgs := []string{"--build-config", "exec", "--pwd", "/", "--writable"}
 		cmdArgs = append(cmdArgs, "--cleanenv", "--env", aEnvironment, "--env", sEnvironment, "--env", aLabels, "--env", sLabels)
 
 		if sessionResolv != "" {

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2351,7 +2351,9 @@ func (c *container) createCwdDir(system *mount.System) error {
 	cwdHost := filepath.Clean(c.engine.EngineConfig.GetCwd())
 	if cwdHost == "" || cwdHost == "/" {
 		c.skipCwd = true
-		sylog.Warningf("No current working directory set: skipping mount")
+		if cwdHost == "" {
+			sylog.Warningf("No current working directory set: skipping mount")
+		}
 		return nil
 	} else if cwdHost[0] != '/' {
 		return fmt.Errorf("current working directory %s is not an absolute path", cwdHost)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Suppress unneeded warnings and pass message level value to post script instance

### This fixes or addresses the following GitHub issues:

 - Fixes #1314


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).

### Test

```
[vagrant@localhost test]$ cat nvidia.def 
Bootstrap: docker
From: ubuntu:18.04

%test
    nvidia-smi

%runscript
    nvidia-smi

%post
    nvidia-sm

[vagrant@localhost test]$ apptainer build nvidia.sif nvidia.def
INFO:    Starting build...
INFO:    Fetching OCI image...
24.5MiB / 24.5MiB [===================================================================] 100 % 0.0 b/s 0s
INFO:    Extracting OCI image...
INFO:    Inserting Apptainer configuration...
INFO:    Running post scriptlet
+ nvidia-smi
/.post.script: 1: /.post.script: nvidia-smi: not found
FATAL:   While performing build: while running engine: while running %post section: exit status 127

[vagrant@localhost test]$ apptainer build --nv nvidia.sif nvidia.def
INFO:    Starting build...
INFO:    Fetching OCI image...
24.5MiB / 24.5MiB [===================================================================] 100 % 0.0 b/s 0s
INFO:    Extracting OCI image...
INFO:    Inserting Apptainer configuration...
INFO:    Running post scriptlet
WARNING: Could not find any nv files on this host!
+ nvidia-smi
/.post.script: 1: /.post.script: nvidia-smi: not found
FATAL:   While performing build: while running engine: while running %post section: exit status 127

[vagrant@localhost test]$ apptainer -s build --nv nvidia.sif nvidia.def
+ nvidia-smi
/.post.script: 1: /.post.script: nvidia-smi: not found
FATAL:   While performing build: while running engine: while running %post section: exit status 127

[vagrant@localhost test]$ apptainer -q build --nv nvidia.sif nvidia.def
WARNING: Could not find any nv files on this host!
+ nvidia-smi
/.post.script: 1: /.post.script: nvidia-smi: not found
FATAL:   While performing build: while running engine: while running %post section: exit status 127

[vagrant@localhost test]$ apptainer build --ignore-subuid --nv nvidia.sif nvidia.def
INFO:    User not listed in /etc/subuid, trying root-mapped namespace
INFO:    The %post section will be run under the fakeroot command
INFO:    Starting build...
INFO:    Fetching OCI image...
24.5MiB / 24.5MiB [====================================================================] 100 % 0.0 b/s 0s
INFO:    Extracting OCI image...
INFO:    Inserting Apptainer configuration...
INFO:    Running post scriptlet
WARNING: Could not find any nv files on this host!
FATAL:   exec /.singularity.d/libs/fakeroot failed: a shared library is likely missing in the image
INFO:    If error was from fakeroot, try --ignore-fakeroot-command and
INFO:      maybe use fakeroot inside the %post section as described at
INFO:      https://apptainer.org/docs/user/latest/fakeroot.html#fakeroot-inside-def
FATAL:   While performing build: while running engine: while running %post section: exit status 255

[vagrant@localhost test]$ apptainer -q build --ignore-subuid --nv nvidia.sif nvidia.def
WARNING: Could not find any nv files on this host!
FATAL:   exec /.singularity.d/libs/fakeroot failed: a shared library is likely missing in the image
FATAL:   While performing build: while running engine: while running %post section: exit status 255

[vagrant@localhost test]$ apptainer -s build --ignore-subuid --nv nvidia.sif nvidia.def
FATAL:   exec /.singularity.d/libs/fakeroot failed: a shared library is likely missing in the image
FATAL:   While performing build: while running engine: while running %post section: exit status 255
```