### PR TITLE
Restore looking for registry mirrors in /etc/containers/registry.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.4.1
 
+- Restore looking for registry mirrors in `/etc/containers/registry.conf`
+  and related files.  This had been inadvertently dropped beginning in 1.4.0.
 - Fix use of the image cache, when the home directory contains `@` characters.
   Previously it would assume that it was the start of a digest in the oci-dir.
 - Add support of automatic triggering of Ubuntu PPA builds.

--- a/internal/pkg/ociimage/sourcesink.go
+++ b/internal/pkg/ociimage/sourcesink.go
@@ -18,6 +18,9 @@ import (
 	progressClient "github.com/apptainer/apptainer/internal/pkg/client"
 	"github.com/apptainer/apptainer/internal/pkg/util/ociauth"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/pkg/sysregistriesv2"
+	"github.com/containers/image/v5/types"
 	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -47,6 +50,57 @@ func getDockerImage(ctx context.Context, src string, tOpts *TransportOptions, rt
 	srcRef, err := name.ParseReference(src, nameOpts...)
 	if err != nil {
 		return nil, err
+	}
+
+	// See if there's a mirror to use for this registry by applying
+	// containers/image library functions.
+	// This may one day be done automatically by go-containerregistry.
+	// If that happens we can remove this code.
+	// See https://github.com/apptainer/apptainer/issues/2919
+	host := srcRef.Context().Registry.Name()
+	var regctx types.SystemContext
+	registry, _ := sysregistriesv2.FindRegistry(&regctx, host)
+	if host == "index.docker.io" {
+		// This is the default registry; if it failed to find a mirror,
+		// instead try the equivalent shorter version that might be
+		// defined with a mirror.
+		host = "docker.io"
+		if registry == nil {
+			registry, _ = sysregistriesv2.FindRegistry(&regctx, host)
+		}
+	}
+	if (registry != nil) && (len(registry.Mirrors) > 0) {
+		mirror := registry.Mirrors[0].Location
+		nameOpts = []name.Option{}
+		if registry.Mirrors[0].Insecure {
+			nameOpts = append(nameOpts, name.Insecure)
+		}
+		mirrorSrc := src
+		// Normalize the src, for example by prefixing docker.io and
+		// adding library/ for standard docker.io containers, because
+		// mirrors expect this to already be done.
+		normalizedRef, err := reference.ParseNormalizedNamed(mirrorSrc)
+		if err != nil {
+			sylog.Debugf("Normalizing %s failed, using as-is: %v", mirrorSrc, err)
+		} else {
+			mirrorSrc = normalizedRef.String()
+		}
+		// remove the first component if it was an explicit registry
+		mirrorParts := strings.Split(mirrorSrc, "/")
+		if (host != "docker.io") || strings.HasSuffix(mirrorParts[0], host) {
+			// this should always happen unless normalizing
+			// failed and the src is missing a registry name
+			mirrorSrc = strings.Join(mirrorParts[1:], "/")
+		}
+		// then add the mirror in its place
+		mirrorSrc = mirror + "/" + mirrorSrc
+		sylog.Debugf("Using %s mirror in place of %s", mirrorSrc, src)
+		mirrorRef, err := name.ParseReference(mirrorSrc, nameOpts...)
+		if err != nil {
+			sylog.Warningf("Error parsing registry mirror reference %s, skipping mirror: %v", mirrorSrc, err)
+		} else {
+			srcRef = mirrorRef
+		}
 	}
 
 	pullOpts := []remote.Option{


### PR DESCRIPTION
This restores identifying and using registry mirrors defined in `/etc/containers/registry.conf`, `/etc/containers/registry.conf.d/*.conf`, and `~/.config/containers/registry.conf`.  These use libraries in `containers/image/v5` which we had stopped using due to the conversion to go-containerregistry libraries in 1.4.0.

- Fixes #2919 