### PR TITLE
Fix Archlinux pacman.conf URL

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	defaultPacmanConfURL = "https://github.com/archlinux/svntogit-packages/raw/master/pacman/trunk/pacman.conf"
+	defaultPacmanConfURL = "https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/raw/main/pacman.conf"
 )
 
 // Default list of packages to install when bootstrapping arch


### PR DESCRIPTION
## Fix Archlinux `pacman.conf` URL

In the Arch bootstrap, a default pacman config is downloaded. But the repo `github.com/archlinux/svntogit-packages` the config file is downloaded from, has been archived on May 20, 2023. The old `pacman.conf` in that repo includes the `[community]` package repo, which has been removed [1]. This causes building an Arch-based container to fail, if the user doesn't provide a `pacman.conf`.

This PR updates the URL to `pacman.conf` URL to the newest Archlinux repo on their Gitlab.

[1] https://archlinux.org/news/cleaning-up-old-repositories/


### This fixes or addresses the following GitHub issues:

 - Fixes #2849 


#### Before submitting a PR, make sure you have done the following:

- [X] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [X] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [X] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [X] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
