### PR TITLE
Restore looking for mirrors in /etc/containers/registry.conf (release-1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.4.1
 
+- Restore looking for registry mirrors in `/etc/containers/registry.conf`
+  and related files.  This had been inadvertently dropped beginning in 1.4.0.
 - Add support of automatic triggering of Ubuntu PPA builds.
 - Fix the signature verification failure for unsigned images.
 


### PR DESCRIPTION
This cherry-picks #3081 to the release-1.4 branch