### PR TITLE
Don't disable instance cgroups with user namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   by squashfuse_ll.
 - Add automated tests for OpenSUSE Leap and Tumbleweed and Debian Bookworm.
 - Fixed typo in `nvliblist.conf` (`libnvoptix.so.1` -> `libnvoptix.so`)
-- Containers and instances can now be successfully
-  started as a non-root user on cgroups v2 systems when both:
-  - The system configuration / environment does not provide the correct
-    information necessary to communicate with systemd via dbus.
-  - Resource limits (e.g. `--cpus`) have not been requested.
-  The container / instance will be started in the current cgroup, and information
-  about the configuration issue displayed to the user as warnings.
+- Statistics are now normally available for instances that are
+  started by non-root users on cgroups v2 systems.  
+  The instance will be started in the current cgroup.  Information
+  about configuration issues that prevent collection of statistics are
+  displayed as INFO messages by default.
 - Fix storage of credentials for `docker.io` to behave the same as for
   `index.docker.io`.
 - Skip attempting to bind inaccessible mount points when handling the

--- a/e2e/cgroups/cgroups.go
+++ b/e2e/cgroups/cgroups.go
@@ -786,6 +786,7 @@ func (c *ctx) actionDbusXDG(t *testing.T) {
 					e2e.WithProfile(profile),
 					e2e.WithCommand("exec"),
 					e2e.WithArgs(tt.args...),
+					e2e.WithRootlessEnv(),
 					e2e.WithEnv(testEnv),
 					e2e.ExpectExit(tt.expectErrorCode, exitFunc...),
 				)

--- a/internal/pkg/cgroups/manager_linux.go
+++ b/internal/pkg/cgroups/manager_linux.go
@@ -347,8 +347,8 @@ func newManager(resources *specs.LinuxResources, group string, systemd bool) (ma
 // If a group name is supplied, it will be used by the manager.
 // If group = "" then "/apptainer/<pid>" is used as a default.
 func NewManagerWithSpec(spec *specs.LinuxResources, pid int, group string, systemd bool) (manager *Manager, err error) {
-	if !CanUseCgroups(systemd, true) {
-		return nil, fmt.Errorf("system configuration does not support cgroup management")
+	if err := CanUseCgroups(systemd); err != nil {
+		return nil, fmt.Errorf("cannot use cgroups - %v", err)
 	}
 
 	if pid == 0 {


### PR DESCRIPTION
This stops disabling instance cgroups when running unprivileged.

- Fixes #2684
- The bug was introduced in #2535 which has not yet been released so there's no need for a  CHANGELOG entry