### PR TITLE
Run all unit tests during ci, not just short unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,8 +309,8 @@ jobs:
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 
-  short_unit_tests:
-    name: short_unit_tests
+  unit_tests:
+    name: unit_tests
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
@@ -331,7 +331,7 @@ jobs:
           make -C ./builddir all && sudo make -C ./builddir install
 
       - name: Run unit tests
-        run: make -C ./builddir short-unit-test
+        run: make -C ./builddir unit-test
 
       - name: Check NFPM
         run: |


### PR DESCRIPTION
I noticed that some unit tests were being skipped during CI checks just because they were not considered as part of the "short" unit tests.  This changes the short-unit-test to unit-test.