### PR TITLE
Update gocryptfs and squashfuse versions (release-1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes since 1.4.0-rc.2
 - Fix the crash that happens when executing a privilege-encrypted container as
   root.
 - Update the default pacman `confURL` for `Bootstrap: arch` container builds.
+- Update the bundled gocryptfs to 2.5.1 and squashfuse to 0.6.0.
 
 ## v1.4.0 Release Candidate 2 - \[2025-03-4\]
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -33,8 +33,8 @@
 # For example, it has dash instead of tilde for release candidates.
 %global package_version @PACKAGE_VERSION@
 
-%global gocryptfs_version 2.5.0
-%global squashfuse_version 0.5.2
+%global gocryptfs_version 2.5.1
+%global squashfuse_version 0.6.0
 %global e2fsprogs_version 1.47.2
 %global fuse_overlayfs_version 1.14
 %global squashfs_tools_version 4.6.1


### PR DESCRIPTION
Cherry-pick #2858 to the release-1.4 branch.