### PR TITLE
Derive the GNU build ID from the Go one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   user namespaces.
 - Remove runtime and compute libraries from `rocmliblist.conf`,
   they should be provided by the container image.
+- Make binary builds more reproducible by deriving the GNU build ID
+  from the Go build ID instead of using a randomly generated one.
 
 ## v1.3.6 - \[2024-12-02\]
 

--- a/mlocal/frags/go_normal_opts.mk
+++ b/mlocal/frags/go_normal_opts.mk
@@ -1,3 +1,3 @@
 # This tells go's link command to add a GNU Build Id, needed for later
 #   symbol stripping for example as is done by rpmbuild.
-GO_LDFLAGS += -ldflags="-B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`"
+GO_LDFLAGS += -ldflags="-B gobuildid"


### PR DESCRIPTION
This is achieved using the linker option `-B gobuildid` See: https://pkg.go.dev/cmd/link.
This way binaries will get unique build IDs and the build will be reproducible as binaries built from identical sources will have the same build ID.
This fixes issue #1623.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #1623


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
