### PR TITLE
Fix the version reported by gocryptfs - release-1.4

### DIFF
--- a/scripts/compile-dependencies
+++ b/scripts/compile-dependencies
@@ -55,13 +55,15 @@ for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs; do
 	    make
 	    ;;
 	gocryptfs)
+	    VER=${DIR/*-/}
+	    echo "v$VER" >VERSION
 	    # Don't hardcode the amd64 microarchitecture
 	    sed -e '/GOAMD64.*v2/d' -i.orig build.bash
 	    # GOPROXY=off makes sure we fail instead of making network requests
 	    # the -B ldflags prevent rpm complaints about "No build ID note found"
 	    CGO_ENABLED=0 GOPROXY=off ./build.bash \
 		-mod=vendor -tags without_openssl \
-		-ldflags="-X main.GitVersion=%{gocryptfs_version} \
+		-buildvcs=false -ldflags="-X main.GitVersion=v$VER \
 		-B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`"
 	    ;;
 	*)


### PR DESCRIPTION

## Description of the Pull Request (PR):

Avoid warning about not being able to determine the version.

Parse the version from the tarball name, and add the silent "v".

### This fixes or addresses the following GitHub issues:

 - Cherry-pick #2876
