### PR TITLE
Support parsing nested variables defined inside definition file. (release-1.3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Skip attempting to bind inaccessible mount points when handling the
   `mount hostfs = yes` configuration option.
+- Support parsing nested variables defined inside `%arguments` section of
+  definition file.
 
 ## v1.3.4 - \[2024-09-04\]
 

--- a/internal/pkg/build/args/args_test.go
+++ b/internal/pkg/build/args/args_test.go
@@ -222,7 +222,7 @@ func TestReader(t *testing.T) {
 		{
 			name: "ok case with variables defined in comment lines",
 			input: `
-			%argument
+			%arguments
 				OS_VER=1 #  comment line {{ OS_VER }}
 			%post
 			    	# comment
@@ -233,7 +233,7 @@ func TestReader(t *testing.T) {
 				#should not be replaced as well 
 			`,
 			output: `
-			%argument
+			%arguments
 				OS_VER=1 #  comment line {{ OS_VER }}
 			%post
 			    	# comment


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry picking the commit 5f023a98aa3adbf12d328074ef1e8ac21497e596 from PR https://github.com/apptainer/apptainer/pull/2540

### This fixes or addresses the following GitHub issues:

 - Fixes #2534


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
