### PR TITLE
Update rpm License field to new standard

### DIFF
--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -50,7 +50,7 @@ Release: @PACKAGE_RELEASE@%{?dist}
 # See LICENSE_THIRD_PARTY.md for incorporated code (ASL 2.0)
 # See LICENSE_DEPENDENCIES.md for dependencies
 # License identifiers taken from: https://fedoraproject.org/wiki/Licensing
-License: BSD and LBNL BSD and ASL 2.0
+License: LicenseRef-Callaway-BSD AND BSD-3-Clause-LBNL AND Apache-2.0
 URL: https://apptainer.org
 Source: https://github.com/%{name}/%{name}/releases/download/v%{package_version}/%{name}-%{package_version}.tar.gz
 @PACKAGE_GOLANG_SOURCE@


### PR DESCRIPTION
Fedora had automatically updated the License field in apptainer.spec to these new names.