### PR TITLE
Don't look for @ character in layout directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.4.1
 
+- Fix use of the image cache, when the home directory contains `@` characters.
+  Previously it would assume that it was the start of a digest in the oci-dir.
+
 ## v1.4.1 - \[2025-05-14\]
 
 - Fix the use of libsubid which had been broken by the revision applied in

--- a/internal/pkg/ociimage/sourcesink.go
+++ b/internal/pkg/ociimage/sourcesink.go
@@ -12,6 +12,7 @@ package ociimage
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	progressClient "github.com/apptainer/apptainer/internal/pkg/client"
@@ -69,9 +70,11 @@ func getDockerImage(ctx context.Context, src string, tOpts *TransportOptions, rt
 // If no digest is provided, and there is only one image in the layout, it will be returned.
 // A digest must be specified when retrieving an image from a layout containing multiple images.
 func getOCIImage(src string, tOpts *TransportOptions) (v1.Image, error) {
-	refParts := strings.SplitN(src, "@", 2)
+	dir, base := filepath.Split(src)
+	refParts := strings.SplitN(base, "@", 2)
 
-	lp, err := layout.FromPath(refParts[0])
+	file := filepath.Join(dir, refParts[0])
+	lp, err := layout.FromPath(file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

## Description of the Pull Request (PR):

There might be false positives, if the home directory contains @ characters. So only look in the file name.

### This fixes or addresses the following GitHub issues:

 - Fixes #2976 

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
