### PR TITLE
fix: update `ed25519-public.pem` reference

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -31,7 +31,7 @@ the [keys](keys/) directory:
 
 - ECDSA: [ecdsa-public.pem](keys/ecdsa-public.pem)/
   [ecdsa-private.pem](keys/ecdsa-private.pem)
-- Ed25519: [ed25519-public.pem](ed25519-public.pem)/
+- Ed25519: [ed25519-public.pem](keys/ed25519-public.pem)/
   [ed25519-private.pem](keys/ed25519-private.pem)
 - RSA: [rsa-public.pem](keys/rsa-public.pem)/
   [rsa-private.pem](keys/rsa-private.pem)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Small PR - adjusts the `ed25519-public.pem` reference in `test/README.md`.

### This fixes or addresses the following GitHub issues:

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
