### PR TITLE
Default variant to v7 for architecture arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   Also add the image name (ref) of the image from "docker", with registry and tag.
   This is useful for traceability, when using `docker.io` or a tag like `latest`.
   Unfortunately the feature does not work with "docker-archive" or "docker-daemon".
+- Change the default `arm` variant to `v7`, and stop using the GOARM environment
+  variable. The variables GOOS, GOARCH and GOARM are only used when building.
 
 ## v1.4.x changes
 

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -320,15 +320,6 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 
 	c.env.RunApptainer(
 		t,
-		e2e.AsSubtest("pull image failure because --arch-variant is required"),
-		e2e.WithProfile(e2e.UserProfile),
-		e2e.WithCommand("pull"),
-		e2e.WithArgs([]string{"--force", "--arch", "arm", sifname, "docker://alpine:3.6"}...),
-		e2e.ExpectExit(255, e2e.ExpectError(e2e.ContainMatch, "arm needs variant specification")),
-	)
-
-	c.env.RunApptainer(
-		t,
 		e2e.AsSubtest("pull image failure because of wrong --arch-variant"),
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("pull"),

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -15,7 +15,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/apptainer/apptainer/internal/pkg/cache"
@@ -302,11 +301,7 @@ func ConvertArch(arch, archVariant string) (string, error) {
 		return tmpArch, nil
 	case "arm":
 		if archVariant == "" {
-			armVal, ok := os.LookupEnv("GOARM")
-			if !ok {
-				return "", fmt.Errorf("arch: %s needs variant specification, supported variants are [5, 6, 7], please set --arch-variant option", arch)
-			}
-			archVariant = armVal
+			return "arm32v7", nil
 		}
 		tmpArch := ""
 		if strings.HasPrefix(archVariant, "v") {
@@ -316,7 +311,7 @@ func ConvertArch(arch, archVariant string) (string, error) {
 		}
 		// verification
 		if _, ok := ArchMap[tmpArch]; !ok {
-			return "", fmt.Errorf("arch: %s is not valid, supported archs are: %v, supported variants are [5, 6, 7]", tmpArch, supportedArchs)
+			return "", fmt.Errorf("arch: %s is not valid, supported archs are: %v, supported variants are [5, 6, 7], please remove --arch-variant option", tmpArch, supportedArchs)
 		}
 		return tmpArch, nil
 	default:

--- a/internal/pkg/ociimage/transport.go
+++ b/internal/pkg/ociimage/transport.go
@@ -12,7 +12,6 @@ package ociimage
 import (
 	"errors"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"golang.org/x/sys/cpu"
 )
 
 var ociTransports = []string{"docker", "docker-archive", "docker-daemon", "oci", "oci-archive"}
@@ -235,9 +235,12 @@ func defaultSysCtx() *types.SystemContext {
 		sysCtx.ArchitectureChoice = runtime.GOARCH
 		sysCtx.VariantChoice = "v8"
 	case "arm":
-		if variance, ok := os.LookupEnv("GOARM"); ok {
+		if !cpu.ARM.HasVFP {
 			sysCtx.ArchitectureChoice = runtime.GOARCH
-			sysCtx.VariantChoice = "v" + variance
+			sysCtx.VariantChoice = "v5"
+		} else if !cpu.ARM.HasVFPv3 {
+			sysCtx.ArchitectureChoice = runtime.GOARCH
+			sysCtx.VariantChoice = "v6"
 		} else {
 			// by default, we are using arm32v7
 			sysCtx.ArchitectureChoice = runtime.GOARCH


### PR DESCRIPTION
There are very few arm32 systems still using armv5 and armv6, so might as well have the default be armv7 (like in Docker).

Also we should not use the buildtime variables to determine what variant to use by default, based that on CPU instead.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #2807

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
