### PR TITLE
Don't look for riscv macro and riscv32

### DIFF
--- a/mlocal/checks/basechecks.chk
+++ b/mlocal/checks/basechecks.chk
@@ -320,7 +320,7 @@ fi
 if echo | $hstcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	hst_arch=ppc64
 fi
-if echo | $hstcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+if echo | $hstcc -E -dM - | grep -qs -e "__riscv_xlen 64"; then
 	hst_arch=riscv64
 fi
 if [ "$hst_arch" != "" ]; then
@@ -353,7 +353,7 @@ fi
 if echo | $tgtcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	tgt_arch=ppc64
 fi
-if echo | $tgtcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+if echo | $tgtcc -E -dM - | grep -qs -e "__riscv_xlen 64"; then
 	tgt_arch=riscv64
 fi
 if [ "$tgt_arch" != "" ]; then
@@ -387,7 +387,7 @@ fi
 if echo | $hstcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	hst_word=64
 fi
-if echo | $hstcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+if echo | $hstcc -E -dM - | grep -qs -e "__riscv_xlen 64"; then
 	hst_word=64
 fi
 if [ "$hst_word" != "" ]; then
@@ -420,7 +420,7 @@ fi
 if echo | $tgtcc -E -dM - | grep -qs -e __ARCH_PPC64 -e __PPC64__; then
 	tgt_word=64
 fi
-if echo | $tgtcc -E -dM - | grep -qs -e __riscv -e "__riscv_xlen 64"; then
+if echo | $tgtcc -E -dM - | grep -qs -e "__riscv_xlen 64"; then
 	tgt_word=64
 fi
 if [ "$tgt_word" != "" ]; then

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -342,7 +342,11 @@ elif [ "$DIST" = el8 ]; then
 		OSUTILS="$OSUTILS fuse-libs e2fsprogs-libs e2fsprogs"
 	fi
 elif [[ "$DIST" == suse20* ]] || [ "$DIST" = "opensuse-tumbleweed" ]; then
-	OSUTILS="$OSUTILS squashfs liblzo2-2 liblz4-1 libzstd1 libfuse3-3 $EXTRASUTILS $EPELUTILS"
+	FUSELIBSO=3
+	if [ "$DIST" = "opensuse-tumbleweed" ]; then
+		FUSELIBSO=4
+	fi
+	OSUTILS="$OSUTILS squashfs liblzo2-2 liblz4-1 libzstd1 libfuse3-$FUSELIBSO $EXTRASUTILS $EPELUTILS"
 	if $NEEDSFUSE2FS; then
 		OSUTILS="$OSUTILS fuse2fs"
 	fi


### PR DESCRIPTION
Only interested in riscv64, and not in riscv32 (unsupported).

Mistakenly thought `grep -e` would use AND, but it uses OR...

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #2878


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
