### PR TITLE
Fix the version reported by gocryptfs

### DIFF
--- a/scripts/compile-dependencies
+++ b/scripts/compile-dependencies
@@ -55,11 +55,13 @@ for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs; do
 	    make
 	    ;;
 	gocryptfs)
+	    VER=${DIR/*-/}
+	    echo "v$VER" >VERSION
 	    # GOPROXY=off makes sure we fail instead of making network requests
 	    # the -B ldflags prevent rpm complaints about "No build ID note found"
 	    CGO_ENABLED=0 GOPROXY=off ./build.bash \
 		-mod=vendor -tags without_openssl \
-		-ldflags="-X main.GitVersion=%{gocryptfs_version} \
+		-buildvcs=false -ldflags="-X main.GitVersion=v$VER \
 		-B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`"
 	    ;;
 	*)


### PR DESCRIPTION
Avoid warning about not being able to determine the version.

Parse the version from the tarball name, and add the silent "v".

## Description of the Pull Request (PR):

Here is the output from the fixed version, leaving the zero date for reproducible builds:

`gocryptfs v2.5.1 without_openssl; go-fuse v2.5.0; 0000-00-00 go1.24.0 linux/amd64`

Added -buildvcs=false, to stop apptainer from trying to brand gocryptfs debuginfo.

You can verify with `go version -m gocryptfs`, which shows the recorded versions.

### This fixes or addresses the following GitHub issues:

 - Fixes #2872


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
