### PR TITLE
Record metadata for original image used from oci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## v1.5.x changes
 
+- Record image digest metadata (sha256 from `RepoDigests`), for OCI registry images.
+  Also add the image name (ref) of the image from "docker", with registry and tag.
+  This is useful for traceability, when using `docker.io` or a tag like `latest`.
+  Unfortunately the feature does not work with "docker-archive" or "docker-daemon".
+
 ## v1.4.x changes
 
 - Check for existence of `/run/systemd/system` when verifying cgroups can be

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -341,6 +341,12 @@ func addBuildLabels(labels map[string]string, b *types.Bundle) error {
 		}
 	}
 
+	// Digest of image
+	if b.Opts.Tag != "" && b.Opts.Digest != "" {
+		labels["org.opencontainers.image.base.name"] = b.Opts.Tag
+		labels["org.opencontainers.image.base.digest"] = b.Opts.Digest
+	}
+
 	// Architecture of build
 	buildarch := oci.ArchMap[b.Opts.Arch]
 	labels["org.label-schema.build-arch"] = buildarch.Arch

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -171,6 +171,23 @@ func parseURI(uri string) (types.ImageReference, *GoArch, error) {
 	return imgRef, arch, err
 }
 
+// RepoDigest returns the (tag and) digest of a docker image
+func RepoDigest(ctx context.Context, uri string, topts *ociimage.TransportOptions) (tag string, digest string, err error) {
+	ref, _, err := parseURI(uri)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to parse image name %v: %v", uri, err)
+	}
+	if ref.Transport().Name() != "docker" {
+		return "", "", nil
+	}
+	// nolint:staticcheck
+	d, err := docker.GetDigest(ctx, ociimage.SystemContextFromTransportOptions(topts), ref)
+	if err != nil {
+		return "", "", err
+	}
+	return ref.DockerReference().String(), d.String(), nil
+}
+
 // ImageDigest obtains the digest of a uri's manifest
 func ImageDigest(ctx context.Context, uri string, topts *ociimage.TransportOptions) (digest string, err error) {
 	ref, arch, err := parseURI(uri)

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -194,6 +194,13 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 		imgCache = cp.b.Opts.ImgCache
 	}
 
+	tag, digest, err := build_oci.RepoDigest(ctx, ref, cp.topts)
+	if err != nil {
+		return err
+	}
+	b.Opts.Tag = tag
+	b.Opts.Digest = digest
+
 	// Fetch the image into a temporary containers/image oci layout dir.
 	cp.srcImg, err = ociimage.FetchToLayout(ctx, cp.topts, imgCache, ref, b.TmpDir)
 	if err != nil {

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -109,6 +109,10 @@ type Options struct {
 	Binds []string
 	// whether using gocryptfs to build and run encrypted containers
 	Unprivilege bool
+	// Tag info (from RepoTags)
+	Tag string
+	// Digest info (from RepoDigests)
+	Digest string
 	// Arch info
 	Arch string
 	// Authentication file for registry credentials


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add two new fields to the metadata, when building from `docker:`

`org.opencontainers.image.base.name`
`org.opencontainers.image.base.digest`

The fields used for Apptainer are the same that is used in the OCI image specification:

https://github.com/opencontainers/image-spec/blob/main/annotations.md

These record the information that is available, but hidden away:

```console
$ docker pull alpine
Using default tag: latest
latest: Pulling from library/alpine
Digest: sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
Status: Image is up to date for alpine:latest
docker.io/library/alpine:latest
```

In addition to the basic metadata that was previously recorded:

```
org.label-schema.usage.singularity.deffile.bootstrap: docker
org.label-schema.usage.singularity.deffile.from: alpine
```

```
org.opencontainers.image.base.digest: sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
org.opencontainers.image.base.name: docker.io/library/alpine:latest
```

We don't need to record the Id (ConfigFile) or the Manifest checksums:

docker inspect
```
        "Id": "sha256:aded1e1a5b3705116fa0a92ba074a5e0b0031647d9c315983ccba2ee5428ec8b",
        "RepoTags": [
            "alpine:latest"
        ],
        "RepoDigests": [
            "alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"
        ],
```

podman inspect
```
          "Id": "aded1e1a5b3705116fa0a92ba074a5e0b0031647d9c315983ccba2ee5428ec8b",
          "Digest": "sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c",
          "RepoTags": [
               "docker.io/library/alpine:latest"
          ],
          "RepoDigests": [
               "docker.io/library/alpine@sha256:1c4eef651f65e2f7daee7ee785882ac164b02b78fb74503052a26dc061c90474",
               "docker.io/library/alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"
          ],
```

But we should record the full name of the image, and the full digest.

https://hub.docker.com/layers/library/alpine/latest/images/sha256-a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c

https://www.redhat.com/en/blog/be-careful-when-pulling-images-short-name

Note: 1c4eef651f65 is the amd64 manifest, that was picked from the image index

```
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1022,
         "digest": "sha256:1c4eef651f65e2f7daee7ee785882ac164b02b78fb74503052a26dc061c90474",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
```

But we should record the digest that is the same for all platforms.

```
org.label-schema.build-arch: amd64
org.label-schema.build-date: Tuesday_22_April_2025_18:46:13_CEST
```

### This fixes or addresses the following GitHub issues:

 - Fixes #2764


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
