### PR TITLE
fix: run go-licenses correctly with downloaded go (from sylabs #3266)

### DIFF
--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -15,931 +15,931 @@ The dependencies and their licenses are as follows:
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/Netflix/go-expect/blob/master/LICENSE>
+**License URL:** <https://github.com/Netflix/go-expect/blob/73e0943537d2/LICENSE>
 
 ## github.com/containerd/log
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/containerd/log/blob/master/LICENSE>
+**License URL:** <https://github.com/containerd/log/blob/v0.1.0/LICENSE>
 
 ## github.com/containerd/stargz-snapshotter/estargz
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/containerd/stargz-snapshotter/blob/master/estargz/LICENSE>
+**License URL:** <https://github.com/containerd/stargz-snapshotter/blob/estargz/v0.15.1/estargz/LICENSE>
 
 ## github.com/containernetworking/cni
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/containernetworking/cni/blob/master/LICENSE>
+**License URL:** <https://github.com/containernetworking/cni/blob/v1.2.3/LICENSE>
 
 ## github.com/containernetworking/plugins
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/containernetworking/plugins/blob/master/LICENSE>
+**License URL:** <https://github.com/containernetworking/plugins/blob/v1.5.1/LICENSE>
 
 ## github.com/containers/image/v5
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/containers/image/blob/master/v5/LICENSE>
+**License URL:** <https://github.com/containers/image/blob/v5.31.1/LICENSE>
 
 ## github.com/containers/libtrust
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/containers/libtrust/blob/master/LICENSE>
+**License URL:** <https://github.com/containers/libtrust/blob/c1716e8a8d01/LICENSE>
 
 ## github.com/containers/ocicrypt
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/containers/ocicrypt/blob/master/LICENSE>
+**License URL:** <https://github.com/containers/ocicrypt/blob/v1.1.10/LICENSE>
 
 ## github.com/containers/storage/pkg
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/containers/storage/blob/master/pkg/LICENSE>
+**License URL:** <https://github.com/containers/storage/blob/v1.54.0/LICENSE>
 
 ## github.com/coreos/go-iptables/iptables
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/coreos/go-iptables/blob/master/iptables/LICENSE>
+**License URL:** <https://github.com/coreos/go-iptables/blob/v0.7.0/LICENSE>
 
 ## github.com/coreos/go-systemd/v22/dbus
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/coreos/go-systemd/blob/master/v22/dbus/LICENSE>
+**License URL:** <https://github.com/coreos/go-systemd/blob/v22.5.0/LICENSE>
 
 ## github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/cyberphone/json-canonicalization/blob/master/go/src/webpki.org/jsoncanonicalizer/LICENSE>
+**License URL:** <https://github.com/cyberphone/json-canonicalization/blob/ba74d44ecf5f/LICENSE>
 
 ## github.com/distribution/reference
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/distribution/reference/blob/master/LICENSE>
+**License URL:** <https://github.com/distribution/reference/blob/v0.6.0/LICENSE>
 
 ## github.com/docker/cli/cli/config
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/docker/cli/blob/master/cli/config/LICENSE>
+**License URL:** <https://github.com/docker/cli/blob/v27.3.1/LICENSE>
 
 ## github.com/docker/distribution
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/docker/distribution/blob/master/LICENSE>
+**License URL:** <https://github.com/docker/distribution/blob/v2.8.3/LICENSE>
 
 ## github.com/docker/docker
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/docker/docker/blob/master/LICENSE>
+**License URL:** <https://github.com/docker/docker/blob/v27.3.1/LICENSE>
 
 ## github.com/docker/go-connections
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/docker/go-connections/blob/master/LICENSE>
+**License URL:** <https://github.com/docker/go-connections/blob/v0.5.0/LICENSE>
 
 ## github.com/docker/go-metrics
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/docker/go-metrics/blob/master/LICENSE>
+**License URL:** <https://github.com/docker/go-metrics/blob/v0.0.1/LICENSE>
 
 ## github.com/docker/go-units
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/docker/go-units/blob/master/LICENSE>
+**License URL:** <https://github.com/docker/go-units/blob/v0.5.0/LICENSE>
 
 ## github.com/docker/libtrust
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/docker/libtrust/blob/master/LICENSE>
+**License URL:** <https://github.com/docker/libtrust/blob/aabc10ec26b7/LICENSE>
 
 ## github.com/go-jose/go-jose/v3
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-jose/go-jose/blob/master/v3/LICENSE>
+**License URL:** <https://github.com/go-jose/go-jose/blob/v3.0.3/LICENSE>
 
 ## github.com/go-logr/logr
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-logr/logr/blob/master/LICENSE>
+**License URL:** <https://github.com/go-logr/logr/blob/v1.4.1/LICENSE>
 
 ## github.com/go-logr/stdr
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-logr/stdr/blob/master/LICENSE>
+**License URL:** <https://github.com/go-logr/stdr/blob/v1.2.2/LICENSE>
 
 ## github.com/go-openapi/analysis
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/analysis/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/analysis/blob/v0.23.0/LICENSE>
 
 ## github.com/go-openapi/errors
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/errors/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/errors/blob/v0.22.0/LICENSE>
 
 ## github.com/go-openapi/jsonpointer
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/jsonpointer/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/jsonpointer/blob/v0.21.0/LICENSE>
 
 ## github.com/go-openapi/jsonreference
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/jsonreference/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/jsonreference/blob/v0.21.0/LICENSE>
 
 ## github.com/go-openapi/loads
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/loads/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/loads/blob/v0.22.0/LICENSE>
 
 ## github.com/go-openapi/runtime
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/runtime/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/runtime/blob/v0.28.0/LICENSE>
 
 ## github.com/go-openapi/spec
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/spec/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/spec/blob/v0.21.0/LICENSE>
 
 ## github.com/go-openapi/strfmt
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/strfmt/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/strfmt/blob/v0.23.0/LICENSE>
 
 ## github.com/go-openapi/swag
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/swag/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/swag/blob/v0.23.0/LICENSE>
 
 ## github.com/go-openapi/validate
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/go-openapi/validate/blob/master/LICENSE>
+**License URL:** <https://github.com/go-openapi/validate/blob/v0.24.0/LICENSE>
 
 ## github.com/google/go-containerregistry
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/google/go-containerregistry/blob/master/LICENSE>
+**License URL:** <https://github.com/google/go-containerregistry/blob/v0.20.2/LICENSE>
 
 ## github.com/gosimple/unidecode
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/gosimple/unidecode/blob/master/LICENSE>
+**License URL:** <https://github.com/gosimple/unidecode/blob/v1.0.1/LICENSE>
 
 ## github.com/klauspost/compress
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/klauspost/compress/blob/master/LICENSE>
+**License URL:** <https://github.com/klauspost/compress/blob/v1.17.8/LICENSE>
 
 ## github.com/moby/docker-image-spec/specs-go/v1
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/moby/docker-image-spec/blob/master/specs-go/v1/LICENSE>
+**License URL:** <https://github.com/moby/docker-image-spec/blob/v1.3.1/LICENSE>
 
 ## github.com/moby/patternmatcher
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/moby/patternmatcher/blob/master/LICENSE>
+**License URL:** <https://github.com/moby/patternmatcher/blob/v0.5.0/LICENSE>
 
 ## github.com/moby/sys/mountinfo
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/moby/sys/blob/master/mountinfo/LICENSE>
+**License URL:** <https://github.com/moby/sys/blob/mountinfo/v0.7.1/mountinfo/LICENSE>
 
 ## github.com/moby/sys/sequential
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/moby/sys/blob/master/sequential/LICENSE>
+**License URL:** <https://github.com/moby/sys/blob/sequential/v0.5.0/sequential/LICENSE>
 
 ## github.com/moby/sys/user
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/moby/sys/blob/master/user/LICENSE>
+**License URL:** <https://github.com/moby/sys/blob/user/v0.1.0/user/LICENSE>
 
 ## github.com/moby/sys/userns
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/moby/sys/blob/master/userns/LICENSE>
+**License URL:** <https://github.com/moby/sys/blob/userns/v0.1.0/userns/LICENSE>
 
 ## github.com/modern-go/concurrent
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/modern-go/concurrent/blob/master/LICENSE>
+**License URL:** <https://github.com/modern-go/concurrent/blob/bacd9c7ef1dd/LICENSE>
 
 ## github.com/modern-go/reflect2
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/modern-go/reflect2/blob/master/LICENSE>
+**License URL:** <https://github.com/modern-go/reflect2/blob/v1.0.2/LICENSE>
 
 ## github.com/oklog/ulid
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/oklog/ulid/blob/master/LICENSE>
+**License URL:** <https://github.com/oklog/ulid/blob/v1.3.1/LICENSE>
 
 ## github.com/opencontainers/go-digest
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/opencontainers/go-digest/blob/master/LICENSE>
+**License URL:** <https://github.com/opencontainers/go-digest/blob/v1.0.0/LICENSE>
 
 ## github.com/opencontainers/image-spec/specs-go
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/opencontainers/image-spec/blob/master/specs-go/LICENSE>
+**License URL:** <https://github.com/opencontainers/image-spec/blob/v1.1.0/LICENSE>
 
 ## github.com/opencontainers/runc/libcontainer
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/opencontainers/runc/blob/master/libcontainer/LICENSE>
+**License URL:** <https://github.com/opencontainers/runc/blob/v1.1.15/LICENSE>
 
 ## github.com/opencontainers/runtime-spec/specs-go
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/opencontainers/runtime-spec/blob/master/specs-go/LICENSE>
+**License URL:** <https://github.com/opencontainers/runtime-spec/blob/v1.2.0/LICENSE>
 
 ## github.com/opencontainers/umoci
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/opencontainers/umoci/blob/master/COPYING>
+**License URL:** <https://github.com/opencontainers/umoci/blob/v0.4.7/COPYING>
 
 ## github.com/opencontainers/umoci/third_party/shared
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/opencontainers/umoci/blob/master/third_party/shared/COPYING>
+**License URL:** <https://github.com/opencontainers/umoci/blob/v0.4.7/third_party/shared/COPYING>
 
 ## github.com/prometheus/client_golang/prometheus
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/prometheus/client_golang/blob/master/prometheus/LICENSE>
+**License URL:** <https://github.com/prometheus/client_golang/blob/v1.19.0/LICENSE>
 
 ## github.com/prometheus/client_model/go
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/prometheus/client_model/blob/master/go/LICENSE>
+**License URL:** <https://github.com/prometheus/client_model/blob/v0.6.0/LICENSE>
 
 ## github.com/prometheus/common
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/prometheus/common/blob/master/LICENSE>
+**License URL:** <https://github.com/prometheus/common/blob/v0.51.1/LICENSE>
 
 ## github.com/prometheus/procfs
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/prometheus/procfs/blob/master/LICENSE>
+**License URL:** <https://github.com/prometheus/procfs/blob/v0.12.0/LICENSE>
 
 ## github.com/rootless-containers/proto/go-proto
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/rootless-containers/proto/blob/master/go-proto/COPYING>
+**License URL:** <https://github.com/rootless-containers/proto/blob/v0.1.0/COPYING>
 
 ## github.com/safchain/ethtool
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/safchain/ethtool/blob/master/LICENSE>
+**License URL:** <https://github.com/safchain/ethtool/blob/v0.4.0/LICENSE>
 
 ## github.com/seccomp/containers-golang
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/seccomp/containers-golang/blob/master/LICENSE>
+**License URL:** <https://github.com/seccomp/containers-golang/blob/v0.6.0/LICENSE>
 
 ## github.com/sigstore/fulcio/pkg/certificate
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/sigstore/fulcio/blob/master/pkg/certificate/LICENSE>
+**License URL:** <https://github.com/sigstore/fulcio/blob/v1.4.5/LICENSE>
 
 ## github.com/sigstore/rekor/pkg/generated/models
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/sigstore/rekor/blob/master/pkg/generated/models/LICENSE>
+**License URL:** <https://github.com/sigstore/rekor/blob/v1.3.6/LICENSE>
 
 ## github.com/sigstore/sigstore/pkg
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/sigstore/sigstore/blob/master/pkg/LICENSE>
+**License URL:** <https://github.com/sigstore/sigstore/blob/v1.8.4/LICENSE>
 
 ## github.com/spf13/cobra
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/spf13/cobra/blob/master/LICENSE.txt>
+**License URL:** <https://github.com/spf13/cobra/blob/v1.8.1/LICENSE.txt>
 
 ## github.com/stefanberger/go-pkcs11uri
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/stefanberger/go-pkcs11uri/blob/master/LICENSE>
+**License URL:** <https://github.com/stefanberger/go-pkcs11uri/blob/78d3cae3a980/LICENSE>
 
 ## github.com/vbatts/go-mtree/pkg/govis
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/vbatts/go-mtree/blob/master/pkg/govis/COPYING>
+**License URL:** <https://github.com/vbatts/go-mtree/blob/v0.5.0/pkg/govis/COPYING>
 
 ## github.com/vishvananda/netlink
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/vishvananda/netlink/blob/master/LICENSE>
+**License URL:** <https://github.com/vishvananda/netlink/blob/v1.2.1-beta.2/LICENSE>
 
 ## github.com/vishvananda/netns
 
 **License:** Apache-2.0
 
-**License URL:** <https://github.com/vishvananda/netns/blob/master/LICENSE>
+**License URL:** <https://github.com/vishvananda/netns/blob/v0.0.4/LICENSE>
 
 ## go.mongodb.org/mongo-driver
 
 **License:** Apache-2.0
 
-**Project URL:** <https://go.mongodb.org/mongo-driver>
+**License URL:** <https://github.com/mongodb/mongo-go-driver/blob/v1.14.0/LICENSE>
 
 ## go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 
 **License:** Apache-2.0
 
-**Project URL:** <https://go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp>
+**License URL:** <https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.49.0/instrumentation/net/http/otelhttp/LICENSE>
 
 ## go.opentelemetry.io/otel
 
 **License:** Apache-2.0
 
-**Project URL:** <https://go.opentelemetry.io/otel>
+**License URL:** <https://github.com/open-telemetry/opentelemetry-go/blob/v1.24.0/LICENSE>
 
 ## go.opentelemetry.io/otel/metric
 
 **License:** Apache-2.0
 
-**Project URL:** <https://go.opentelemetry.io/otel/metric>
+**License URL:** <https://github.com/open-telemetry/opentelemetry-go/blob/metric/v1.24.0/metric/LICENSE>
 
 ## go.opentelemetry.io/otel/trace
 
 **License:** Apache-2.0
 
-**Project URL:** <https://go.opentelemetry.io/otel/trace>
+**License URL:** <https://github.com/open-telemetry/opentelemetry-go/blob/trace/v1.24.0/trace/LICENSE>
 
 ## google.golang.org/genproto/googleapis/rpc/status
 
 **License:** Apache-2.0
 
-**Project URL:** <https://google.golang.org/genproto/googleapis/rpc/status>
+**License URL:** <https://github.com/googleapis/go-genproto/blob/94a12d6c2237/googleapis/rpc/LICENSE>
 
 ## google.golang.org/grpc
 
 **License:** Apache-2.0
 
-**Project URL:** <https://google.golang.org/grpc>
+**License URL:** <https://github.com/grpc/grpc-go/blob/v1.62.1/LICENSE>
 
 ## gopkg.in/go-jose/go-jose.v2
 
 **License:** Apache-2.0
 
-**Project URL:** <https://gopkg.in/go-jose/go-jose.v2>
+**License URL:** <https://github.com/go-jose/go-jose/blob/v2.6.3/LICENSE>
 
 ## gopkg.in/yaml.v2
 
 **License:** Apache-2.0
 
-**Project URL:** <https://gopkg.in/yaml.v2>
+**License URL:** <https://github.com/go-yaml/yaml/blob/v2.4.0/LICENSE>
 
 ## gotest.tools/v3
 
 **License:** Apache-2.0
 
-**Project URL:** <https://gotest.tools/v3>
+**License URL:** <https://github.com/gotestyourself/gotest.tools/blob/v3.5.1/LICENSE>
 
 ## github.com/godbus/dbus/v5
 
 **License:** BSD-2-Clause
 
-**License URL:** <https://github.com/godbus/dbus/blob/master/v5/LICENSE>
+**License URL:** <https://github.com/godbus/dbus/blob/v5.1.0/LICENSE>
 
 ## github.com/gorilla/handlers
 
 **License:** BSD-2-Clause
 
-**License URL:** <https://github.com/gorilla/handlers/blob/master/LICENSE>
+**License URL:** <https://github.com/gorilla/handlers/blob/v1.5.1/LICENSE>
 
 ## github.com/pkg/errors
 
 **License:** BSD-2-Clause
 
-**License URL:** <https://github.com/pkg/errors/blob/master/LICENSE>
+**License URL:** <https://github.com/pkg/errors/blob/v0.9.1/LICENSE>
 
 ## github.com/russross/blackfriday/v2
 
 **License:** BSD-2-Clause
 
-**License URL:** <https://github.com/russross/blackfriday/blob/master/v2/LICENSE.txt>
+**License URL:** <https://github.com/russross/blackfriday/blob/v2.1.0/LICENSE.txt>
 
 ## github.com/syndtr/gocapability/capability
 
 **License:** BSD-2-Clause
 
-**License URL:** <https://github.com/syndtr/gocapability/blob/master/capability/LICENSE>
+**License URL:** <https://github.com/syndtr/gocapability/blob/42c35b437635/LICENSE>
 
 ## github.com/ProtonMail/go-crypto
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/ProtonMail/go-crypto/blob/master/LICENSE>
+**License URL:** <https://github.com/ProtonMail/go-crypto/blob/v1.0.0/LICENSE>
 
 ## github.com/apptainer/container-key-client/client
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/apptainer/container-key-client/blob/master/client/LICENSE.md>
+**License URL:** <https://github.com/apptainer/container-key-client/blob/v0.8.0/LICENSE.md>
 
 ## github.com/apptainer/container-library-client/client
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/apptainer/container-library-client/blob/master/client/LICENSE.md>
+**License URL:** <https://github.com/apptainer/container-library-client/blob/v1.4.6/LICENSE.md>
 
 ## github.com/apptainer/sif/v2
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/apptainer/sif/blob/master/v2/LICENSE.md>
+**License URL:** <https://github.com/apptainer/sif/blob/v2.15.2/LICENSE.md>
 
 ## github.com/cloudflare/circl
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/cloudflare/circl/blob/master/LICENSE>
+**License URL:** <https://github.com/cloudflare/circl/blob/v1.3.7/LICENSE>
 
 ## github.com/cyphar/filepath-securejoin
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/cyphar/filepath-securejoin/blob/master/LICENSE>
+**License URL:** <https://github.com/cyphar/filepath-securejoin/blob/v0.3.4/LICENSE>
 
 ## github.com/go-jose/go-jose/v3/json
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/go-jose/go-jose/blob/master/v3/json/LICENSE>
+**License URL:** <https://github.com/go-jose/go-jose/blob/v3.0.3/json/LICENSE>
 
 ## github.com/gogo/protobuf/proto
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/gogo/protobuf/blob/master/proto/LICENSE>
+**License URL:** <https://github.com/gogo/protobuf/blob/v1.3.2/LICENSE>
 
 ## github.com/golang/protobuf/proto
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/golang/protobuf/blob/master/proto/LICENSE>
+**License URL:** <https://github.com/golang/protobuf/blob/v1.5.4/LICENSE>
 
 ## github.com/google/go-cmp/cmp
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/google/go-cmp/blob/master/cmp/LICENSE>
+**License URL:** <https://github.com/google/go-cmp/blob/v0.6.0/LICENSE>
 
 ## github.com/google/uuid
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/google/uuid/blob/master/LICENSE>
+**License URL:** <https://github.com/google/uuid/blob/v1.6.0/LICENSE>
 
 ## github.com/gorilla/mux
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/gorilla/mux/blob/master/LICENSE>
+**License URL:** <https://github.com/gorilla/mux/blob/v1.8.1/LICENSE>
 
 ## github.com/klauspost/compress/internal/snapref
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/klauspost/compress/blob/master/internal/snapref/LICENSE>
+**License URL:** <https://github.com/klauspost/compress/blob/v1.17.8/internal/snapref/LICENSE>
 
 ## github.com/miekg/pkcs11
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/miekg/pkcs11/blob/master/LICENSE>
+**License URL:** <https://github.com/miekg/pkcs11/blob/v1.1.1/LICENSE>
 
 ## github.com/proglottis/gpgme
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/proglottis/gpgme/blob/master/LICENSE>
+**License URL:** <https://github.com/proglottis/gpgme/blob/v0.1.3/LICENSE>
 
 ## github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/prometheus/common/blob/master/internal/bitbucket.org/ww/goautoneg/README.txt>
+**License URL:** <https://github.com/prometheus/common/blob/v0.51.1/internal/bitbucket.org/ww/goautoneg/README.txt>
 
 ## github.com/spf13/pflag
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/spf13/pflag/blob/master/LICENSE>
+**License URL:** <https://github.com/spf13/pflag/blob/v1.0.5/LICENSE>
 
 ## github.com/sylabs/json-resp
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/sylabs/json-resp/blob/master/LICENSE.md>
+**License URL:** <https://github.com/sylabs/json-resp/blob/v0.9.4/LICENSE.md>
 
 ## github.com/ulikunitz/xz
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/ulikunitz/xz/blob/master/LICENSE>
+**License URL:** <https://github.com/ulikunitz/xz/blob/v0.5.12/LICENSE>
 
 ## github.com/vbatts/go-mtree
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/vbatts/go-mtree/blob/master/LICENSE>
+**License URL:** <https://github.com/vbatts/go-mtree/blob/v0.5.0/LICENSE>
 
 ## github.com/vbatts/tar-split
 
 **License:** BSD-3-Clause
 
-**License URL:** <https://github.com/vbatts/tar-split/blob/master/LICENSE>
+**License URL:** <https://github.com/vbatts/tar-split/blob/v0.11.5/LICENSE>
 
 ## golang.org/x/crypto
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://golang.org/x/crypto>
+**License URL:** <https://cs.opensource.google/go/x/crypto/+/v0.28.0:LICENSE>
 
 ## golang.org/x/exp/maps
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://golang.org/x/exp/maps>
+**License URL:** <https://cs.opensource.google/go/x/exp/+/9bf2ced1:LICENSE>
 
 ## golang.org/x/net
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://golang.org/x/net>
+**License URL:** <https://cs.opensource.google/go/x/net/+/v0.25.0:LICENSE>
 
 ## golang.org/x/sync
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://golang.org/x/sync>
+**License URL:** <https://cs.opensource.google/go/x/sync/+/v0.8.0:LICENSE>
 
 ## golang.org/x/sys
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://golang.org/x/sys>
+**License URL:** <https://cs.opensource.google/go/x/sys/+/v0.26.0:LICENSE>
 
 ## golang.org/x/term
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://golang.org/x/term>
+**License URL:** <https://cs.opensource.google/go/x/term/+/v0.25.0:LICENSE>
 
 ## golang.org/x/text
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://golang.org/x/text>
+**License URL:** <https://cs.opensource.google/go/x/text/+/v0.19.0:LICENSE>
 
 ## google.golang.org/protobuf
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://google.golang.org/protobuf>
+**License URL:** <https://github.com/protocolbuffers/protobuf-go/blob/v1.33.0/LICENSE>
 
 ## gopkg.in/go-jose/go-jose.v2/json
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://gopkg.in/go-jose/go-jose.v2/json>
+**License URL:** <https://github.com/go-jose/go-jose/blob/v2.6.3/json/LICENSE>
 
 ## gotest.tools/v3/internal/difflib
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://gotest.tools/v3/internal/difflib>
+**License URL:** <https://github.com/gotestyourself/gotest.tools/blob/v3.5.1/internal/difflib/LICENSE>
 
 ## mvdan.cc/sh/v3
 
 **License:** BSD-3-Clause
 
-**Project URL:** <https://mvdan.cc/sh/v3>
+**License URL:** <https://github.com/mvdan/sh/blob/v3.8.0/LICENSE>
 
 ## github.com/BurntSushi/toml
 
 **License:** MIT
 
-**License URL:** <https://github.com/BurntSushi/toml/blob/master/COPYING>
+**License URL:** <https://github.com/BurntSushi/toml/blob/v1.4.0/COPYING>
 
 ## github.com/VividCortex/ewma
 
 **License:** MIT
 
-**License URL:** <https://github.com/VividCortex/ewma/blob/master/LICENSE>
+**License URL:** <https://github.com/VividCortex/ewma/blob/v1.2.0/LICENSE>
 
 ## github.com/acarl005/stripansi
 
 **License:** MIT
 
-**License URL:** <https://github.com/acarl005/stripansi/blob/master/LICENSE>
+**License URL:** <https://github.com/acarl005/stripansi/blob/5a71ef0e047d/LICENSE>
 
 ## github.com/adigunhammedolalekan/registry-auth
 
 **License:** MIT
 
-**License URL:** <https://github.com/adigunhammedolalekan/registry-auth/blob/master/LICENSE>
+**License URL:** <https://github.com/adigunhammedolalekan/registry-auth/blob/8cde180a3a60/LICENSE>
 
 ## github.com/apex/log
 
 **License:** MIT
 
-**License URL:** <https://github.com/apex/log/blob/master/LICENSE>
+**License URL:** <https://github.com/apex/log/blob/v1.9.0/LICENSE>
 
 ## github.com/asaskevich/govalidator
 
 **License:** MIT
 
-**License URL:** <https://github.com/asaskevich/govalidator/blob/master/LICENSE>
+**License URL:** <https://github.com/asaskevich/govalidator/blob/a9d515a09cc2/LICENSE>
 
 ## github.com/astromechza/etcpwdparse
 
 **License:** MIT
 
-**License URL:** <https://github.com/astromechza/etcpwdparse/blob/master/LICENSE.md>
+**License URL:** <https://github.com/astromechza/etcpwdparse/blob/f0e5f0779716/LICENSE.md>
 
 ## github.com/beorn7/perks/quantile
 
 **License:** MIT
 
-**License URL:** <https://github.com/beorn7/perks/blob/master/quantile/LICENSE>
+**License URL:** <https://github.com/beorn7/perks/blob/v1.0.1/LICENSE>
 
 ## github.com/blang/semver/v4
 
 **License:** MIT
 
-**License URL:** <https://github.com/blang/semver/blob/master/v4/LICENSE>
+**License URL:** <https://github.com/blang/semver/blob/v4.0.0/v4/LICENSE>
 
 ## github.com/buger/goterm
 
 **License:** MIT
 
-**License URL:** <https://github.com/buger/goterm/blob/master/LICENSE>
+**License URL:** <https://github.com/buger/goterm/blob/v1.0.4/LICENSE>
 
 ## github.com/buger/jsonparser
 
 **License:** MIT
 
-**License URL:** <https://github.com/buger/jsonparser/blob/master/LICENSE>
+**License URL:** <https://github.com/buger/jsonparser/blob/v1.1.1/LICENSE>
 
 ## github.com/cenkalti/backoff/v4
 
 **License:** MIT
 
-**License URL:** <https://github.com/cenkalti/backoff/blob/master/v4/LICENSE>
+**License URL:** <https://github.com/cenkalti/backoff/blob/v4.3.0/LICENSE>
 
 ## github.com/cespare/xxhash/v2
 
 **License:** MIT
 
-**License URL:** <https://github.com/cespare/xxhash/blob/master/v2/LICENSE.txt>
+**License URL:** <https://github.com/cespare/xxhash/blob/v2.2.0/LICENSE.txt>
 
 ## github.com/cilium/ebpf
 
 **License:** MIT
 
-**License URL:** <https://github.com/cilium/ebpf/blob/master/LICENSE>
+**License URL:** <https://github.com/cilium/ebpf/blob/v0.9.1/LICENSE>
 
 ## github.com/cpuguy83/go-md2man/v2/md2man
 
 **License:** MIT
 
-**License URL:** <https://github.com/cpuguy83/go-md2man/blob/master/v2/md2man/LICENSE.md>
+**License URL:** <https://github.com/cpuguy83/go-md2man/blob/v2.0.4/LICENSE.md>
 
 ## github.com/creack/pty
 
 **License:** MIT
 
-**License URL:** <https://github.com/creack/pty/blob/master/LICENSE>
+**License URL:** <https://github.com/creack/pty/blob/v1.1.23/LICENSE>
 
 ## github.com/docker/docker-credential-helpers
 
 **License:** MIT
 
-**License URL:** <https://github.com/docker/docker-credential-helpers/blob/master/LICENSE>
+**License URL:** <https://github.com/docker/docker-credential-helpers/blob/v0.8.1/LICENSE>
 
 ## github.com/fatih/color
 
 **License:** MIT
 
-**License URL:** <https://github.com/fatih/color/blob/master/LICENSE.md>
+**License URL:** <https://github.com/fatih/color/blob/v1.17.0/LICENSE.md>
 
 ## github.com/felixge/httpsnoop
 
 **License:** MIT
 
-**License URL:** <https://github.com/felixge/httpsnoop/blob/master/LICENSE.txt>
+**License URL:** <https://github.com/felixge/httpsnoop/blob/v1.0.4/LICENSE.txt>
 
 ## github.com/go-log/log
 
 **License:** MIT
 
-**License URL:** <https://github.com/go-log/log/blob/master/LICENSE>
+**License URL:** <https://github.com/go-log/log/blob/v0.2.0/LICENSE>
 
 ## github.com/josharian/intern
 
 **License:** MIT
 
-**License URL:** <https://github.com/josharian/intern/blob/master/license.md>
+**License URL:** <https://github.com/josharian/intern/blob/v1.0.0/license.md>
 
 ## github.com/json-iterator/go
 
 **License:** MIT
 
-**License URL:** <https://github.com/json-iterator/go/blob/master/LICENSE>
+**License URL:** <https://github.com/json-iterator/go/blob/v1.1.12/LICENSE>
 
 ## github.com/klauspost/compress/zstd/internal/xxhash
 
 **License:** MIT
 
-**License URL:** <https://github.com/klauspost/compress/blob/master/zstd/internal/xxhash/LICENSE.txt>
+**License URL:** <https://github.com/klauspost/compress/blob/v1.17.8/zstd/internal/xxhash/LICENSE.txt>
 
 ## github.com/klauspost/pgzip
 
 **License:** MIT
 
-**License URL:** <https://github.com/klauspost/pgzip/blob/master/LICENSE>
+**License URL:** <https://github.com/klauspost/pgzip/blob/v1.2.6/LICENSE>
 
 ## github.com/mailru/easyjson
 
 **License:** MIT
 
-**License URL:** <https://github.com/mailru/easyjson/blob/master/LICENSE>
+**License URL:** <https://github.com/mailru/easyjson/blob/v0.7.7/LICENSE>
 
 ## github.com/mattn/go-colorable
 
 **License:** MIT
 
-**License URL:** <https://github.com/mattn/go-colorable/blob/master/LICENSE>
+**License URL:** <https://github.com/mattn/go-colorable/blob/v0.1.13/LICENSE>
 
 ## github.com/mattn/go-isatty
 
 **License:** MIT
 
-**License URL:** <https://github.com/mattn/go-isatty/blob/master/LICENSE>
+**License URL:** <https://github.com/mattn/go-isatty/blob/v0.0.20/LICENSE>
 
 ## github.com/mattn/go-runewidth
 
 **License:** MIT
 
-**License URL:** <https://github.com/mattn/go-runewidth/blob/master/LICENSE>
+**License URL:** <https://github.com/mattn/go-runewidth/blob/v0.0.16/LICENSE>
 
 ## github.com/mattn/go-sqlite3
 
 **License:** MIT
 
-**License URL:** <https://github.com/mattn/go-sqlite3/blob/master/LICENSE>
+**License URL:** <https://github.com/mattn/go-sqlite3/blob/v1.14.22/LICENSE>
 
 ## github.com/mitchellh/go-homedir
 
 **License:** MIT
 
-**License URL:** <https://github.com/mitchellh/go-homedir/blob/master/LICENSE>
+**License URL:** <https://github.com/mitchellh/go-homedir/blob/v1.1.0/LICENSE>
 
 ## github.com/mitchellh/mapstructure
 
 **License:** MIT
 
-**License URL:** <https://github.com/mitchellh/mapstructure/blob/master/LICENSE>
+**License URL:** <https://github.com/mitchellh/mapstructure/blob/v1.5.0/LICENSE>
 
 ## github.com/pelletier/go-toml/v2
 
 **License:** MIT
 
-**License URL:** <https://github.com/pelletier/go-toml/blob/master/v2/LICENSE>
+**License URL:** <https://github.com/pelletier/go-toml/blob/v2.2.2/LICENSE>
 
 ## github.com/rivo/uniseg
 
 **License:** MIT
 
-**License URL:** <https://github.com/rivo/uniseg/blob/master/LICENSE.txt>
+**License URL:** <https://github.com/rivo/uniseg/blob/v0.4.7/LICENSE.txt>
 
 ## github.com/samber/lo
 
 **License:** MIT
 
-**License URL:** <https://github.com/samber/lo/blob/master/LICENSE>
+**License URL:** <https://github.com/samber/lo/blob/v1.47.0/LICENSE>
 
 ## github.com/secure-systems-lab/go-securesystemslib
 
 **License:** MIT
 
-**License URL:** <https://github.com/secure-systems-lab/go-securesystemslib/blob/master/LICENSE>
+**License URL:** <https://github.com/secure-systems-lab/go-securesystemslib/blob/v0.8.0/LICENSE>
 
 ## github.com/shopspring/decimal
 
 **License:** MIT
 
-**License URL:** <https://github.com/shopspring/decimal/blob/master/LICENSE>
+**License URL:** <https://github.com/shopspring/decimal/blob/v1.4.0/LICENSE>
 
 ## github.com/sirupsen/logrus
 
 **License:** MIT
 
-**License URL:** <https://github.com/sirupsen/logrus/blob/master/LICENSE>
+**License URL:** <https://github.com/sirupsen/logrus/blob/v1.9.3/LICENSE>
 
 ## github.com/titanous/rocacheck
 
 **License:** MIT
 
-**License URL:** <https://github.com/titanous/rocacheck/blob/master/LICENSE>
+**License URL:** <https://github.com/titanous/rocacheck/blob/afe73141d399/LICENSE>
 
 ## go.mozilla.org/pkcs7
 
 **License:** MIT
 
-**Project URL:** <https://go.mozilla.org/pkcs7>
+**License URL:** <https://github.com/mozilla-services/pkcs7/blob/33d05740a352/LICENSE>
 
 ## gopkg.in/yaml.v3
 
 **License:** MIT
 
-**Project URL:** <https://gopkg.in/yaml.v3>
+**License URL:** <https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE>
 
 ## github.com/gosimple/slug
 
 **License:** MPL-2.0
 
-**License URL:** <https://github.com/gosimple/slug/blob/master/LICENSE>
+**License URL:** <https://github.com/gosimple/slug/blob/v1.14.0/LICENSE>
 
 ## github.com/letsencrypt/boulder
 
 **License:** MPL-2.0
 
-**License URL:** <https://github.com/letsencrypt/boulder/blob/master/LICENSE.txt>
+**License URL:** <https://github.com/letsencrypt/boulder/blob/6d76a0f91e1e/LICENSE.txt>
 
 ## github.com/garyburd/redigo/internal
 

--- a/scripts/update-license-dependencies.sh
+++ b/scripts/update-license-dependencies.sh
@@ -3,8 +3,6 @@
 set -e
 set -u
 
-go install github.com/google/go-licenses@v1.0.0
-
 if [ -d "vendor" ]; then
   echo "Please remove vendor directory before running this script"
   exit 255
@@ -23,7 +21,7 @@ exclude="github.com/apptainer/apptainer|github.com/vbauerster/mpb"
 # Ensure a constant sort order
 export LC_ALL=C
 
-go-licenses csv ./... | grep -v -E "${exclude}" | sort -k3,3 -k1,1 -t, > LICENSE_DEPENDENCIES.csv
+$(go env GOROOT)/bin/go run github.com/google/go-licenses@v1.6.0 csv ./... | grep -v -E "${exclude}" | sort -k3,3 -k1,1 -t, > LICENSE_DEPENDENCIES.csv
 
 # Header for the markdown file
 cat <<-'EOF' >LICENSE_DEPENDENCIES.md


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/3266

which had an original description of
> If the go toolchain is downloaded due to installed version vs go.mod then we need to set GOROOT for go-licenses to run correctly.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in

- https://github.com/apptainer/apptainer/issues/2546


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
