### PR TITLE
Correct markdown link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 If you suspect you have found a vulnerability in Apptainer we want
 to work with you so that it can be investigated, fixed, and disclosed in
-a responsible manner. Please follow the steps in our published `Security
-Policy <https://apptainer.org/security-policy/>`__, which begins with
-contacting us privately via `security@apptainer.org`
+a responsible manner. Please follow the steps in our published
+[Security Policy](https://apptainer.org/security-policy/), which begins with
+contacting us privately via `security@apptainer.org`.
 
 We disclose vulnerabilities found in Apptainer through public
 CVE reports, and notifications on our community channels. We encourage


### PR DESCRIPTION
I noticed this because the "New issue" button now offers people an option between looking at SECURITY.md or creating a regular issue.