### PR TITLE
use multiple environment variable files (from sylabs #2855)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   - `allow user ns`, default value is `yes`, when set to `no`, it will disable
     creation of user namespaces. This will prevent execution of containers with
     the `--userns` or `--fakeroot` flags, and unprivileged installations of Apptainer.
+- It is now possible to use multiple environment variable files using the --env-file
+  flag, files can be specified as a comma-separated list or by using the flag
+  multiple times. Variables defined in later files take precedence.
 
 ## Changes for v1.3.x
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -17,28 +17,28 @@ import (
 
 // actionflags.go contains flag variables for action-like commands to draw from
 var (
-	appName          string
-	bindPaths        []string
-	mounts           []string
-	homePath         string
-	overlayPath      []string
-	scratchPath      []string
-	workdirPath      string
-	cwdPath          string
-	shellPath        string
-	hostname         string
-	network          string
-	networkArgs      []string
-	dns              string
-	security         []string
-	cgroupsTOMLFile  string
-	containLibsPath  []string
-	fuseMount        []string
-	apptainerEnv     map[string]string
-	apptainerEnvFile string
-	noMount          []string
-	dmtcpLaunch      string
-	dmtcpRestart     string
+	appName           string
+	bindPaths         []string
+	mounts            []string
+	homePath          string
+	overlayPath       []string
+	scratchPath       []string
+	workdirPath       string
+	cwdPath           string
+	shellPath         string
+	hostname          string
+	network           string
+	networkArgs       []string
+	dns               string
+	security          []string
+	cgroupsTOMLFile   string
+	containLibsPath   []string
+	fuseMount         []string
+	apptainerEnv      map[string]string
+	apptainerEnvFiles []string
+	noMount           []string
+	dmtcpLaunch       string
+	dmtcpRestart      string
 
 	isBoot          bool
 	isFakeroot      bool
@@ -609,8 +609,8 @@ var actionEnvFlag = cmdline.Flag{
 // --env-file
 var actionEnvFileFlag = cmdline.Flag{
 	ID:           "actionEnvFileFlag",
-	Value:        &apptainerEnvFile,
-	DefaultValue: "",
+	Value:        &apptainerEnvFiles,
+	DefaultValue: []string{},
 	Name:         "env-file",
 	Usage:        "pass environment variables from file to contained process",
 	EnvKeys:      []string{"ENV_FILE"},

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -321,7 +321,7 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 		launch.OptRocm(rocm),
 		launch.OptNoRocm(noRocm),
 		launch.OptContainLibs(containLibsPath),
-		launch.OptEnv(apptainerEnv, apptainerEnvFile, isCleanEnv),
+		launch.OptEnv(apptainerEnv, apptainerEnvFiles, isCleanEnv),
 		launch.OptNoEval(noEval),
 		launch.OptNamespaces(ns),
 		launch.OptNetwork(network, networkArgs),

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -73,8 +73,8 @@ type launchOptions struct {
 
 	// Env is a map of name=value env vars to set in the container.
 	Env map[string]string
-	// EnvFile is a file to read container env vars from.
-	EnvFile string
+	// EnvFiles contains filenames to read container env vars from.
+	EnvFiles []string
 	// CleanEnv starts the container with a clean environment, excluding host env vars.
 	CleanEnv bool
 	// NoEval instructs Apptainer not to shell evaluate args and env vars.
@@ -299,13 +299,13 @@ func OptContainLibs(cl []string) Option {
 
 // OptEnv sets container environment
 //
-// envFile is a path to a file container environment variables to set.
+// envFiles is a slice of paths to files container environment variables to set
 // env is a map of name=value env vars to set.
 // clean removes host variables from the container environment.
-func OptEnv(env map[string]string, envFile string, clean bool) Option {
+func OptEnv(env map[string]string, envFiles []string, clean bool) Option {
 	return func(lo *launchOptions) error {
 		lo.Env = env
-		lo.EnvFile = envFile
+		lo.EnvFiles = envFiles
 		lo.CleanEnv = clean
 		return nil
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/2855

which had an original description of
> It is now possible to use multiple environment variable files using the
  `--env-file` flag, files can be specified as a comma-separated list or
  by using the flag multiple times. Variables defined in later files take
  precedence.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in

- https://github.com/apptainer/apptainer/issues/2546


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
