### PR TITLE
Fix copy/paste comment for --arch-variant flag

### DIFF
--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -72,7 +72,7 @@ var pullArchFlag = cmdline.Flag{
 	EnvKeys:      []string{"PULL_ARCH"},
 }
 
-// --arch
+// --arch-variant
 var pullArchVariantFlag = cmdline.Flag{
 	ID:           "pullArchVariantFlag",
 	Value:        &pullArchVariant,


### PR DESCRIPTION
## Description of the Pull Request (PR):

Correct a copy/paste "typo" find when duplicating the arch-variant flag.

### This fixes or addresses the following GitHub issues:


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
