### PR TITLE
Update release action to ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release_assets:
     name: release_assets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
@@ -76,7 +76,7 @@ jobs:
 
   release_container_images:
     name: release_container_images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:


### PR DESCRIPTION
The release actions of 1.4.1 were aborted because ubuntu-20.04 in github actions is no longer supported.