### PR TITLE
Add riscv64 support to mlocal host and target (release/1.4)

### DIFF
--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -320,6 +320,9 @@ fi
 if echo | $hstcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	hst_arch=ppc64
 fi
+if echo | $hstcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+	hst_arch=riscv64
+fi
 if [ "$hst_arch" != "" ]; then
 	echo $hst_arch
 else
@@ -349,6 +352,9 @@ if echo | $tgtcc -E -dM - | grep -qs -e __aarch64 -e __aarch64__ -e __arm64 \
 fi
 if echo | $tgtcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	tgt_arch=ppc64
+fi
+if echo | $tgtcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+	tgt_arch=riscv64
 fi
 if [ "$tgt_arch" != "" ]; then
 	echo $tgt_arch
@@ -381,6 +387,9 @@ fi
 if echo | $hstcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	hst_word=64
 fi
+if echo | $hstcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+	hst_word=64
+fi
 if [ "$hst_word" != "" ]; then
 	echo $hst_word
 else
@@ -409,6 +418,9 @@ if echo | $tgtcc -E -dM - | grep -qs -e __aarch64 -e __aarch64__ -e __arm64 \
 	tgt_word=64
 fi
 if echo | $tgtcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
+	tgt_word=64
+fi
+if echo | $tgtcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
 	tgt_word=64
 fi
 if [ "$tgt_word" != "" ]; then


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add riscv64 support to mlocal host and target

### This fixes or addresses the following GitHub issues:

 Backport #2832 