### PR TITLE
Restore github issue template capability

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/default-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/default-issue-template.md
@@ -1,3 +1,12 @@
+---
+name: Default issue template
+about: Default template for all
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 ### Version of Apptainer
 
 What version of Apptainer (or Singularity) are you using? Run


### PR DESCRIPTION
This restores the github issue template.   See why it was needed in apptainer/apptainer-userdocs#348.