### PR TITLE
Support binfmt_misc also with rootless fakeroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## v1.4.x changes
+
+Changes since 1.4.0-rc.1
+
+- Fix running and building containers of different architectures
+  than the host via binfmt_misc when using rootless fakeroot.
+
 ## v1.4.0 Release Candidate 1 - \[2025-01-21\]
 
 Changes since 1.3.6

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 - Alexander Grund <alexander.grund@tu-dresden.de>
 - Amanda Duffy <aduffy@lenovo.com>
 - Ana Guerrero Lopez <aguerrero@suse.com>
+- Anders F Björklund <anders.f.bjorklund@gmail.com>
 - Andrew Bruno <aebruno2@buffalo.edu>
 - Ángel Bejarano <abejarano@ontropos.com>
 - Apuã Paquola <apuapaquola@gmail.com>

--- a/internal/pkg/util/machine/machine.go
+++ b/internal/pkg/util/machine/machine.go
@@ -242,7 +242,11 @@ func canEmulate(arch string) bool {
 	}
 
 	// look at /proc/sys/fs/binfmt_misc
-	content, _ := os.ReadFile(filepath.Join(binfmtMisc, "status"))
+	content, err := os.ReadFile(filepath.Join(binfmtMisc, "status"))
+	if err != nil {
+		sylog.Warningf("%v", err)
+		return false
+	}
 	if string(content) != "enabled\n" {
 		return false
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Support binfmt_misc also with rootless fakeroot

Currently it only works _without_ subuid/subgid


### This fixes or addresses the following GitHub issues:

 - Fixes #2730

- https://github.com/lima-vm/lima/discussions/3135

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
