### PR TITLE
Add riscv64 support to mlocal host and target

### DIFF
--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -320,6 +320,9 @@ fi
 if echo | $hstcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	hst_arch=ppc64
 fi
+if echo | $hstcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+	hst_arch=riscv64
+fi
 if [ "$hst_arch" != "" ]; then
 	echo $hst_arch
 else
@@ -349,6 +352,9 @@ if echo | $tgtcc -E -dM - | grep -qs -e __aarch64 -e __aarch64__ -e __arm64 \
 fi
 if echo | $tgtcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	tgt_arch=ppc64
+fi
+if echo | $tgtcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+	tgt_arch=riscv64
 fi
 if [ "$tgt_arch" != "" ]; then
 	echo $tgt_arch
@@ -381,6 +387,9 @@ fi
 if echo | $hstcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	hst_word=64
 fi
+if echo | $hstcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+	hst_word=64
+fi
 if [ "$hst_word" != "" ]; then
 	echo $hst_word
 else
@@ -409,6 +418,9 @@ if echo | $tgtcc -E -dM - | grep -qs -e __aarch64 -e __aarch64__ -e __arm64 \
 	tgt_word=64
 fi
 if echo | $tgtcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
+	tgt_word=64
+fi
+if echo | $tgtcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
 	tgt_word=64
 fi
 if [ "$tgt_word" != "" ]; then


### PR DESCRIPTION
## Description of the Pull Request (PR):

Apparently I missed to add riscv64 support in mconfig/mlocal.

### This fixes or addresses the following GitHub issues:

 - #2809

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
