### PR TITLE
Split up the minor dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,13 +26,15 @@ updates:
         applies-to: "version-updates"
         patterns:
           - "github.com/opencontainers/*"
-      minor:
-        applies-to: "version-updates"
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+# Leave the "minor" group separated because some require too-new golang
+# and others don't
+#      minor:
+#        applies-to: "version-updates"
+#        patterns:
+#          - "*"
+#        update-types:
+#          - "minor"
+#          - "patch"
 
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
@@ -55,11 +57,11 @@ updates:
         applies-to: "version-updates"
         patterns:
           - "github.com/opencontainers/*"
-      minor:
-        applies-to: "version-updates"
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+#      minor:
+#        applies-to: "version-updates"
+#        patterns:
+#          - "*"
+#        update-types:
+#          - "minor"
+#          - "patch"
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,7 @@ sudo zypper install -y \
 sudo zypper install -y diffutils which
 # Install basic tools for compiling
 # --replacefiles is needed to avoid pam conflict on Tumbleweed
-sudo zypper install -y --replacefiles -t pattern devel_basis
+sudo zypper install -y --replacefiles --allow-downgrade -t pattern devel_basis
 ```
 
 For libsubid support (requires openSUSE Tumbleweed):

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -11,7 +11,7 @@ if [[ $OS_TYPE == *suse* ]]; then
   zypper install -y libseccomp-devel libuuid-devel openssl-devel \
     squashfs fakeroot cryptsetup sysuser-tools wget git go
   zypper install -y diffutils
-  zypper install -y --replacefiles -t pattern devel_basis
+  zypper install -y --replacefiles --allow-downgrade -t pattern devel_basis
   if [[ $OS_TYPE == *tumbleweed* ]]; then
     zypper install -y libsubid-devel
   fi


### PR DESCRIPTION
This removes the "minor" dependabot group because some of them require updates to too-new golang and others don't.  By splitting them up, we'll be able to update the ones that don't require a too-new goolang.

This group was added in #2633 along with others.