### PR TITLE
Allow multi-arch oci-archive with nested index - release-1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   while not using setuid mode.
 - Fix a bug introduced in 1.4.0 that caused arm64 to be mis-converted to arm64v8
   and resulted in a failure when pulling OCI containers.
+- Allow multi-arch oci-archive files that have a nested index with the manifest.
+  This is the default format (both for Docker and OCI) when using `nerdctl save`.
 
 Changes since 1.4.0
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

If the manifest for the image is an index, then look for the platform manifest that is satisfying the desired platform.

### This fixes or addresses the following GitHub issues:

 - Cherry-pick #2908
