### PR TITLE
Don't try kernel overlayfs when lower layer is incompatible (release-1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,24 @@ jobs:
           GO_ARCH: linux-amd64
         run: ./scripts/ci-docker-run
 
-  ubuntu-2310:
-    name: debbuild-ubuntu23
+  debbuild-debian12:
+    name: debbuild-debian12
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      # fetch tags as checkout@v2 doesn't do that by default
+      - run: git fetch --prune --unshallow --tags --force
+
+      - name: Build and test deb under docker
+        env:
+          OS_TYPE: debian
+          OS_VERSION: 12
+          # setting GO_ARCH speeds things by using go binaries instead of source
+          GO_ARCH: linux-amd64
+        run: ./scripts/ci-docker-run
+
+  debbuild-ubuntu22:
+    name: debbuild-ubuntu22
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
@@ -141,7 +157,7 @@ jobs:
       - name: Build and test deb under docker
         env:
           OS_TYPE: ubuntu
-          OS_VERSION: '23.10'
+          OS_VERSION: '22.04'
           GO_ARCH: linux-amd64
         run: ./scripts/ci-docker-run
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## Changes for v1.3.x
+
+- Avoid using kernel overlayfs when the lower layer is a sandbox on an
+  incompatible filesystem type such as GPFS or Lustre.  For those cases
+  use fuse-overlayfs instead.  This fixes a regression introduced in
+  1.3.0.  The regression didn't much impact Lustre because kernel
+  overlayfs refused to try to use it and Apptainer proceeded to use
+  fuse-overlayfs anyway, but with GPFS the kernel overlayfs allowed
+  mounting but returned stale file handle errors.
+
 ## v1.3.5 - \[2024-10-30\]
 
 - Fix a regression introduced in 1.3.4 that overwrote existing standard


### PR DESCRIPTION
Cherry-pick #2659 to the release-1.3 branch.