### PR TITLE
change message level from debug to warning when workdir mounting fails with symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changes since 1.4.0-rc.1
 
 - Fix running and building containers of different architectures
   than the host via binfmt_misc when using rootless fakeroot.
+- Show a warning message if changing directory to the cwd fails, instead
+  of silently switching to the home directory or `/`.
 
 ## v1.4.0 Release Candidate 1 - \[2025-01-21\]
 

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -91,9 +91,11 @@ func (e *EngineOperations) StartProcess(masterConnFd int) error {
 		if customCwd {
 			return fmt.Errorf("failed to set working directory: %s", err)
 		}
-		if err := os.Chdir(e.EngineConfig.GetHomeDest()); err != nil {
-			sylog.Debugf("Error setting the working directory. Using '/' instead: %s", err)
+		if cerr := os.Chdir(e.EngineConfig.GetHomeDest()); cerr != nil {
+			sylog.Warningf("Error changing the container working directory. Using '/' instead: %s", cerr)
 			os.Chdir("/")
+		} else {
+			sylog.Warningf("Error changing the container working directory. Using '%s' instead: %s", e.EngineConfig.GetHomeDest(), err)
 		}
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

change message level from debug to warning when workdir mounting fails with symlinks


### This fixes or addresses the following GitHub issues:

 - Fixes #2754


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).

## Test

```
[vagrant@localhost foo]$ pwd
/home/vagrant/test/foo

[vagrant@localhost foo]$ realpath `pwd`
/storage/workspace

[vagrant@localhost foo]$ apptainer exec ~/test/ubuntu_24.04.sif pwd
INFO:    squashfuse not found, will not be able to mount SIF or other squashfs files
INFO:    gocryptfs not found, will not be able to use gocryptfs
INFO:    Converting SIF file to temporary sandbox...
/home/vagrant
INFO:    Cleaning up image...

[vagrant@localhost foo]$ apptainer -d exec ~/test/ubuntu_24.04.sif pwd
DEBUG   [U=1000,P=1]       func1()                       executablePath does not exist, assuming default prefix
DEBUG   [U=1000,P=1]       startup()                     apptainer runtime engine selected
VERBOSE [U=1000,P=1]       startup()                     Execute stage 2
DEBUG   [U=1000,P=1]       StageTwo()                    Entering stage 2
WARNING [U=1000,P=1]       StartProcess()                Error setting the working directory. Using '/' instead: chdir /home/vagrant: no such file or directory
DEBUG   [U=1000,P=1]       StartProcess()                Setting umask in container to 0022
DEBUG   [U=1000,P=1]       sylogBuiltin()                Running action command exec
DEBUG   [U=1000,P=902303]  PostStartProcess()            Post start process
Parallel unsquashfs: Using 4 processors
2808 inodes (3116 blocks) to write
```