### PR TITLE
feat: AllowNetnsPaths/--netns-path (from sylabs #3192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
   rootfs.
 - Fix a regression issue that overwrites source image runscript, environment
   etc. in build from local image.
+- The new `--netns-path` flag takes a path to a network namespace to join when
+  starting a container. The `root` user may join any network namespace. An
+  unprivileged user can only join a network namespace specified in the new
+  `allowed netns paths` directive in `apptainer.conf`, if they are also listed
+  in `allowed net users` / `allowed net groups`, and apptainer is installed with
+  setuid privileges. Not currently supported with `--fakeroot`.
 
 ## Changes for v1.3.x
 
@@ -244,7 +250,7 @@ Changes since v1.2.5
 - Skip parsing build definition file template variables after comments
   beginning with a hash symbol.
 - Improved the clarity of `apptainer key list` output.
-- The global /tmp directory is no longer used for gocryptfs mountpoints.  
+- The global /tmp directory is no longer used for gocryptfs mountpoints.
 - Updated minimum go version to 1.20
 
 ### New Features & Functionality
@@ -259,7 +265,7 @@ Changes since v1.2.5
 - Added `--config` option to`keyserver` commands.
 - Honor an optional remoteName argument to the `keyserver list` command.
 - Added the `APPTAINER_ENCRYPTION_PEM_DATA` env var to allow for encrypting and
-  running encrypted containers without a PEM file.  
+  running encrypted containers without a PEM file.
 - Adding `--sharens` mode for `apptainer exec/run/shell`, which enables to run multiple
   apptainer instances created by the same parent using the same image in the same
   user namespace.

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -60,6 +60,7 @@ var (
 	disableCache    bool
 
 	netNamespace   bool
+	netnsPath      string
 	utsNamespace   bool
 	userNamespace  bool
 	pidNamespace   bool
@@ -843,6 +844,16 @@ var actionRunscriptTimeoutFlag = cmdline.Flag{
 	Hidden:       false,
 }
 
+// --netns-path
+var actionNetnsPathFlag = cmdline.Flag{
+	ID:           "actionNetnsPathFlag",
+	Value:        &netnsPath,
+	DefaultValue: "",
+	Name:         "netns-path",
+	Usage:        "join the network namespace at the specified path (as root, or if permitted in apptainer.conf)",
+	EnvKeys:      []string{"NETNS_PATH"},
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(ExecCmd)
@@ -885,6 +896,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionKeepPrivsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionMountFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNetNamespaceFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionNetnsPathFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNetworkArgsFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNetworkFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionNoHomeFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -324,6 +324,7 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 		launch.OptEnv(apptainerEnv, apptainerEnvFiles, isCleanEnv),
 		launch.OptNoEval(noEval),
 		launch.OptNamespaces(ns),
+		launch.OptNetnsPath(netnsPath),
 		launch.OptNetwork(network, networkArgs),
 		launch.OptHostname(hostname),
 		launch.OptDNS(dns),

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2696,6 +2696,11 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 		return nil, nil
 	}
 
+	// If we are joining an existing network namespace, then there is no CNI setup to be done.
+	if _, joinPath := c.engine.hasNamespace(specs.NetworkNamespace); joinPath != "" {
+		return nil, nil
+	}
+
 	// In fakeroot mode only permit the `fakeroot` CNI config, overriding any other request.
 	euid := os.Geteuid()
 	fakeroot := c.engine.EngineConfig.GetFakeroot()

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -48,6 +48,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/util/capabilities"
 	"github.com/apptainer/apptainer/pkg/util/fs/proc"
 	"github.com/apptainer/apptainer/pkg/util/namespaces"
+	"github.com/apptainer/apptainer/pkg/util/slice"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 )
@@ -554,14 +555,56 @@ func (e *EngineOperations) removeNamespace(namespaceType specs.LinuxNamespaceTyp
 }
 
 // hasNamespaces checks for existence of a specific namespace in the namespaces slice.
-func (e *EngineOperations) hasNamespace(namespaceType specs.LinuxNamespaceType) bool {
+func (e *EngineOperations) hasNamespace(namespaceType specs.LinuxNamespaceType) (bool, string) {
 	namespaces := e.EngineConfig.OciConfig.Linux.Namespaces
 	for _, ns := range namespaces {
 		if namespaceType == ns.Type {
-			return true
+			return true, ns.Path
 		}
 	}
-	return false
+	return false, ""
+}
+
+func (e *EngineOperations) joinNetns(starterConfig *starter.Config) error {
+	// No netns path requested - nothing to validate here.
+	ok, netnsPath := e.hasNamespace(specs.NetworkNamespace)
+	if !ok || netnsPath == "" {
+		return nil
+	}
+
+	// The netns path must already exist.
+	_, err := os.Stat(netnsPath)
+	if err != nil {
+		return fmt.Errorf("while checking netns path: %w", err)
+	}
+
+	// Root can join any network namespace.
+	euid := os.Geteuid()
+	if euid == 0 {
+		return starterConfig.SetNsPath(specs.NetworkNamespace, netnsPath)
+	}
+
+	// Is the user permitted in the list of unpriv users / groups permitted to join netns?
+	allowedNetUser, err := user.UIDInList(euid, e.EngineConfig.File.AllowNetUsers)
+	if err != nil {
+		return err
+	}
+	allowedNetGroup, err := user.UIDInAnyGroup(euid, e.EngineConfig.File.AllowNetGroups)
+	if err != nil {
+		return err
+	}
+	// Is the netns path permitted in apptainer conf?
+	permittedPath := slice.ContainsString(e.EngineConfig.File.AllowNetnsPaths, netnsPath)
+
+	if !permittedPath {
+		return fmt.Errorf("%q is not an allowed netns path in singularity.conf", netnsPath)
+	}
+
+	if !(allowedNetUser || allowedNetGroup) {
+		return fmt.Errorf("you are not permitted to join network namespaces in apptainer.conf")
+	}
+
+	return starterConfig.SetNsPath(specs.NetworkNamespace, netnsPath)
 }
 
 // prepareContainerConfig is responsible for getting and applying
@@ -583,7 +626,7 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 		if buildcfg.APPTAINER_SUID_INSTALL == 0 {
 			sylog.Fatalf("Unprivileged installation found, user namepace needed but not allowed by configuration.")
 		}
-		if e.hasNamespace(specs.UserNamespace) {
+		if n, _ := e.hasNamespace(specs.UserNamespace); n {
 			sylog.Fatalf("User namespace required but not allowed by configuration.")
 		}
 	}
@@ -593,6 +636,12 @@ func (e *EngineOperations) prepareContainerConfig(starterConfig *starter.Config)
 		if e.EngineConfig.OciConfig.Hostname != "" {
 			sylog.Warningf("Container hostname cannot be set.")
 		}
+	}
+
+	// Validate and apply any request to join an existing network namespace.
+	// Must be root or authorized in singularity.conf.
+	if err := e.joinNetns(starterConfig); err != nil {
+		return err
 	}
 
 	if os.Getuid() == 0 {

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -955,6 +955,12 @@ func (l *Launcher) setNamespaces() {
 			l.cfg.Network = "bridge"
 			l.engineConfig.SetNetwork(l.cfg.Network)
 		}
+		if l.cfg.NetnsPath != "" {
+			sylog.Warningf("cannot join existing --netns-path and create a new network namespace with --net/-n")
+		}
+		// unprivileged installation could not use fakeroot
+		// network because it requires a setuid installation
+		// so we fallback to none
 		if l.cfg.Fakeroot && l.cfg.Network != "none" {
 			// unprivileged installation could not use fakeroot
 			// network because it requires a setuid installation
@@ -968,6 +974,11 @@ func (l *Launcher) setNamespaces() {
 			}
 		}
 		l.generator.AddOrReplaceLinuxNamespace("network", "")
+	}
+	if l.cfg.NetnsPath != "" {
+		// Note - runtime code checks whether netns-path is permitted (root or
+		// allowed via apptainer.conf).
+		l.generator.AddOrReplaceLinuxNamespace("network", l.cfg.NetnsPath)
 	}
 	if l.cfg.Namespaces.UTS {
 		l.generator.AddOrReplaceLinuxNamespace("uts", "")

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -83,6 +83,10 @@ type launchOptions struct {
 	// Namespaces is the list of optional Namespaces requested for the container.
 	Namespaces Namespaces
 
+	// NetnsPath is the path to a network namespace to join, rather than
+	// creating one / applying a CNI config.
+	NetnsPath string
+
 	// Network is the name of an optional CNI networking configuration to apply.
 	Network string
 	// NetworkArgs are argument to pass to the CNI plugin that will configure networking when Network is set.
@@ -323,6 +327,14 @@ func OptNoEval(b bool) Option {
 func OptNamespaces(n Namespaces) Option {
 	return func(lo *launchOptions) error {
 		lo.Namespaces = n
+		return nil
+	}
+}
+
+// OptJoinNetNamespace sets the network namespace to join, if permitted.
+func OptNetnsPath(n string) Option {
+	return func(lo *launchOptions) error {
+		lo.NetnsPath = n
 		return nil
 	}
 }

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -117,6 +117,7 @@ type File struct {
 	AllowNetUsers             []string `directive:"allow net users"`
 	AllowNetGroups            []string `directive:"allow net groups"`
 	AllowNetNetworks          []string `directive:"allow net networks"`
+	AllowNetnsPaths           []string `directive:"allow netns paths"`
 	RootDefaultCapabilities   string   `default:"full" authorized:"full,file,no" directive:"root default capabilities"`
 	MemoryFSType              string   `default:"tmpfs" authorized:"tmpfs,ramfs" directive:"memory fs type"`
 	CniConfPath               string   `directive:"cni configuration path"`
@@ -455,11 +456,13 @@ allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }
 
 # ALLOW NET USERS: [STRING]
 # DEFAULT: NULL
-# Allow specified root administered CNI network configurations to be used by the
-# specified list of users. By default only root may use CNI configuration,
-# except in the case of a fakeroot execution where only 40_fakeroot.conflist
-# is used. This feature only applies when Apptainer is running in
-# SUID mode and the user is non-root.
+# A list of non-root users that are permitted to use the CNI configurations
+# specified in the 'allow net networks' directive, and can join existing
+# network namespaces listed in the 'allow netns paths' directive.
+# By default only root may use CNI configurations, or join existing network
+# namespaces, except in the case of a fakeroot execution where only the 
+# 40_fakeroot.conflist CNI configuration is used. The restriction only applies
+# when Apptainer is running in SUID mode and the user is non-root.
 #allow net users = gmk, apptainer
 {{ range $index, $owner := .AllowNetUsers }}
 {{- if eq $index 0 }}allow net users = {{ else }}, {{ end }}{{$owner}}
@@ -467,11 +470,13 @@ allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }
 
 # ALLOW NET GROUPS: [STRING]
 # DEFAULT: NULL
-# Allow specified root administered CNI network configurations to be used by the
-# specified list of users. By default only root may use CNI configuration,
-# except in the case of a fakeroot execution where only 40_fakeroot.conflist
-# is used. This feature only applies when Apptainer is running in
-# SUID mode and the user is non-root.
+# A list of non-root groups that are permitted to use the CNI configurations
+# specified in the 'allow net networks' directive, and can join existing
+# network namespaces listed in the 'allow netns paths' directive.
+# By default only root may use CNI configurations, or join existing network
+# namespaces, except in the case of a fakeroot execution where only the 
+# 40_fakeroot.conflist CNI configuration is used. The restriction only applies
+# when Apptainer is running in SUID mode and the user is non-root.
 #allow net groups = group1, apptainer
 {{ range $index, $group := .AllowNetGroups }}
 {{- if eq $index 0 }}allow net groups = {{ else }}, {{ end }}{{$group}}
@@ -480,11 +485,21 @@ allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }
 # ALLOW NET NETWORKS: [STRING]
 # DEFAULT: NULL
 # Specify the names of CNI network configurations that may be used by users and
-# groups listed in the allow net users / allow net groups directives. Thus feature
+# groups listed in the allow net users / allow net groups directives. This restriction
 # only applies when Apptainer is running in SUID mode and the user is non-root.
 #allow net networks = bridge
 {{ range $index, $group := .AllowNetNetworks }}
 {{- if eq $index 0 }}allow net networks = {{ else }}, {{ end }}{{$group}}
+{{- end }}
+
+# ALLOW NETNS PATHS: [STRING]
+# DEFAULT: NULL
+# Specify the paths to network namespaces that may be joined by users and groups
+# listed in the allow net users / allow net groups directives. This restriction
+# only applies when Apptainer is running in SUID mode and the user is non-root.
+#allow netns paths = /var/run/netns/my_network
+{{ range $index, $path := .AllowNetnsPaths }}
+{{- if eq $index 0 }}allow netns paths = {{ else }}, {{ end }}{{$path}}
 {{- end }}
 
 # ALWAYS USE NV ${TYPE}: [BOOL]


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/3192

which had an original description of
> Allow the root user, or specified users/groups (in setuid mode) to start containers that join existing network namespaces.
The root user can join any network namespace, when starting a container in native mode, with the new --netns-path flag.
An unprivileged user in the allow net users / allow net groups directives in singularity.conf can join a namepace with a path listed in allow netns paths.
Note that network namespace join is not available in --fakeroot mode, as the starter / runtime enter the uid-mapped user namespace early.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in

- https://github.com/apptainer/apptainer/issues/2546

#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
