### PR TITLE
change log level to debug when variables already having value and not forwarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
   setuid privileges. Not currently supported with `--fakeroot`.
 - Go version 1.22 is now required.
 - Refactor image arch variation using go-containerregistry's platform.
+- Change message log level from warning to debug when environment variables
+  set inside a container or by APPTAINERENV have a different value than the
+  environment variable on the host.
 
 ## v1.3.6 - \[2024-12-02\]
 

--- a/internal/pkg/util/env/create.go
+++ b/internal/pkg/util/env/create.go
@@ -165,7 +165,7 @@ EnvKeys:
 		if mustAddToHostEnv(e[0], cleanEnv) {
 			if value, ok := envKeys[e[0]]; ok {
 				if value != e[1] {
-					sylog.Warningf("Environment variable %s already has value [%s], will not forward new value [%s] from parent process environment", e[0], value, e[1])
+					sylog.Debugf("Environment variable %s already has value [%s], will not forward new value [%s] from parent process environment", e[0], value, e[1])
 				} else {
 					sylog.Debugf("Environment variable %s already has duplicate value [%s], will not forward from parent process environment", e[0], value)
 				}


### PR DESCRIPTION
## Description of the Pull Request (PR):

change log level to debug when variables already having value and not forwarded


### This fixes or addresses the following GitHub issues:

 - Fixes #2563


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
