### PR TITLE
refine the error message of container creation failure when apptainer-suid is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   For instance RHEL 9 uses v2 and RHEL 10 uses v3 as their default values.
 - Fix a bug introduced in 1.4.0 that caused arm64 to be mis-converted to arm64v8
   and resulted in a failure when pulling OCI containers.
+- Add a clear error message if someone tries to use privileged network options
+  while not using setuid mode.
 
 Changes since 1.4.0
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2725,7 +2725,7 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 	}
 
 	allowedNetUnpriv := false
-	if euid != 0 && !forceFakerootNet {
+	if euid != 0 && !forceFakerootNet && !c.userNS {
 		// Is the user permitted in the list of unpriv users / groups permitted to use CNI?
 		allowedNetUser, err := user.UIDInList(euid, c.engine.EngineConfig.File.AllowNetUsers)
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

refine the error message of container creation failure when apptainer-suid is not installed

### This fixes or addresses the following GitHub issues:

 - Fixes #2871


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).

## Test

### UserNS enabled case
apptainer is built with `--without-suid`
```
➜  test apptainer shell --net --network=bridge ubuntu_24.04.sif
INFO:    Cleanup error: while unmounting /usr/local/var/apptainer/mnt/session/final directory: no such file or directory, while unmounting /usr/local/var/apptainer/mnt/session/rootfs directory: no such file or directory
FATAL:   container creation failed: network requires root or a suid installation with /etc/subuid --fakeroot; non-root users can only use --network=none unless permitted by the administrator
```

### suid enabled case
apptainer is built with `--with-suid`
```
➜  test apptainer shell --net --network=bridge ubuntu_24.04.sif 
Apptainer> exit
exit
```

