### PR TITLE
fix: set missing platform in TestOCIConveyor/Packer (from sylabs 2991)

### DIFF
--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -91,6 +91,7 @@ func handleOCI(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command, 
 		DockerHost:  dockerHost,
 		NoHTTPS:     noHTTPS,
 		ReqAuthFile: reqAuthFile,
+		Platform:    getOCIPlatform(),
 	}
 
 	return oci.Pull(ctx, imgCache, pullFrom, pullOpts)
@@ -124,7 +125,10 @@ func handleLibrary(ctx context.Context, imgCache *cache.Handle, pullFrom string)
 	if err != nil {
 		return "", err
 	}
-	return library.Pull(ctx, imgCache, r, runtime.GOARCH, tmpDir, c)
+	pullOpts := library.PullOptions{
+		LibraryConfig: c,
+	}
+	return library.Pull(ctx, imgCache, r, runtime.GOARCH, tmpDir, pullOpts)
 }
 
 func handleShub(ctx context.Context, imgCache *cache.Handle, pullFrom string) (string, error) {

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	"github.com/apptainer/apptainer/internal/pkg/fakeroot"
+	"github.com/apptainer/apptainer/internal/pkg/ociplatform"
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	fakerootConfig "github.com/apptainer/apptainer/internal/pkg/runtime/engine/fakeroot/config"
 	"github.com/apptainer/apptainer/internal/pkg/util/env"
@@ -350,6 +351,11 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 
 	}
 
+	dp, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		sylog.Fatalf("%v", err)
+	}
+
 	b, err := build.New(
 		defs,
 		build.Config{
@@ -377,6 +383,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 				Binds:             buildArgs.bindPaths,
 				Unprivilege:       unprivilege,
 				ReqAuthFile:       reqAuthFile,
+				Platform:          *dp,
 			},
 		})
 	if err != nil {

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -266,7 +266,12 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("Unable to get keyserver client configuration: %v", err)
 		}
 
-		_, err = library.PullToFile(ctx, imgCache, pullTo, ref, pullArch, tmpDir, lc, co, pullSandbox)
+		pullOpts := library.PullOptions{
+			KeyClientOpts: co,
+			LibraryConfig: lc,
+		}
+
+		_, err = library.PullToFile(ctx, imgCache, pullTo, ref, pullArch, tmpDir, pullOpts, pullSandbox)
 		if err != nil && err != library.ErrLibraryPullUnsigned {
 			sylog.Fatalf("While pulling library image: %v", err)
 		}
@@ -312,6 +317,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			NoCleanUp:   buildArgs.noCleanUp,
 			Pullarch:    arch,
 			ReqAuthFile: reqAuthFile,
+			Platform:    getOCIPlatform(),
 		}
 
 		_, err = oci.PullToFile(ctx, imgCache, pullTo, pullFrom, pullSandbox, pullOpts)

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -66,13 +66,14 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 	sylog.Debugf("LibraryURL: %v", libraryURL)
 	sylog.Debugf("LibraryRef: %v", imageRef.String())
 
-	libraryConfig := &client.Config{
-		BaseURL:   libraryURL,
-		AuthToken: authToken,
-		Logger:    (golog.Logger)(sylog.DebugLogger{}),
+	pullOpts := library.PullOptions{
+		LibraryConfig: &client.Config{
+			BaseURL:   libraryURL,
+			AuthToken: authToken,
+			Logger:    (golog.Logger)(sylog.DebugLogger{}),
+		},
 	}
-
-	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, runtime.GOARCH, cp.b.TmpDir, libraryConfig)
+	imagePath, err := library.Pull(ctx, b.Opts.ImgCache, imageRef, runtime.GOARCH, cp.b.TmpDir, pullOpts)
 	if err != nil {
 		return fmt.Errorf("while fetching library image: %v", err)
 	}

--- a/internal/pkg/build/sources/conveyorPacker_library_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_library_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/build/sources"
+	"github.com/apptainer/apptainer/internal/pkg/ociplatform"
 	"github.com/apptainer/apptainer/internal/pkg/test"
 	"github.com/apptainer/apptainer/pkg/build/types"
 )
@@ -39,6 +40,11 @@ func TestLibraryConveyor(t *testing.T) {
 	}
 
 	b.Opts.LibraryURL = libraryURL
+	p, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		t.Fatalf("failed to get DefaultPlatform: %v", err)
+	}
+	b.Opts.Platform = *p
 
 	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
 	if err != nil {
@@ -70,6 +76,12 @@ func TestLibraryPacker(t *testing.T) {
 	}
 
 	b.Opts.LibraryURL = libraryURL
+
+	p, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		t.Fatalf("failed to get DefaultPlatform: %v", err)
+	}
+	b.Opts.Platform = *p
 
 	b.Recipe, err = types.NewDefinitionFromURI(libraryURI)
 	if err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -141,6 +141,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		AuthFilePath:     ociauth.ChooseAuthFile(cp.b.Opts.ReqAuthFile),
 		UserAgent:        useragent.Value(),
 		TmpDir:           b.TmpDir,
+		Platform:         cp.b.Opts.Platform,
 	}
 
 	if cp.b.Opts.OCIAuthConfig == nil && cp.b.Opts.DockerAuthConfig != nil {

--- a/internal/pkg/build/sources/conveyorPacker_oci_test.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/build/sources"
 	"github.com/apptainer/apptainer/internal/pkg/cache"
+	"github.com/apptainer/apptainer/internal/pkg/ociplatform"
 	testCache "github.com/apptainer/apptainer/internal/pkg/test/tool/cache"
 	"github.com/apptainer/apptainer/pkg/build/types"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
@@ -70,6 +71,11 @@ func TestOCIConveyorDocker(t *testing.T) {
 	}
 
 	b.Opts.ImgCache = imgCache
+	p, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		t.Fatalf("failed to get DefaultPlatform: %v", err)
+	}
+	b.Opts.Platform = *p
 
 	cp := &sources.OCIConveyorPacker{}
 
@@ -268,6 +274,12 @@ func TestOCIPacker(t *testing.T) {
 	imgCache, cleanup := setupCache(t)
 	defer cleanup()
 	b.Opts.ImgCache = imgCache
+
+	p, err := ociplatform.DefaultPlatform()
+	if err != nil {
+		t.Fatalf("failed to get DefaultPlatform: %v", err)
+	}
+	b.Opts.Platform = *p
 
 	err = ocp.Get(context.Background(), b)
 	// clean up tmpfs since assembler isn't called

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -39,6 +39,7 @@ type PullOptions struct {
 	NoCleanUp   bool
 	Pullarch    string
 	ReqAuthFile string
+	Platform    v1.Platform
 }
 
 // transportOptions maps PullOptions to OCI image transport options
@@ -50,7 +51,7 @@ func transportOptions(opts PullOptions) *ociimage.TransportOptions {
 		TmpDir:           opts.TmpDir,
 		UserAgent:        useragent.Value(),
 		DockerDaemonHost: opts.DockerHost,
-		Platform:         v1.Platform{},
+		Platform:         opts.Platform,
 	}
 }
 
@@ -134,6 +135,7 @@ func convertOciToSIF(ctx context.Context, imgCache *cache.Handle, image, cachedI
 				ImgCache:         imgCache,
 				Arch:             opts.Pullarch,
 				ReqAuthFile:      opts.ReqAuthFile,
+				Platform:         opts.Platform,
 			},
 		},
 	)

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -22,6 +22,7 @@ import (
 	keyClient "github.com/apptainer/container-key-client/client"
 	ocitypes "github.com/containers/image/v5/types"
 	"github.com/google/go-containerregistry/pkg/authn"
+	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"golang.org/x/sys/unix"
 )
 
@@ -94,6 +95,8 @@ type Options struct {
 	Arch string
 	// Authentication file for registry credentials
 	ReqAuthFile string
+	// Which Platform to use when retrieving images for the build
+	Platform ggcrv1.Platform
 }
 
 // NewEncryptedBundle creates an Encrypted Bundle environment.


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/2991

which had an original description of
> We must provide platform when retrieving an OCI image.

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in

- https://github.com/apptainer/apptainer/issues/2546


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
