### PR TITLE
ubuntu ppa autobuild

### DIFF
--- a/.github/workflows/ubuntu-ppa-release.yml
+++ b/.github/workflows/ubuntu-ppa-release.yml
@@ -1,0 +1,139 @@
+name: ubuntu-ppa
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: 'apptainer published tag (e.g. 1.4.1), this is used for retrieving tagged source code)'
+        required: true
+      revision:
+        type: number
+        description: 'publish revision number (default: 1)'
+        required: false
+        default: 1
+      sub_tag:
+        type: string
+        description: 'sub tags to append (e.g. stable => 1.4.1-stable),this will add sub tags to the above main tag to create different changelogs and uploads'
+        required: false
+jobs:
+  prepare:
+    name: prepare
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: git fetch --prune --unshallow --tags --force
+
+      - name: Prepare the apptainer source package
+        run: |
+          if [ -z "${{ inputs.tag }}"]; then
+            echo "Skipping because no apptainer tag is defined"
+            # terminate the job
+            exit 1
+          fi
+
+          APPTAINER_VERSION="${{ inputs.tag }}"
+
+          # download released apptainer-{APPTAINER_VERSION}.tar.gz from github
+          URL="https://github.com/apptainer/apptainer/releases/download/v$APPTAINER_VERSION/apptainer-$APPTAINER_VERSION.tar.gz"
+          wget -O "apptainer-$APPTAINER_VERSION.tar.gz" "$URL" && tar -xzvf "apptainer-$APPTAINER_VERSION.tar.gz" && rm -rf "apptainer-$APPTAINER_VERSION.tar.gz"
+
+          # update scripts/ci-deb-build-test script
+          new_content=$(cat << 'EOF'
+          su testuser -c '
+            set -x
+            set -e
+            mv dist/debian .
+            MIN_VERSION="$(scripts/get-min-go-version)"
+            GOSRC="go$MIN_VERSION.src.tar.gz"
+            GOBIN_AMD64="go$MIN_VERSION.linux-amd64.tar.gz"
+            GOBIN_ARM64="go$MIN_VERSION.linux-arm64.tar.gz"
+            curl -f -L -sS -o debian/$GOBIN_AMD64 https://golang.org/dl/$GOBIN_AMD64
+            curl -f -L -sS -o debian/$GOBIN_ARM64 https://golang.org/dl/$GOBIN_ARM64
+            if [ -n "'$GO_ARCH'" ]; then
+              # Download and install binary too to avoid debuild having to compile the
+              #  go toolchain from source
+              GOBIN="$(echo "$GOSRC"|sed "s/\.src./.'$GO_ARCH'./")"
+              tar -xzf debian/"$GOBIN" -C /local
+              PATH=/local/go/bin:$PATH
+            fi
+            go version
+            ./scripts/download-dependencies debian
+            find debian/ -type f -name "*.tar.gz" -printf "debian/%f\n" >> debian/source/include-binaries
+            export DEB_FULLNAME="'"${DEB_FULLNAME:-CI Test}"'"
+            export DEBEMAIL="'${DEBEMAIL:-citest@example.com}'"
+            debuild --prepend-path $PATH -S -uc -us --lintian-opts --display-info --show-overrides
+          '
+          EOF
+          )
+
+          sed -i "69,95d" "apptainer-$APPTAINER_VERSION/scripts/ci-deb-build-test"
+          echo "$new_content" >> "apptainer-$APPTAINER_VERSION/scripts/ci-deb-build-test"
+          sed -i '49c mv .??* !(src|*.orig.tar.gz) src' "apptainer-$APPTAINER_VERSION/scripts/ci-deb-build-test"
+
+          # copy the latest scripts/ubuntu-ppa into the orig.tar.gz
+          cp scripts/ubuntu-ppa "apptainer-$APPTAINER_VERSION/scripts/ubuntu-ppa"
+
+          # retar the apptainer folder to create .orig.tar.gz file for debuild to use
+          tar --exclude="apptainer-$APPTAINER_VERSION/dist/debian" -czf "apptainer_$APPTAINER_VERSION.orig.tar.gz" -C "apptainer-$APPTAINER_VERSION/" .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: apptainer-artifact
+          path: "*.orig.tar.gz"
+
+  ubuntu-ppa-release:
+    runs-on: ubuntu-22.04
+    needs: prepare
+    strategy:
+      matrix:
+        include:
+            - version: '24.04'
+              name: noble
+            - version: '22.04'
+              name: jammy
+            - version: '20.04'
+              name: focal
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: apptainer-artifact
+
+      - name: Build and push to Ubuntu PPA
+        env:
+          OS_TYPE: ubuntu
+          OS_VERSION: ${{matrix.version}}
+          OS_NAME: ${{matrix.name}}
+          GO_ARCH: linux-amd64
+        run: |
+          APPTAINER_VERSION="${{ inputs.tag }}"
+          BUILD_VERSION="${{ inputs.tag }}"
+          if [ -n "${{ inputs.sub_tag }}" ]; then
+            BUILD_VERSION="${{ inputs.tag }}-${{ inputs.sub_tag }}"
+          fi
+          APPTAINER_REVISION="${{ inputs.revision }}"
+
+          # install necessary packages
+          sudo apt update && sudo apt install -y devscripts
+
+          # set target_ppa environment variable
+          export TARGET_PPA="${{ vars.TARGET_PPA }}"
+
+          # set gpg keys
+          echo "${{ secrets.APPTAINER_UBUNTU_PPA_PRIVATE_KEY }}" | gpg --batch --import --passphrase "${{ secrets.APPTAINER_UBUNTU_PPA_PRIVATE_KEY_PASSPHRASE }}" 
+          export GPG_PASSPHRASE="${{ secrets.APPTAINER_UBUNTU_PPA_PRIVATE_KEY_PASSPHRASE }}"
+          gpg --list-keys
+
+          # uncompress the apptainer source code
+          mkdir -p "apptainer-$APPTAINER_VERSION"
+          tar -xzvf "apptainer_$APPTAINER_VERSION.orig.tar.gz" -C "apptainer-$APPTAINER_VERSION/"
+          mv "apptainer_$APPTAINER_VERSION.orig.tar.gz" "apptainer-$APPTAINER_VERSION/apptainer_$BUILD_VERSION.orig.tar.gz"
+          cd "apptainer-$APPTAINER_VERSION"
+
+          # call real script to build and push
+          ./scripts/ubuntu-ppa "$BUILD_VERSION" "$APPTAINER_REVISION"
+
+          # cleanup
+          unset GPG_PASSPHRASE

--- a/scripts/ubuntu-ppa
+++ b/scripts/ubuntu-ppa
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -ne 2 ];then
+   echo "Should be exactly two args passed"
+   exit 1
+fi
+
+if [ -z $1 ]; then
+   echo "Apptainer version is empty"
+   exit 1
+fi
+
+APPTAINER_VERSION=$1
+APPTAINER_REVISION=$2
+
+if [ -z "${OS_TYPE}" ]; then
+   echo "OS_TYPE is unset"
+   exit 1
+fi
+
+if [ -z "${OS_VERSION}" ]; then
+   echo "OS_VERSION is unset"
+   exit 1
+fi
+
+if [ -z "${OS_NAME}" ]; then
+   echo "OS_NAME is unset"
+   exit 1
+fi
+
+if [ -z "${TARGET_PPA}" ]; then
+   echo "TARGET_PPA is unset"
+   exit 1
+fi
+
+if [ -z "${GO_ARCH}" ]; then
+   GO_ARCH="linux-amd64"
+fi
+
+BUILD_VERSION="$APPTAINER_VERSION-$APPTAINER_REVISION~$OS_NAME"
+
+# replace debian related stuffs for debuild
+sed -i "s/0.1.0-1/$BUILD_VERSION/g" dist/debian/changelog
+sed -i "s/unstable/$OS_NAME/g" dist/debian/changelog
+sed -i "s/Placeholder/rebuild for $OS_NAME/g" dist/debian/changelog
+
+sed -i '82,83d' dist/debian/rules
+sed -i "81c \ \ \ \ \ \ \ \ \ \ \ \ tar -xf \$\$HERE/debian/go\$(MINGO_VERSION).\$(GO_ARCH).tar.gz; \\\\" dist/debian/rules
+# sed -i '81c \    \    \    tar -xf $$HERE/debian/go$(MINGO_VERSION).$(GO_ARCH).tar.gz; \\' dist/debian/rules
+sed -i '31i GOMODCACHE = $${TMPDIR:-/tmp}/appdebgo/modcache' dist/debian/rules
+sed -i '9i GO_ARCH := linux-$(shell dpkg --print-architecture)' dist/debian/rules
+sed -i 's/GOCACHE=\$(GOCACHE)/GOCACHE=\$(GOCACHE) GOMODCACHE=\$(GOMODCACHE)/g' dist/debian/rules
+
+# real build
+./scripts/ci-docker-run
+
+# change permission, sign the changes and upload via dput
+sudo chown "$USER:$USER" .
+sudo chown "$USER:$USER" ..
+find . -maxdepth 1 -type f -exec sudo chown -R "$USER:$USER" {} \;
+sed -i "s/Changed-By: Gregory M\. Kurtzer <gmkurtzer@gmail\.com>/Changed-By: Xu Yang <jasonyangshadow@gmail\.com>/" "apptainer_${BUILD_VERSION}_source.changes"
+debsign -p "gpg --pinentry-mode loopback --passphrase $GPG_PASSPHRASE" -S -k FECD51E916A94E226507325F20DCFCC7C2389D6B apptainer_${BUILD_VERSION}_source.changes
+dput -f -U "${TARGET_PPA}" "apptainer_${BUILD_VERSION}_source.changes" 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Create automated builds for ubuntu PPA


### This fixes or addresses the following GitHub issues:

 - Fixes #2869


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).

## Description:

The `workflow_dispatch` is only triggered on `main` branch. so it'll be unavailable on the actions tab until this PR gets merged.

![image](https://github.com/user-attachments/assets/8105f38e-4ef5-4b6a-bef9-db2a09fff2ce)

1. `apptaienr published tag (e.g. 1.4.1)` => Fill in the already published apptainer tag (e.g. 1.4.1, this tag is used for downloading the apptainer-{tag}.tar.gz file from github)
2. `publish ppa, ppa:apptainer/ppa => prod, others => test` => Choose the published ppa. (we need to set the proper gpg private_key and private_key_passphrase on the github settings, as well as the Ubuntu PPA launchpad settings)
3. `publish revision number (default: 1)` => Publish revision number, no need to change unless previous builds failed, then we need to change the revision number and the following `new_tag` to overwrite the `.orig.tar.gz` file
4. `publish tag, this will rename the published apptainer tag (e.g. 1.4.1-unofficial)` => Use together with the above field, if previous builds failed and you need to test changes. (can write anything, this would change the name of the .orig.tar.gz file). 

## Attention:
Following file changes:
```
scripts/ci-deb-bulld-test
dist/debian/changelog
dist/debian/rules
```
and other build-related file changes might corrupt the PPA builds, as the script heavily modifies existing builds scripts and changes might result in the corruption. 

## Test:
existing builds:

https://launchpad.net/~jasonyangshadow/+archive/ubuntu/unofficial-apptainer/+packages

![image](https://github.com/user-attachments/assets/6addb593-1ad4-4b66-8b55-e5c64eb8a3ed)

```
vagrant@vagrant:~$ sudo add-apt-repository ppa:jasonyangshadow/unofficial-apptainer
Repository: 'Types: deb
URIs: https://ppa.launchpadcontent.net/jasonyangshadow/unofficial-apptainer/ubuntu/
Suites: noble
Components: main
'
Description:
unofficial-apptainer test repository, to install apptainer please go to this PPA:
ppa: apptainer/apptainer
More info: https://launchpad.net/~jasonyangshadow/+archive/ubuntu/unofficial-apptainer
Adding repository.
Press [ENTER] to continue or Ctrl-c to cancel.
Hit:1 https://download.docker.com/linux/ubuntu noble InRelease
Get:2 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Hit:3 http://us.archive.ubuntu.com/ubuntu noble InRelease
Get:4 http://security.ubuntu.com/ubuntu noble-security/main amd64 Components [21.5 kB]
Get:5 http://us.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:6 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Components [212 B]
Get:7 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Components [52.2 kB]
Get:8 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Components [212 B]
Get:9 https://ppa.launchpadcontent.net/jasonyangshadow/unofficial-apptainer/ubuntu noble InRelease [17.8 kB]
Get:10 https://ppa.launchpadcontent.net/jasonyangshadow/unofficial-apptainer/ubuntu noble/main amd64 Packages [820 B]
Get:11 http://us.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:12 https://ppa.launchpadcontent.net/jasonyangshadow/unofficial-apptainer/ubuntu noble/main Translation-en [628 B]
Get:13 http://us.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [161 kB]
Get:14 http://us.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Components [212 B]
Get:15 http://us.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [376 kB]
Get:16 http://us.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
Get:17 http://us.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [7,060 B]
Get:18 http://us.archive.ubuntu.com/ubuntu noble-backports/restricted amd64 Components [216 B]
Get:19 http://us.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [16.4 kB]
Get:20 http://us.archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Components [212 B]
Fetched 1,034 kB in 3s (323 kB/s)
Reading package lists... Done
```

```
vagrant@vagrant:~$ sudo apt search apptainer
Sorting... Done
Full Text Search... Done
apptainer/noble 1.4.0-unofficial-1~noble amd64
  container platform focused on supporting "Mobility of Compute" formerly known as Singularity

apptainer-suid/noble 1.4.0-unofficial-1~noble amd64
  setuid-root portion of apptainer

golang-github-apptainer-container-key-client-dev/noble 0.7.2-2 all
  Go client for Apptainer key storage and retrieval using HKP (library)

golang-github-apptainer-container-library-client-dev/noble 1.2.2-2 all
  Golang client for Apptainer container library (library)

```

```
vagrant@vagrant:~$ sudo apt install apptainer
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  apptainer
0 upgraded, 1 newly installed, 0 to remove and 15 not upgraded.
Need to get 30.6 MB of archives.
After this operation, 131 MB of additional disk space will be used.
Get:1 https://ppa.launchpadcontent.net/jasonyangshadow/unofficial-apptainer/ubuntu noble/main amd64 apptainer amd64 1.4.0-unofficial-1~noble [30.6 MB]
Fetched 30.6 MB in 1min 27s (354 kB/s)
Selecting previously unselected package apptainer.
(Reading database ... 71408 files and directories currently installed.)
Preparing to unpack .../apptainer_1.4.0-unofficial-1~noble_amd64.deb ...
Unpacking apptainer (1.4.0-unofficial-1~noble) ...
Setting up apptainer (1.4.0-unofficial-1~noble) ...
Processing triggers for man-db (2.12.0-4build2) ...
Scanning processes...
Scanning linux images...

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
vagrant@vagrant:~$ apptainer version
1.4.0
```