### PR TITLE
chore: dependabot grouping / schedule, from sylabs3379

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,58 @@ updates:
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
+      time: "07:00"
     target-branch: main
+    groups:
+      moby:
+        applies-to: "version-updates"
+        patterns:
+          - "github.com/moby/*"
+          - "github.com/docker/*"
+      containerd:
+        applies-to: "version-updates"
+        patterns:
+          - "github.com/containerd/*"
+      opencontainers:
+        applies-to: "version-updates"
+        patterns:
+          - "github.com/opencontainers/*"
+      minor:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
+      time: "08:00"
     target-branch: release-1.3
+    groups:
+      moby:
+        applies-to: "version-updates"
+        patterns:
+          - "github.com/moby/*"
+          - "github.com/docker/*"
+      containerd:
+        applies-to: "version-updates"
+        patterns:
+          - "github.com/containerd/*"
+      opencontainers:
+        applies-to: "version-updates"
+        patterns:
+          - "github.com/opencontainers/*"
+      minor:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+


### PR DESCRIPTION
This PR cherry-picks

- sylabs/singularity#3379

The original commit description was:

> Generate dependabot version updates weekly, on a Friday at 7 & 8am UTC.
> 
> Setup an intial grouping:
> 
>     * All moby/* and docker/* updates together, as these are generally quite interdependent, and often require adapting some code.
> 
>     * All containerd/* updates together, as these can be interdependent and require more review / adaptation.
> 
>     * All opencontainers/* updates together, so OCI spec changes are not wrapped up with general minor updates.
> 
>     * All other minor / patch version updates together.
> 
> 
> Any security updates will still raise a separate PR.
> 
> Any major updates (outside of moby/containerd/opencontainers) will still raise a separate PR.

