### PR TITLE
Build gocryptfs as default v1 instead of v2 - release-1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Check for existence of `/run/systemd/system` when verifying cgroups can be
   used via systemd manager.
+- Compile gocryptfs with the default `GOAMD64` microarchitecture of the go
+  compiler instead of always using `GOAMD64=v2`.
+  The default value in the upstream go compiler is `GOAMD64=v1`, to work with
+  older CPUs, although it can have a cost in performance on newer CPUs.
+  It is still possible to set `GOAMD64` to a newer microarchitecture (v2+).
+  For instance RHEL 9 uses v2 and RHEL 10 uses v3 as their default values.
 
 Changes since 1.4.0
 

--- a/scripts/compile-dependencies
+++ b/scripts/compile-dependencies
@@ -55,6 +55,8 @@ for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs; do
 	    make
 	    ;;
 	gocryptfs)
+	    # Don't hardcode the amd64 microarchitecture
+	    sed -e '/GOAMD64.*v2/d' -i.orig build.bash
 	    # GOPROXY=off makes sure we fail instead of making network requests
 	    # the -B ldflags prevent rpm complaints about "No build ID note found"
 	    CGO_ENABLED=0 GOPROXY=off ./build.bash \


### PR DESCRIPTION
## Description of the Pull Request (PR):

It is still possible to build for v2 or v3, if you want.

But the default is v1, which means no SSE instructions.

### This fixes or addresses the following GitHub issues:

 - Cherry-pick #2877

commit d913045c9a014e60c775a6a599b9c15b93231381