### PR TITLE
Build gocryptfs as default v1 instead of v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Check for existence of `/run/systemd/system` when verifying cgroups can be
   used via systemd manager.
+- Compile gocryptfs as v1 instead of v2 for x86_64, to work with older CPUs.
+  It now uses the default value of the go compiler, "GOAMD64=v1" upstream.
+  It is still _possible_ to set `GOAMD64` to a newer microarchitecture (v2+).
+  For instance RHEL 9 uses v2 and RHEL 10 uses v3 as their default values.
 
 Changes since 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Check for existence of `/run/systemd/system` when verifying cgroups can be
   used via systemd manager.
-- Compile gocryptfs as v1 instead of v2 for x86_64, to work with older CPUs.
-  It now uses the default value of the go compiler, "GOAMD64=v1" upstream.
-  It is still _possible_ to set `GOAMD64` to a newer microarchitecture (v2+).
+- Compile gocryptfs with the default `GOAMD64` microarchitecture of the go
+  compiler instead of always using `GOAMD64=v2`.
+  The default value in the upstream go compiler is `GOAMD64=v1`, to work with
+  older CPUs, although it can have a cost in performance on newer CPUs.
+  It is still possible to set `GOAMD64` to a newer microarchitecture (v2+).
   For instance RHEL 9 uses v2 and RHEL 10 uses v3 as their default values.
 
 Changes since 1.4.0

--- a/scripts/compile-dependencies
+++ b/scripts/compile-dependencies
@@ -57,6 +57,8 @@ for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs; do
 	gocryptfs)
 	    VER=${DIR/*-/}
 	    echo "v$VER" >VERSION
+	    # Don't hardcode the amd64 microarchitecture
+	    sed -e '/GOAMD64.*v2/d' -i.orig build.bash
 	    # GOPROXY=off makes sure we fail instead of making network requests
 	    # the -B ldflags prevent rpm complaints about "No build ID note found"
 	    CGO_ENABLED=0 GOPROXY=off ./build.bash \


### PR DESCRIPTION
It is still possible to build for v2 or v3, if you want.

But the default is v1, which means no SSE instructions.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #2873


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
