### PR TITLE
Fixed small typo in install.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -216,6 +216,7 @@ On SLE/openSUSE:
 ```sh
 sudo zypper install -y gzip fuse3-devel lzo-devel liblz4-devel \
     xz-devel libzstd-devel
+```
 
 To download the source code from the top level of the Apptainer source
 tree do:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Whilst installing `apptainer` I noticed a small typo in the `INSTALL.md` document where closing backticks for a code block appeared to be missing.
