### PR TITLE
Fix an issue that arm64 is mis-converted to arm64v8 resulting in the failure pulling images (release-1.4.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   For instance RHEL 9 uses v2 and RHEL 10 uses v3 as their default values.
 - Add a clear error message if someone tries to use privileged network options
   while not using setuid mode.
+- Fix a bug introduced in 1.4.0 that caused arm64 to be mis-converted to arm64v8
+  and resulted in a failure when pulling OCI containers.
 
 Changes since 1.4.0
 

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -357,7 +357,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 		sylog.Fatalf("While processing the arch and arch variant: %v", err)
 		return
 	}
-	dp, err := ociplatform.DefaultPlatform()
+	dp, err := ociplatform.PlatformFromArch(arch)
 	if err != nil {
 		sylog.Fatalf("%v", err)
 	}

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/internal/pkg/client/shub"
 	"github.com/apptainer/apptainer/internal/pkg/ociimage"
+	"github.com/apptainer/apptainer/internal/pkg/ociplatform"
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	"github.com/apptainer/apptainer/internal/pkg/util/uri"
 	"github.com/apptainer/apptainer/pkg/cmdline"
@@ -309,6 +310,11 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While processing the arch and arch variant: %v", err)
 			return
 		}
+		platform, err := ociplatform.PlatformFromArch(arch)
+		if err != nil {
+			sylog.Fatalf("While processing arch and platform: %v", err)
+			return
+		}
 		pullOpts := oci.PullOptions{
 			TmpDir:      tmpDir,
 			OciAuth:     ociAuth,
@@ -317,7 +323,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			NoCleanUp:   buildArgs.noCleanUp,
 			Pullarch:    arch,
 			ReqAuthFile: reqAuthFile,
-			Platform:    getOCIPlatform(),
+			Platform:    *platform,
 		}
 
 		_, err = oci.PullToFile(ctx, imgCache, pullTo, pullFrom, pullSandbox, pullOpts)

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -293,7 +293,8 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 	)
 
 	shamap := map[string]string{
-		"arm64":      "b118e86313b8da65a597ae0f773fb7cac49fac8e6666147a9443b172288c5306",
+		"arm64":      "ee74dfacff0fba9ec53b5f48dca94b1716b4e176425cb174fb1b58e973746ef8",
+		"arm64v8":    "b118e86313b8da65a597ae0f773fb7cac49fac8e6666147a9443b172288c5306",
 		"amd64":      "f38acf33dd020a91d4673e16c6ab14048b00a5fd83e334edd8b33d339103cf83",
 		"arm32v6":    "9fe584fc821b9ceaf4e04cd21ed191dfa553517728da94e3f50632523b3ab374",
 		"amd64uri":   "82e895f183a2f926f72ad8d28c3c36444ce37de4f9e1efeba35f4ed1643232d6",
@@ -358,6 +359,16 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
+		e2e.AsSubtest("pull arm64 image"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("pull"),
+		e2e.WithArgs([]string{"--force", "--arch", "arm64", "--arch-variant", "v8", sifname, "docker://alpine:3.6"}...),
+		e2e.ExpectExit(0),
+	)
+	ensureCachedWithSha(t, cacheDir, shamap["arm64v8"])
+
+	c.env.RunApptainer(
+		t,
 		e2e.AsSubtest("pull arm32v6 image"),
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("pull"),
@@ -367,7 +378,7 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 	ensureCachedWithSha(t, cacheDir, shamap["arm32v6"])
 
 	files = retrieveFileNames(t, cacheDir)
-	if len(files) != 3 {
+	if len(files) != 4 {
 		t.Fatalf("Unexpected cache files: %v", files)
 	}
 
@@ -392,7 +403,7 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 	ensureCachedWithSha(t, cacheDir, shamap["arm64v8uri"])
 
 	files = retrieveFileNames(t, cacheDir)
-	if len(files) != 5 {
+	if len(files) != 6 {
 		t.Fatalf("Unexpected cache files: %v", files)
 	}
 
@@ -452,7 +463,7 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 	)
 
 	files = retrieveFileNames(t, cacheDir)
-	if len(files) != 5 {
+	if len(files) != 6 {
 		t.Fatalf("Unexpected cache files: %v", files)
 	}
 }

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -41,6 +41,10 @@ type GoArch struct {
 }
 
 var ArchMap = map[string]GoArch{
+	"arm64": {
+		Arch: "arm64",
+		Var:  "",
+	},
 	"amd64": {
 		Arch: "amd64",
 		Var:  "",
@@ -266,7 +270,7 @@ func ConvertArch(arch, archVariant string) (string, error) {
 	switch arch {
 	case "arm64":
 		if archVariant == "" {
-			return "arm64v8", nil
+			return "arm64", nil
 		}
 		tmpArch := ""
 		if strings.HasPrefix(archVariant, "v") {


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry pick commit 66c8e3ae5f635eef72d226504278112768d784c7 from PR https://github.com/apptainer/apptainer/pull/2895


### This fixes or addresses the following GitHub issues:

 - Fixes #2894


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
