### PR TITLE
Show mksquashfs progress without being too verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changes since 1.4.0-rc.1
   `--arch-variant`, to build images for another architecture
   than the current host arch. This requires that the host has
   been set up to support multiple architectures (binfmt_misc).
+- If the `mksquashfs` version is new enough (version 4.6 or later),
+  then show a percentage progress bar (with ETA) during SIF creation.
+  If the mksquashfs version is older, than fallback to the old message:
+  "To see mksquashfs output with progress bar enable verbose logging"
 
 ## v1.4.0 Release Candidate 1 - \[2025-01-21\]
 


### PR DESCRIPTION
If the mksquashfs version is new enough (version 4.6 or later),
then show the percentage of progress only if not already verbose.

If the mksquashfs version is older, than fallback to the old message:
"To see mksquashfs output with progress bar enable verbose logging"

## Description of the Pull Request (PR):

Show a progress bar for the SIF creation, including percentage and ETA.

This is just one line of output, compared to the `--verbose` multiple lines.

### This fixes or addresses the following GitHub issues:

* Fixes #2787

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
