### PR TITLE
Remove libraries from `--rocm` binds

### DIFF
--- a/etc/rocmliblist.conf
+++ b/etc/rocmliblist.conf
@@ -9,36 +9,3 @@
 # exclude writing by non-privileged users.  
 rocm-smi
 rocminfo
-
-# put libs here (must end in .so)
-libamd_comgr.so
-libcomgr.so
-libCXLActivityLogger.so
-libelf.so
-libhc_am.so
-libhipblas.so
-libhip_hcc.so
-libhiprand.so
-libhsakmt.so
-libhsa-runtime64.so
-libmcwamp.so
-libmcwamp_cpu.so
-libmcwamp_hsa.so
-libmiopengemm.so
-libMIOpen.so
-libdrm.so
-libdrm_amdgpu.so
-libnuma.so
-libpci.so
-librccl.so
-librocblas.so
-librocfft-device.so
-librocfft.so
-librocrand.so
-librocr_debug_agent64.so
-
-libamdcomgr64.so
-libamdocl64.so
-libcltrace.so
-libOpenCL.so
- 

--- a/etc/rocmliblist.conf
+++ b/etc/rocmliblist.conf
@@ -9,3 +9,19 @@
 # exclude writing by non-privileged users.  
 rocm-smi
 rocminfo
+
+# put libs here (must end in .so)
+libCXLActivityLogger.so
+libhc_am.so
+libmcwamp.so
+libmcwamp_cpu.so
+libmcwamp_hsa.so
+libdrm.so
+libdrm_amdgpu.so
+libnuma.so
+libpci.so
+librocr_debug_agent64.so
+libamdcomgr64.so
+libamdocl64.so
+libcltrace.so
+libOpenCL.so


### PR DESCRIPTION
## Description of the Pull Request (PR):

Binding these libraries from the host causes GLIBC version incompatibilities, since the ROCm libraries refer to specific, they should be provided as part of the container image.

An example for such a failure (host uses Rocky 9.4, container uses Ubuntu 18.04):

```
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /.singularity.d/libs/libnuma.so.1)
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /.singularity.d/libs/libelf.so.1)
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /.singularity.d/libs/libdrm.so.2)
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /.singularity.d/libs/libdrm_amdgpu.so.1)
```

cc @dtrudg and @tom-papatheodore

Related PR that only did half the job: https://github.com/apptainer/apptainer/pull/1622

### This fixes or addresses the following GitHub issues:

 - Fixes #1621

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
