### PR TITLE
Check for existence of /run/systemd/system when verifying cgroups can  be used via systemd manager.(from sylabs #3537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## v1.4.x changes
 
+- Check for existence of `/run/systemd/system` when verifying cgroups can be
+  used via systemd manager.
+
 Changes since 1.4.0
 
 ## v1.4.0 - \[2025-03-18\]

--- a/internal/pkg/cgroups/manager_linux_test.go
+++ b/internal/pkg/cgroups/manager_linux_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -23,6 +23,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/test"
 	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
+	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 )
 
 // This file contains tests that will run under cgroups v1 & v2, and test utility functions.
@@ -59,6 +60,9 @@ func runCgroupfsTests(t *testing.T, tests CgroupTests) {
 
 func runSystemdTests(t *testing.T, tests CgroupTests) {
 	t.Run("systemd", func(t *testing.T) {
+		if !fs.IsDir("/run/systemd/system") {
+			t.Skip("systemd not running as init on this host")
+		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				tt.testFunc(t, true)


### PR DESCRIPTION
## Description of the Pull Request (PR):

this PR cherry-picks and revises the sylabs PR
https://github.com/sylabs/singularity/pull/3537

### This fixes or addresses the following GitHub issues:

 - Fixes #2804


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
