### PR TITLE
fix: accommodate binfmt_misc in pkg/image tests (from sylabs #2990)

### DIFF
--- a/pkg/image/sif_test.go
+++ b/pkg/image/sif_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	"github.com/apptainer/apptainer/internal/pkg/util/machine"
 	"github.com/apptainer/sif/v2/pkg/sif"
 )
 
@@ -122,12 +123,17 @@ func TestSIFInitializer(t *testing.T) {
 			expectedSections:   0,
 		},
 		{
-			name:               "PrimaryPartitionOtherArchSIF",
-			path:               createSIF(t, false, primPartOtherArch),
-			writable:           false,
-			expectedSuccess:    false,
-			expectedPartitions: 0,
-			expectedSections:   0,
+			name:            "PrimaryPartitionOtherArchSIF",
+			path:            createSIF(t, false, primPartOtherArch),
+			writable:        false,
+			expectedSuccess: machine.CompatibleWith("s390x"),
+			expectedPartitions: func() int {
+				if machine.CompatibleWith("s390x") {
+					return 1
+				}
+				return 0
+			}(),
+			expectedSections: 0,
 		},
 		{
 			name:               "PrimaryPartitionSIF",


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR re-implements the Singularity PR: https://github.com/sylabs/singularity/pull/2990

which had an original description of
> When a host is configured such that there is s390x binfmt_misc emulation support, then the PrimaryPartitionOtherArchSIF test will succeed, rather than fail..

### This fixes or addresses the following GitHub issues:

Addresses one of the PRs in

- https://github.com/apptainer/apptainer/issues/2546

#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
