### PR TITLE
e2e:fix ensure e2e.Privileged funcs are called (from sylabs #3107)

### DIFF
--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -809,7 +809,7 @@ func (c actionTests) PersistentOverlay(t *testing.T) {
 		if err != nil {
 			t.Logf("Error while removing directory %s for test %s: %#v", testdir, t.Name(), err)
 		}
-	})
+	})(t)
 
 	dir := c.overlayCreate(t, testdir)
 	squashfsImage := c.squashfsCreate(t, testdir)
@@ -1188,7 +1188,7 @@ func (c actionTests) actionBinds(t *testing.T) {
 
 	workspace, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "bind-workspace-", "")
 	sandbox, _ := e2e.MakeTempDir(t, workspace, "sandbox-", "")
-	defer e2e.Privileged(cleanup)
+	defer e2e.Privileged(cleanup)(t)
 
 	contCanaryDir := "/canary"
 	hostCanaryDir := filepath.Join(workspace, "canary")
@@ -1981,7 +1981,7 @@ func (c actionTests) actionLayerType(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	sandbox, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "action-layertype-sandbox", "")
-	defer e2e.Privileged(cleanup)
+	defer e2e.Privileged(cleanup)(t)
 
 	// convert test image to sandbox
 	c.env.RunApptainer(
@@ -2152,7 +2152,7 @@ func (c actionTests) fuseMount(t *testing.T) {
 	u := e2e.UserProfile.HostUser(t)
 
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "sshfs-", "")
-	defer e2e.Privileged(cleanup)
+	defer e2e.Privileged(cleanup)(t)
 
 	sshfsWrapper := filepath.Join(imageDir, "sshfs-wrapper")
 	rootPrivKey := filepath.Join(imageDir, "/etc/ssh/ssh_host_rsa_key")
@@ -3060,7 +3060,7 @@ func (c actionTests) relWorkdirScratch(t *testing.T) {
 	testdir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "persistent-overlay-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			e2e.Privileged(cleanup)
+			e2e.Privileged(cleanup)(t)
 		}
 	})
 

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -675,7 +675,7 @@ func (c actionTests) issue6165(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
 	workspace, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue6165-", "")
-	defer e2e.Privileged(cleanup)
+	defer e2e.Privileged(cleanup)(t)
 
 	hostCanaryFile := filepath.Join(workspace, "file")
 

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1418,7 +1418,7 @@ func (c imgBuildTests) buildUpdateSandbox(t *testing.T) {
 	testDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "build-sandbox-", "")
 	t.Cleanup(func() {
 		if !t.Failed() {
-			e2e.Privileged(cleanup)
+			e2e.Privileged(cleanup)(t)
 		}
 	})
 

--- a/e2e/imgbuild/regressions.go
+++ b/e2e/imgbuild/regressions.go
@@ -529,7 +529,7 @@ from: %s
 				t, c.env.TestDir, fmt.Sprintf("issue1812-sandbox-%s-", testName), "")
 			t.Cleanup(func() {
 				if !t.Failed() {
-					e2e.Privileged(cleanup)
+					e2e.Privileged(cleanup)(t)
 				}
 			})
 
@@ -550,7 +550,7 @@ from: %s
 				t, c.env.TestDir, fmt.Sprintf("issue1812-sandbox-%s-", testName), "")
 			t.Cleanup(func() {
 				if !t.Failed() {
-					e2e.Privileged(cleanup)
+					e2e.Privileged(cleanup)(t)
 				}
 			})
 

--- a/e2e/instance/checkpoint.go
+++ b/e2e/instance/checkpoint.go
@@ -89,7 +89,7 @@ func (c *ctx) testCheckpointInstance(t *testing.T) {
 	require.DMTCP(t)
 
 	imageDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "checkpoint-", "")
-	defer e2e.Privileged(cleanup)
+	defer e2e.Privileged(cleanup)(t)
 
 	imagePath := filepath.Join(imageDir, "state-server.sif")
 	checkpointName := randomName(t)

--- a/e2e/run/run.go
+++ b/e2e/run/run.go
@@ -300,7 +300,7 @@ func (c ctx) testAddPackageWithFakerootAndTmpfs(t *testing.T) {
 	e2e.EnsureDebianImage(t, c.env)
 
 	tempDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "", "")
-	defer e2e.Privileged(cleanup)
+	defer e2e.Privileged(cleanup)(t)
 
 	sandbox, err := os.MkdirTemp(tempDir, "sandbox")
 	if err != nil {

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -118,7 +118,7 @@ func Run(t *testing.T) {
 	testenv.PrivCacheDir = privCacheDir
 	defer e2e.Privileged(func(t *testing.T) {
 		cleanPrivCache(t)
-	})
+	})(t)
 
 	unprivCacheDir, cleanUnprivCache := e2e.MakeCacheDir(t, testenv.TestDir)
 	testenv.UnprivCacheDir = unprivCacheDir


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/3107

which had an original description of
> e2e.Privileged returns a function that must be called with (t). Some instances were not calling the privileged function. Fix these.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in

- https://github.com/apptainer/apptainer/issues/2546


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
