### PR TITLE
Avoid warning on `--rocm` with empty `rocmliblist.conf`

### DIFF
--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -916,7 +916,10 @@ func (l *Launcher) setRocmConfig() error {
 func (l *Launcher) addGPUBinds(libs, bins, ipcs, regularFiles []string, gpuPlatform string) {
 	files := make([]string, len(bins)+len(ipcs)+len(regularFiles))
 	if len(files) == 0 {
-		sylog.Warningf("Could not find any %s files on this host!", gpuPlatform)
+		if bins != nil {
+			// only warn if we requested files to bind
+			sylog.Warningf("Could not find any %s files on this host!", gpuPlatform)
+		}
 	} else {
 		if l.cfg.Writable {
 			sylog.Warningf("%s files may not be bound with --writable", gpuPlatform)
@@ -934,7 +937,10 @@ func (l *Launcher) addGPUBinds(libs, bins, ipcs, regularFiles []string, gpuPlatf
 		l.engineConfig.AppendFilesPath(files...)
 	}
 	if len(libs) == 0 {
-		sylog.Warningf("Could not find any %s libraries on this host!", gpuPlatform)
+		if libs != nil {
+			// only warn if we requested libraries to bind
+			sylog.Warningf("Could not find any %s libraries on this host!", gpuPlatform)
+		}
 	} else {
 		l.engineConfig.AppendLibrariesPath(libs...)
 	}

--- a/internal/pkg/util/gpu/rocm.go
+++ b/internal/pkg/util/gpu/rocm.go
@@ -24,6 +24,10 @@ func RocmPaths(configFilePath string) ([]string, []string, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not read %s: %v", filepath.Base(configFilePath), err)
 	}
+	// return nil slices to signal that the input was empty
+	if len(rocmFiles) == 0 {
+		return nil, nil, nil
+	}
 
 	libs, bins, _, err := paths.Resolve(rocmFiles)
 	return libs, bins, err


### PR DESCRIPTION
## Description of the Pull Request (PR):

Related to #2606, I configured my `rocmliblist.conf` to be empty deliberately, and the resulting warnings are unnecessary.


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
