### PR TITLE
refine the error message of container creation failure when apptainer-suid is not installed (release-1.4.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   older CPUs, although it can have a cost in performance on newer CPUs.
   It is still possible to set `GOAMD64` to a newer microarchitecture (v2+).
   For instance RHEL 9 uses v2 and RHEL 10 uses v3 as their default values.
+- Add a clear error message if someone tries to use privileged network options
+  while not using setuid mode.
 
 Changes since 1.4.0
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2725,7 +2725,7 @@ func (c *container) prepareNetworkSetup(system *mount.System, pid int) (func(con
 	}
 
 	allowedNetUnpriv := false
-	if euid != 0 && !forceFakerootNet {
+	if euid != 0 && !forceFakerootNet && !c.userNS {
 		// Is the user permitted in the list of unpriv users / groups permitted to use CNI?
 		allowedNetUser, err := user.UIDInList(euid, c.engine.EngineConfig.File.AllowNetUsers)
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry picking commit 8b1cd17f00f2a3ed77726cf47309f23c09f1437e from PR https://github.com/apptainer/apptainer/pull/2891

### This fixes or addresses the following GitHub issues:

 - Fixes #2871


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
