### PR TITLE
remove ubuntu 23.10 as it reaches EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,21 +146,6 @@ jobs:
           GO_ARCH: linux-amd64
         run: ./scripts/ci-docker-run
 
-  debbuild-ubuntu23:
-    name: debbuild-ubuntu23
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-      # fetch tags as checkout@v2 doesn't do that by default
-      - run: git fetch --prune --unshallow --tags --force
-
-      - name: Build and test deb under docker
-        env:
-          OS_TYPE: ubuntu
-          OS_VERSION: '23.10'
-          GO_ARCH: linux-amd64
-        run: ./scripts/ci-docker-run
-  
   debbuild-ubuntu24:
     name: debbuild-ubuntu24
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description of the Pull Request (PR):

Ubuntu 23.10 reaches its EOL
https://fridge.ubuntu.com/2024/07/17/ubuntu-23-10-mantic-minotaur-reached-end-of-life-on-july-11-2024/
docker hub does not include 23.10 as the supported tags any longer
https://hub.docker.com/_/ubuntu/

As we already tested against 24.04, so 23.10 can be safely removed. 

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
