### PR TITLE
Bundle squashfs-tools with apptainer libexec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
           go-version: 1.22.7
 
       - name: Fetch deps
-        run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
+        run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
 
       - name: Build and install Apptainer
         run: |
@@ -353,7 +353,7 @@ jobs:
           go-version: 1.22.7
 
       - name: Fetch deps
-        run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential squashfs-tools libseccomp-dev cryptsetup dbus-user-session
+        run: sudo apt-get -q update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libseccomp-dev cryptsetup dbus-user-session
 
       - name: Build and install Apptainer
         run: |
@@ -402,8 +402,8 @@ jobs:
         run: |
           set -e
           sudo apt-get -q update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential uidmap squashfs-tools squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf automake libtool pkg-config libfuse3-dev zlib1g-dev
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential uidmap squashfuse fuse-overlayfs fakeroot fuse2fs libseccomp-dev cryptsetup dbus-user-session
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf automake libtool pkg-config libfuse3-dev zlib1g-dev liblzo2-dev liblz4-dev liblzma-dev libzstd-dev
 
       - name: Download, compile, and install dependent packages
         if: env.run_tests

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ e2fsprogs-*
 fuse-overlayfs-*
 gocryptfs-*
 squashfuse-*
+squashfs-tools-*
 *.m4
 *.pyc
 *.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Changes since 1.4.0-rc.1
   If the mksquashfs version is older, than fallback to the old message:
   "To see mksquashfs output with progress bar enable verbose logging"
 - Complete the previously partial support for the `riscv64` architecture.
+- Apptainer now includes a bundled copy of squashfs-tools to make the
+  progress bar available and to ensure that all compression types are
+  available. This includes the programs `mksquashfs` and `unsquashfs`.
 
 ## v1.4.0 Release Candidate 1 - \[2025-01-21\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,6 @@ sudo apt-get install -y \
     libseccomp-dev \
     pkg-config \
     uidmap \
-    squashfs-tools \
     fakeroot \
     cryptsetup \
     tzdata \
@@ -46,7 +45,6 @@ sudo dnf install -y epel-release
 # Install RPM packages for dependencies
 sudo dnf install -y \
     libseccomp-devel \
-    squashfs-tools \
     fakeroot \
     cryptsetup \
     wget git
@@ -67,7 +65,7 @@ sudo zypper install -y \
   libseccomp-devel \
   libuuid-devel \
   openssl-devel \
-  squashfs fakeroot \
+  fakeroot \
   cryptsetup sysuser-tools \
   wget git go
 # Install these before devel tools to avoid clashing busybox pkgs on Tumbleweed

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -22,6 +22,7 @@ Build-Depends:
  libfuse3-dev,
  zlib1g-dev,
  liblzo2-dev,
+ liblz4-dev,
  liblzma-dev,
  libzstd-dev,
  dh-apparmor
@@ -36,7 +37,6 @@ Depends:
  ${misc:Depends},
  ${shlibs:Depends},
  uidmap,
- squashfs-tools,
  fakeroot
 Conflicts: singularity-container
 Description: container platform focused on supporting "Mobility of Compute" formerly known as Singularity

--- a/dist/nfpm/nfpm.yaml
+++ b/dist/nfpm/nfpm.yaml
@@ -141,7 +141,6 @@ overrides:
   deb:
     depends:
       - libseccomp2
-      - squashfs-tools
 {{- if .Rootless }}
     recommends:
       - uidmap
@@ -149,7 +148,6 @@ overrides:
   rpm:
     depends:
       - libseccomp
-      - squashfs-tools
 {{- if .Rootless }}
     recommends:
       - shadow-utils

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -37,6 +37,7 @@
 %global squashfuse_version 0.5.2
 %global e2fsprogs_version 1.47.2
 %global fuse_overlayfs_version 1.14
+%global squashfs_tools_version 4.6.1
 
 # The last singularity version number in EPEL/Fedora
 %global last_singularity_version 3.8.7-3
@@ -68,6 +69,9 @@ Source11: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squas
 Source12: e2fsprogs-%{e2fsprogs_version}.tar.gz
 %endif
 Source13: https://github.com/containers/fuse-overlayfs/archive/v%{fuse_overlayfs_version}/fuse-overlayfs-%{fuse_overlayfs_version}.tar.gz
+%if "%{?squashfs_tools_version}" != ""
+Source14: https://github.com/plougher/squashfs-tools/archive/%{squashfs_tools_version}/squashfs-tools-%{squashfs_tools_version}.tar.gz
+%endif
 
 # This Conflicts is in case someone tries to install the main apptainer
 # package when an old singularity package is installed.  An Obsoletes is on
@@ -95,6 +99,7 @@ Provides: bundled(squashfuse) = %{squashfuse_version}
 Provides: bundled(e2fsprogs) = %{e2fsprogs_version}
 Provides: bundled(fuse2fs) = %{e2fsprogs_version}
 Provides: bundled(fuse-overlayfs) = %{fuse_overlayfs_version}
+Provides: bundled(squashfs-tools) = %{squashfs_tools_version}
 @BUNDLED_PROVIDES@
 
 %if "%{_target_vendor}" == "suse"
@@ -115,7 +120,7 @@ BuildRequires: make
 BuildRequires: libseccomp-devel
 BuildRequires: cryptsetup
 BuildRequires: fuse3-devel
-%if ("%{?squashfuse_version}" != "") || ("%{e2fsprogs_version}" != "") || ("%{fuse_overlayfs_version}" != "")
+%if ("%{?squashfuse_version}" != "") || ("%{e2fsprogs_version}" != "") || ("%{fuse_overlayfs_version}" != "") || ("%{?squashfs_tools_version}" != "")
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool
@@ -126,10 +131,8 @@ BuildRequires: xz-devel
 BuildRequires: libzstd-devel
 %endif
 %if "%{_target_vendor}" == "suse"
-Requires: squashfs
 Recommends: fakeroot
 %else
-Requires: squashfs-tools
 Requires: fakeroot
 %endif
 
@@ -214,6 +217,11 @@ install -m 755 e2fsprogs-%{e2fsprogs_version}/fuse2fs %{buildroot}%{_libexecdir}
 install -m 755 fuse-overlayfs-%{fuse_overlayfs_version}/fuse-overlayfs %{buildroot}%{_libexecdir}/%{name}/bin/fuse-overlayfs
 %endif
 
+%if "%{?squashfs_tools_version}" != ""
+install -m 755 squashfs-tools-%{squashfs_tools_version}/squashfs-tools/mksquashfs %{buildroot}%{_libexecdir}/%{name}/bin/mksquashfs
+install -m 755 squashfs-tools-%{squashfs_tools_version}/squashfs-tools/unsquashfs %{buildroot}%{_libexecdir}/%{name}/bin/unsquashfs
+%endif
+
 %post
 # $1 in %%posttrans cannot distinguish between fresh installs and upgrades,
 # so check it here and create a file to pass the knowledge to that step
@@ -280,6 +288,10 @@ fi
 %endif
 %if "%{?fuse_overlayfs_version}" != ""
 %{_libexecdir}/%{name}/bin/fuse-overlayfs
+%endif
+%if "%{?squashfs_tools_version}" != ""
+%{_libexecdir}/%{name}/bin/mksquashfs
+%{_libexecdir}/%{name}/bin/unsquashfs
 %endif
 %{_libexecdir}/%{name}/cni
 %{_libexecdir}/%{name}/lib

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -18,7 +18,6 @@ apt-get install -y \
     libseccomp-dev \
     pkg-config \
     uidmap \
-    squashfs-tools \
     fakeroot \
     cryptsetup \
     tzdata \
@@ -35,7 +34,7 @@ apt-get install -y \
     golang-go \
     dh-apparmor
 
-# for squashfuse_ll build
+# for squashfs-tools and squashfuse_ll build
 apt-get install -y autoconf automake libtool pkg-config libfuse3-dev \
     zlib1g-dev liblzo2-dev liblz4-dev liblzma-dev libzstd-dev
 

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -9,7 +9,7 @@
 # install dependencies
 if [[ $OS_TYPE == *suse* ]]; then
   zypper install -y libseccomp-devel libuuid-devel openssl-devel \
-    squashfs fakeroot cryptsetup sysuser-tools wget git go
+    fakeroot cryptsetup sysuser-tools wget git go
   zypper install -y diffutils
   zypper install -y --replacefiles --allow-downgrade -t pattern devel_basis
   if [[ $OS_TYPE == *tumbleweed* ]]; then
@@ -24,7 +24,7 @@ else
   if [ $OS_TYPE != fedora ]; then
     dnf install -y epel-release
   fi
-  dnf install -y libseccomp-devel squashfs-tools fakeroot cryptsetup wget git
+  dnf install -y libseccomp-devel fakeroot cryptsetup wget git
   dnf --enablerepo=devel install -y shadow-utils-subid-devel
   dnf install -y golang
   dnf install -y fuse3-devel lzo-devel lz4-devel

--- a/scripts/clean-dependencies
+++ b/scripts/clean-dependencies
@@ -8,6 +8,6 @@
 # FUSE-based packages.
 
 set -ex
-for PKG in squashfuse e2fsprogs fuse-overlayfs gocryptfs; do
+for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs; do
     rm -rf $PKG-*
 done

--- a/scripts/compile-dependencies
+++ b/scripts/compile-dependencies
@@ -18,7 +18,7 @@ if [ -n "$1" ]; then
 fi
 
 set -ex
-for PKG in squashfuse e2fsprogs fuse-overlayfs gocryptfs; do
+for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs; do
     TGZ="$(echo $SRC/${PKG}-*.tar.gz)"
     if [ ! -f "$TGZ" ]; then
 	echo "$PKG-*.tar.gz not found in $SRC" >&2
@@ -35,6 +35,10 @@ for PKG in squashfuse e2fsprogs fuse-overlayfs gocryptfs; do
 	fi
     done
     case "$PKG" in
+	squashfs-tools)
+	    make -C squashfs-tools mksquashfs unsquashfs GZIP_SUPPORT=1 \
+	    LZO_SUPPORT=1 LZ4_SUPPORT=1 XZ_SUPPORT=1 ZSTD_SUPPORT=1
+	    ;;
 	squashfuse)
 	    ./autogen.sh
 	    FLAGS=-std=c99 ./configure --enable-multithreading

--- a/scripts/install-dependencies
+++ b/scripts/install-dependencies
@@ -33,7 +33,7 @@ if [ ! -w "$DIR" ]; then
 fi
 
 set -ex
-for CMD in squashfuse-*/squashfuse_ll e2fsprogs-*/fuse2fs fuse-overlayfs-*/fuse-overlayfs gocryptfs-*/gocryptfs; do
+for CMD in squashfs-tools-*/squashfs-tools/{mksquashfs,unsquashfs} squashfuse-*/squashfuse_ll e2fsprogs-*/fuse2fs fuse-overlayfs-*/fuse-overlayfs gocryptfs-*/gocryptfs; do
     if [ ! -f "$CMD" ]; then
 	echo "$CMD not found" >&2
 	exit 1


### PR DESCRIPTION
For access to all compression methods (same as `squashfuse_ll`),
and for the new -percentage option for showing a progress bar.

This means that the squashfs-tools (or "squashfs") package
no longer needs to be pre-installed from the distribution.

## Description of the Pull Request (PR):

Bundle squashfs-tools with apptainer, similar to squashfuse.

Enable all compression methods with their libraries installed.

### This fixes or addresses the following GitHub issues:

 - Fixes #2785

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
