### PR TITLE
Merge release-1.3 into main after 1.3.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   setuid privileges. Not currently supported with `--fakeroot`.
 - Go version 1.22 is now required.
 
-## Changes for v1.3.x
+## v1.3.6 - \[2024-12-02\]
 
 - Avoid using kernel overlayfs when the lower layer is a sandbox on an
   incompatible filesystem type such as GPFS or Lustre.  For those cases
@@ -83,6 +83,17 @@ For older changes see the [archived Singularity change log](https://github.com/a
   overlayfs refused to try to use it and Apptainer proceeded to use
   fuse-overlayfs anyway, but with GPFS the kernel overlayfs allowed
   mounting but returned stale file handle errors.
+
+## v1.3.5 - \[2024-10-30\]
+
+- Fix a regression introduced in 1.3.4 that overwrote existing standard
+  `/.singularity.d` files such as `runscript` in container images even
+  if they had been modified.
+- Skip attempting to bind inaccessible mount points when handling the
+  `mount hostfs = yes` configuration option.
+- Support parsing nested variables defined inside `%arguments` section of
+  definition files.
+- Ignore invalid environment variables when pulling oci/docker containers.
 
 ## v1.3.4 - \[2024-09-04\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -158,7 +158,7 @@ To build a specific version of Apptainer, check out a
 for example:
 
 ```sh
-git checkout v1.3.4
+git checkout v1.3.6
 ```
 
 ## Compiling Apptainer
@@ -327,7 +327,7 @@ Then download the latest
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-VERSION=1.3.4  # this is the apptainer version, change as you need
+VERSION=1.3.6  # this is the apptainer version, change as you need
 # Fetch the source
 wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/apptainer-${VERSION}.tar.gz
 ```


### PR DESCRIPTION
Looks like there was never a marge after the 1.3.5 release so this includes both 1.3.5 and 1.3.6.