### PR TITLE
patch the sign key info

### DIFF
--- a/.github/workflows/ubuntu-ppa-release.yml
+++ b/.github/workflows/ubuntu-ppa-release.yml
@@ -121,6 +121,9 @@ jobs:
           # set target_ppa environment variable
           export TARGET_PPA="${{ vars.TARGET_PPA }}"
 
+          # set PPA_SIGN_KEY environment variable
+          export PPA_SIGN_KEY="${{ vars.PPA_SIGN_KEY }}"
+
           # set gpg keys
           echo "${{ secrets.APPTAINER_UBUNTU_PPA_PRIVATE_KEY }}" | gpg --batch --import --passphrase "${{ secrets.APPTAINER_UBUNTU_PPA_PRIVATE_KEY_PASSPHRASE }}" 
           export GPG_PASSPHRASE="${{ secrets.APPTAINER_UBUNTU_PPA_PRIVATE_KEY_PASSPHRASE }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Changes since 1.4.1
 
 - Fix use of the image cache, when the home directory contains `@` characters.
   Previously it would assume that it was the start of a digest in the oci-dir.
+- Add support of automatic triggering of Ubuntu PPA builds.
 
 ## v1.4.1 - \[2025-05-14\]
 

--- a/scripts/ubuntu-ppa
+++ b/scripts/ubuntu-ppa
@@ -35,6 +35,11 @@ if [ -z "${TARGET_PPA}" ]; then
    exit 1
 fi
 
+if [ -z "${PPA_SIGN_KEY}" ]; then
+   echo "PPA_SIGN_KEY is unset"
+   exit 1
+fi
+
 if [ -z "${GO_ARCH}" ]; then
    GO_ARCH="linux-amd64"
 fi
@@ -60,6 +65,6 @@ sed -i 's/GOCACHE=\$(GOCACHE)/GOCACHE=\$(GOCACHE) GOMODCACHE=\$(GOMODCACHE)/g' d
 sudo chown "$USER:$USER" .
 sudo chown "$USER:$USER" ..
 find . -maxdepth 1 -type f -exec sudo chown -R "$USER:$USER" {} \;
-sed -i "s/Changed-By: Gregory M\. Kurtzer <gmkurtzer@gmail\.com>/Changed-By: Xu Yang <jasonyangshadow@gmail\.com>/" "apptainer_${BUILD_VERSION}_source.changes"
-debsign -p "gpg --pinentry-mode loopback --passphrase $GPG_PASSPHRASE" -S -k FECD51E916A94E226507325F20DCFCC7C2389D6B apptainer_${BUILD_VERSION}_source.changes
+sed -i "s/Changed-By: Gregory M\. Kurtzer <gmkurtzer@gmail\.com>/Changed-By: TSC <tsc@apptainer\.org>/" "apptainer_${BUILD_VERSION}_source.changes"
+debsign -p "gpg --pinentry-mode loopback --passphrase $GPG_PASSPHRASE" -S -k "${PPA_SIGN_KEY}" "apptainer_${BUILD_VERSION}_source.changes"
 dput -f -U "${TARGET_PPA}" "apptainer_${BUILD_VERSION}_source.changes" 


### PR DESCRIPTION
## Description of the Pull Request (PR):

patching previous merged PR, added environment variables for signing key, and updated the `change-by` property. 

## Test:
my pr merge:
https://github.com/JasonYangShadow/apptainer/pull/83

github build:
https://github.com/JasonYangShadow/apptainer/actions/runs/15973977756

launchpad ppa: (see 1.4.1-unofficial-6-1)
https://launchpad.net/~jasonyangshadow/+archive/ubuntu/unofficial-apptainer/+packages

add new `repository variable` `SIGN_KEY`
![image](https://github.com/user-attachments/assets/2185fa99-ed6b-4e7b-93f4-f84c4227546f)

### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
