### PR TITLE
Complete the support for the riscv64 architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes since 1.4.0-rc.1
   then show a percentage progress bar (with ETA) during SIF creation.
   If the mksquashfs version is older, than fallback to the old message:
   "To see mksquashfs output with progress bar enable verbose logging"
+- Complete the previously partial support for the `riscv64` architecture.
 
 ## v1.4.0 Release Candidate 1 - \[2025-01-21\]
 

--- a/cmd/starter/c/include/setns.h
+++ b/cmd/starter/c/include/setns.h
@@ -37,6 +37,8 @@
 #    define __NR_setns 350
 #  elif defined(__s390__) || defined(__s390x__)
 #    define __NR_setns 339
+#  elif defined(__riscv)
+#    define __NR_setns 268
 #  elif defined(__mips__)
 #    if _MIPS_SIM == _ABIO32
 #      define __NR_setns 4344

--- a/dist/docker/buildenv.sh
+++ b/dist/docker/buildenv.sh
@@ -26,6 +26,11 @@ case "${TARGETPLATFORM##*/}" in
     export DEBIANARCH=s390x
     export GOARCH=s390x
     ;;
+"riscv64")
+    export TARGETARCH=riscv64
+    export DEBIANARCH=riscv64
+    export GOARCH=riscv64
+    ;;
 *)
     echo "${TARGETPLATFORM##*/} not supported, see dist/docker/build.sh to add it"
     exit 1

--- a/etc/seccomp-profiles/default.json
+++ b/etc/seccomp-profiles/default.json
@@ -47,6 +47,10 @@
 			"subArchitectures": [
 				"SCMP_ARCH_S390"
 			]
+		},
+		{
+			"architecture": "SCMP_ARCH_RISCV64",
+			"subArchitectures": null
 		}
 	],
 	"syscalls": [
@@ -534,6 +538,20 @@
 				"arches": [
 					"s390",
 					"s390x"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"riscv_flush_icache"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"riscv64"
 				]
 			},
 			"excludes": {}

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -73,6 +73,10 @@ var ArchMap = map[string]GoArch{
 		Arch: "s390x",
 		Var:  "",
 	},
+	"riscv64": {
+		Arch: "riscv64",
+		Var:  "",
+	},
 }
 
 // ConvertReference converts a source reference into a cache.ImageReference to cache its blobs
@@ -258,7 +262,7 @@ func getArchFromURI(uri string) (arch *GoArch) {
 
 // Convert CLI options GOARCH and arch variant to recognized docker arch
 func ConvertArch(arch, archVariant string) (string, error) {
-	supportedArchs := []string{"arm", "arm64", "amd64", "386", "ppc64le", "s390x"}
+	supportedArchs := []string{"arm", "arm64", "amd64", "386", "ppc64le", "s390x", "riscv64"}
 	switch arch {
 	case "arm64":
 		if archVariant == "" {

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -40,6 +40,7 @@ var debootstrapArchs = map[string]string{
 	"mipsle":   "mipsel",
 	"mips64le": "mips64el",
 	"s390x":    "s390x",
+	"riscv64":  "riscv64",
 }
 
 // DebootstrapConveyorPacker holds stuff that needs to be packed into the bundle

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -253,6 +253,8 @@ func fakerootSeccompProfile() *specs.LinuxSeccomp {
 		lseccomp.Architectures = []specs.Arch{specs.ArchPPC64, specs.ArchPPC}
 	case "s390x":
 		lseccomp.Architectures = []specs.Arch{specs.ArchS390X, specs.ArchS390}
+	case "riscv64":
+		lseccomp.Architectures = []specs.Arch{specs.ArchRISCV64}
 	}
 
 	return lseccomp

--- a/pkg/util/namespaces/setns_linux.go
+++ b/pkg/util/namespaces/setns_linux.go
@@ -25,6 +25,7 @@ var setnsSysNo = map[string]uintptr{
 	"ppc64":   350,
 	"ppc64le": 350,
 	"s390x":   339,
+	"riscv64": 268,
 }
 
 var nsMap = map[string]uintptr{


### PR DESCRIPTION
There was partial support added previously, but it was not in supported architectures and not in the "setns" syscalls.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #2806 

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
