### PR TITLE
fix a stage build hanging issue because of null TarOption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Change message log level from warning to debug when environment variables
   set inside a container or by APPTAINERENV have a different value than the
   environment variable on the host.
+- Fix hang when copying files between build stages while using suid mode without
+  user namespaces.
 
 ## v1.3.6 - \[2024-12-02\]
 

--- a/pkg/util/archive/copy.go
+++ b/pkg/util/archive/copy.go
@@ -121,6 +121,10 @@ func CopyWithTarWithRoot(src, dst, dstRoot string) error {
 	}
 
 	ar.Untar = func(tarArchive io.Reader, dest string, options *da.TarOptions) error {
+		if options == nil {
+			options = &da.TarOptions{}
+		}
+
 		if eIdentity != nil {
 			options.IDMap = idtools.IdentityMapping{}
 			options.ChownOpts = eIdentity
@@ -130,9 +134,6 @@ func CopyWithTarWithRoot(src, dst, dstRoot string) error {
 			return fmt.Errorf("empty archive")
 		}
 		dest = filepath.Clean(dest)
-		if options == nil {
-			options = &da.TarOptions{}
-		}
 		if options.ExcludePatterns == nil {
 			options.ExcludePatterns = []string{}
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix a hanging issue because of null TarOption during stage builds.

### This fixes or addresses the following GitHub issues:

 - Fixes #2453 


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).

## Test

```
[vagrant@localhost ~]$ cat stagebuild.def
Bootstrap: docker
From: ubuntu:latest
Stage: devel

%post
touch blah
echo "hello" > /blah



Bootstrap: docker
From: ubuntu:latest
Stage: final

%files from devel
/blah /blahtwo

%post
echo "hi"
```

### After
```
[vagrant@localhost ~]$ sudo sysctl -a | grep user.max_user_namespaces
user.max_user_namespaces = 0

[vagrant@localhost ~]$ cat /etc/os-release
NAME="Rocky Linux"
VERSION="8.10 (Green Obsidian)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="8.10"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Rocky Linux 8.10 (Green Obsidian)"
ANSI_COLOR="0;32"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:rocky:rocky:8:GA"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
SUPPORT_END="2029-05-31"
ROCKY_SUPPORT_PRODUCT="Rocky-Linux-8"
ROCKY_SUPPORT_PRODUCT_VERSION="8.10"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.10"

[vagrant@localhost ~]$ apptainer build --force --ignore-subuid test.sif stagebuild.def
INFO:    User not listed in /etc/subuid, trying root-mapped namespace
INFO:    Could not start root-mapped namespace
INFO:    The %post section will be run under the fakeroot command
INFO:    Using --fix-perms because building from a definition file
INFO:     without either root user or unprivileged user namespaces
INFO:    Starting build...
INFO:    Fetching OCI image...
28.4MiB / 28.4MiB [===================================================================================] 100 % 0.0 b/s 0s
INFO:    Extracting OCI image...
WARNING: The --fix-perms option modifies the filesystem permissions on the resulting container.
INFO:    Inserting Apptainer configuration...
INFO:    Running post scriptlet
+ touch blah
+ echo hello
INFO:    Fetching OCI image...
28.4MiB / 28.4MiB [===================================================================================] 100 % 0.0 b/s 0s
INFO:    Extracting OCI image...
WARNING: The --fix-perms option modifies the filesystem permissions on the resulting container.
INFO:    Inserting Apptainer configuration...
INFO:    Copying /blah to /blahtwo
inside untar with root
eidentity is not nil
%v &{1000 1000 }
%v &{[] [] 0 false {[] []} <nil> false 0 false map[] false false}
idtools.identitymapping()
INFO:    Running post scriptlet
+ echo hi
hi
INFO:    Creating SIF file...
INFO:    Build complete: test.sif
```

### Before
```
[vagrant@localhost ~]$ apptainer build --force --ignore-subuid test.sif stagebuild.def
INFO:    User not listed in /etc/subuid, trying root-mapped namespace
INFO:    Could not start root-mapped namespace
INFO:    The %post section will be run under the fakeroot command
INFO:    Using --fix-perms because building from a definition file
INFO:     without either root user or unprivileged user namespaces
INFO:    Starting build...
INFO:    Fetching OCI image...
28.4MiB / 28.4MiB [=============================================================================================] 100 % 0.0 b/s 0s
INFO:    Extracting OCI image...
WARNING: The --fix-perms option modifies the filesystem permissions on the resulting container.
INFO:    Inserting Apptainer configuration...
INFO:    Running post scriptlet
+ touch blah
+ echo hello
INFO:    Fetching OCI image...
28.4MiB / 28.4MiB [=============================================================================================] 100 % 0.0 b/s 0s
INFO:    Extracting OCI image...
WARNING: The --fix-perms option modifies the filesystem permissions on the resulting container.
INFO:    Inserting Apptainer configuration...
INFO:    Copying /blah to /blahtwo
^C[vagrant@localhost ~]$
```