### PR TITLE
Pass in computed golang version to docker container release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get golang version
+        id: min-go-version
+        run: echo "GOLANG_VERSION=$(scripts/get-min-go-version)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         if: env.do_release
         uses: docker/build-push-action@v5
@@ -131,6 +135,7 @@ jobs:
           file: dist/docker/Dockerfile
           build-args: |
             VERSION=${{ env.git_tag }}
+            GOLANG_VERSION=${{ steps.min-go-version.outputs.GOLANG_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -1,5 +1,6 @@
 ARG BASE_IMAGE=debian:bookworm-slim
-ARG GOLANG_IMAGE=golang:1.23.5-bookworm
+ARG GOLANG_VERSION="pass-in-as-build-arg"
+ARG GOLANG_IMAGE=golang:${GOLANG_VERSION}-bookworm
 
 FROM --platform=${TARGETPLATFORM} ${BASE_IMAGE} AS debian-target
 FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} AS build


### PR DESCRIPTION
This fixes the github action to release a container of an apptainer version by passing in the calculated minimum go version instead of hardcoded.