### PR TITLE
Fixups after 1.4.0-rc.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
       interval: "weekly"
       day: "friday"
       time: "08:00"
-    target-branch: release-1.3
+    target-branch: release-1.4
     groups:
       moby:
         applies-to: "version-updates"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ Changes since 1.3.6
 - Expand the build instructions for squashfuse and apptainer packaging to
   include the libraries needed for maximum support of compression algorithms
   by squashfuse_ll.
-- When the logging level is verbose or debug, builds of SIF files now show
-  the output of mksquashfs including the progress bar.
 - Statistics are now normally available for instances that are
   started by non-root users on cgroups v2 systems.  
   The instance will be started in the current cgroup.  Information


### PR DESCRIPTION
There's nothing that needs to be merged into main from the new release-1.4 branch, but change the dependabot branch and remove a duplicate CHANGELOG message.