### PR TITLE
Read docker-archive as oci-archive if compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   Also add the image name (ref) of the image from "docker", with registry and tag.
   This is useful for traceability, when using `docker.io` or a tag like `latest`.
   Unfortunately the feature does not work with "docker-archive" or "docker-daemon".
+- Test if docker-archive is actually an oci-archive (since Docker version 25),
+  and if it is oci then use the OCI parser to avoid bugs in the Docker parser.
 
 ## v1.4.x changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   Unfortunately the feature does not work with "docker-archive" or "docker-daemon".
 - Test if docker-archive is actually an oci-archive (since Docker version 25),
   and if it is oci then use the OCI parser to avoid bugs in the Docker parser.
+  Save the daemon-daemon references to a temporary docker-archive, to benefit
+  from the same improvements also for those references. Parse as oci-archive.
 
 ## v1.4.x changes
 

--- a/internal/pkg/ociimage/fetch.go
+++ b/internal/pkg/ociimage/fetch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/cache"
 	progressClient "github.com/apptainer/apptainer/internal/pkg/client"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/docker/docker/client"
 	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
@@ -61,6 +62,27 @@ func cachedImage(ctx context.Context, imgCache *cache.Handle, srcImg v1.Image) (
 // subdirectory of the provided tmpDir. The caller is responsible for cleaning
 // up tmpDir.
 func FetchToLayout(ctx context.Context, tOpts *TransportOptions, imgCache *cache.Handle, imageURI, tmpDir string) (ggcrv1.Image, error) {
+	// docker-daemon - Save archive to a temporary file, possibly in OCI format.
+	//                 This is to be able to use the new docker-archive code below.
+	if strings.HasPrefix(imageURI, "docker-daemon:") {
+		tmp, err := os.CreateTemp(tOpts.TmpDir, "*.tar")
+		if err != nil {
+			return nil, fmt.Errorf("could not create temporary docker archive: %v", err)
+		}
+
+		// docker-daemon:<name>[:tag|digest]
+		refParts := strings.SplitN(imageURI, ":", 3)
+		ref := refParts[1]
+		if len(refParts) == 3 {
+			ref = ref + ":" + refParts[2]
+		}
+		sylog.Debugf("Saving docker-daemon %q to %q", ref, tmp.Name())
+		err = saveArchive(ctx, tOpts, ref, tmp.Name())
+		if err != nil {
+			return nil, fmt.Errorf("error saving the docker archive file: %v", err)
+		}
+		imageURI = "docker-archive:" + tmp.Name()
+	}
 	// docker-archive - First test if it is also an oci-archive, and if so use it.
 	//                  The newer format avoids go-containerregistry sha256 issues.
 	if strings.HasPrefix(imageURI, "docker-archive:") {
@@ -137,6 +159,32 @@ func FetchToLayout(ctx context.Context, tOpts *TransportOptions, imgCache *cache
 	rt.ProgressWait()
 
 	return OCISourceSink.Image(ctx, tmpLayout, tOpts, nil)
+}
+
+// Save as tar from the docker-daemon, using the given image reference
+func saveArchive(ctx context.Context, tOpts *TransportOptions, src string, dst string) error {
+	var opt client.Opt
+	if tOpts != nil && tOpts.DockerDaemonHost != "" {
+		opt = client.WithHost(tOpts.DockerDaemonHost)
+	} else {
+		opt = client.WithHostFromEnv()
+	}
+	dc, err := client.NewClientWithOpts(opt, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return err
+	}
+	r, err := dc.ImageSave(ctx, []string{src})
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	w, err := os.OpenFile(dst, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+	_, err = io.Copy(w, r)
+	return err
 }
 
 // Check if tar(gz) is really a oci-archive in addition to docker-archive


### PR DESCRIPTION
## Description of the Pull Request (PR):

Newer versions of Docker (since 25) save images in a new format compatible with both docker (manifest.json) and oci (index.json)

This triggered some bugs with parsers of the old format, and the workarounds had some issues with performance and memory usage...

Old format: (`docker-archive`)

```
0dc77ddffdf9b490233380ffaf88c5cb65d61ade165394a7d16a4673b90c9ab6/
0dc77ddffdf9b490233380ffaf88c5cb65d61ade165394a7d16a4673b90c9ab6/VERSION
0dc77ddffdf9b490233380ffaf88c5cb65d61ade165394a7d16a4673b90c9ab6/json
0dc77ddffdf9b490233380ffaf88c5cb65d61ade165394a7d16a4673b90c9ab6/layer.tar
aded1e1a5b3705116fa0a92ba074a5e0b0031647d9c315983ccba2ee5428ec8b.json
manifest.json
repositories
```

New format:

```
blobs/
blobs/sha256/
blobs/sha256/08000c18d16dadf9553d747a58cf44023423a9ab010aab96cf263d2216b8b350
blobs/sha256/11834567b56252a953f68289506f8ea00d4801769467ee8509e868c4b89ec56d
blobs/sha256/293baa240c37f3f57eee5d29d867e8ffa0f48a4d162d6127d189a1ac97794c13
blobs/sha256/aded1e1a5b3705116fa0a92ba074a5e0b0031647d9c315983ccba2ee5428ec8b
index.json
manifest.json
oci-layout
repositories
```

OCI format: (`oci-archive`)

```
blobs/
blobs/sha256/
blobs/sha256/aded1e1a5b3705116fa0a92ba074a5e0b0031647d9c315983ccba2ee5428ec8b
blobs/sha256/b0f6f1c319a1570f67352d490370f0aeb5c0e67a087baf2d5f301ad51ec18858
blobs/sha256/b3454025ce78fa93aba879b2824a06a59e2b8c5005b2a4286368433cd0f41cde
index.json
oci-layout
```

Note: the oci-archive layer is saved in the legacy gzip compression, that's why the sha256 differs.

In the docker-archive, the layers were saved uncompressed and then you ran pigz on the archive.

### This fixes or addresses the following GitHub issues:

 - Fixes #2789
 - Fixes #2904


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
