### PR TITLE
fix: correct instance error messages & xdg var e2e-tests, from sylabs3506

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,8 @@ Changes since 1.3.6
 - A new `--netns-path` option takes a path to a network namespace to join when
   starting a container. The `root` user may join any network namespace. An
   unprivileged user can only join a network namespace specified in the new
-  `allowed netns paths` directive in `apptainer.conf`, if they are also listed
-  in `allowed net users` / `allowed net groups` and apptainer is installed with
+  `allow netns paths` directive in `apptainer.conf`, if they are also listed
+  in `allow net users` / `allow net groups` and apptainer is installed with
   setuid privileges. Not supported with `--fakeroot`.
 - `apptainer.conf` now accepts setting the following options:
   - `allow ipc ns` -- Default value is `yes`; when set to `no`, it will disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Changes since 1.4.0-rc.1
   than the host via binfmt_misc when using rootless fakeroot.
 - Show a warning message if changing directory to the cwd fails, instead
   of silently switching to the home directory or `/`.
+- Write starter messages to stderr when an instance fails to start.
+  Previously they were incorrectly written to stdout.
 - Allow overriding the build architecture with `--arch` and
   `--arch-variant`, to build images for another architecture
   than the current host arch. This requires that the host has

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -23,7 +23,7 @@ reserved.
 
 Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 
-Copyright (c) 2018-2023, Sylabs, Inc. All rights reserved.
+Copyright (c) 2018-2025, Sylabs, Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -1251,7 +1251,7 @@ func (l *Launcher) starterInstance(loadOverlay bool, insideUserNs bool, name str
 		if end-start > 0 {
 			output := make([]byte, end-start)
 			stderr.ReadAt(output, start)
-			fmt.Println(string(output))
+			fmt.Fprintln(os.Stderr, string(output))
 		}
 	}
 


### PR DESCRIPTION
This cherry-picks changes from

- sylabs/singularity#3506

that weren't already fixed here.

Fixes
- #2773