### PR TITLE
Fix a nil pointer panic cauesd by the unintialized image driver with   privileged encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changes since 1.4.0-rc.2
 
 - Fix `target: no such file or directory` error when extracting
   layers from certain OCI images that manipulate hard links across layers.
+- Fix a nil pointer panic cauesd by the unintialized image driver with
+  privileged encryption.
 
 ## v1.4.0 Release Candidate 2 - \[2025-03-4\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Changes since 1.4.0-rc.2
 
 - Fix `target: no such file or directory` error when extracting
   layers from certain OCI images that manipulate hard links across layers.
-- Fix a nil pointer panic cauesd by the unintialized image driver with
-  privileged encryption.
+- Fix the crash that happens when executing a privilege-encrypted container as
+  root.  
 
 ## v1.4.0 Release Candidate 2 - \[2025-03-4\]
 

--- a/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/cleanup_linux.go
@@ -171,7 +171,9 @@ func umount() (err error) {
 	}()
 
 	// empty target to signify to driver we are entering in the stop phase
-	imageDriver.Stop("")
+	if imageDriver != nil {
+		imageDriver.Stop("")
+	}
 
 	// gocryptfs related temp folders
 	var gocryptfsTmp []string


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix a nil pointer panic cauesd by the unintialized image driver with
  privileged encryption

### This fixes or addresses the following GitHub issues:

 - Fixes #2848


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
