### PR TITLE
Add trixie+ .deb package release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - run: git fetch --prune --unshallow --tags --force
 
       - name: Check if release is needed because tag matches latest annotated
         env:
@@ -47,9 +46,8 @@ jobs:
           ./scripts/ci-docker-run
           cp *.tar.gz *.rpm ..
           cd ..
-          sha256sum *.tar.gz *.rpm > sha256sums
 
-      - name: Make deb packages
+      - name: Make standard deb packages
         if: env.do_release
         env:
           OS_TYPE: debian
@@ -63,7 +61,23 @@ jobs:
           ./scripts/ci-docker-run
           cp *.deb ..
           cd ..
-          sha256sum *.deb >> sha256sums
+
+      - name: Make trixie deb packages
+        if: env.do_release
+        env:
+          OS_TYPE: debian
+          # once released, this version should change to 13
+          OS_VERSION: trixie
+          GO_ARCH: linux-amd64
+        run: |
+          # Make another new copy of the source files for this build
+          set -x
+          sudo rm -rf `basename apptainer-*.tar.gz .tar.gz`
+          tar xf apptainer-*.tar.gz
+          cd `basename apptainer-*.tar.gz .tar.gz`
+          ./scripts/ci-docker-run
+          for d in *.deb; do cp $d ../`echo $d|sed 's/\(_[^_]*$\)/-trixie+\1/'`; done
+          cd ..
 
       - name: Release
         if: env.do_release
@@ -73,7 +87,6 @@ jobs:
             *.tar.gz
             *.rpm
             *.deb
-            sha256sums
 
   release_container_images:
     name: release_container_images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.4.1
 
+Additional .deb packages have been added to the release assets that
+include the label "trixie+" to indicate that they are for installing on
+Debian 13 or later.  Those packages are necessary to work with the new
+libfuse3 library in Debian 13.  They also support libsubid, unlike the
+default packages because they are built on Debian 11 which doesn't have
+that library.
+
 - Restore looking for registry mirrors in `/etc/containers/registry.conf`
   and related files.  This had been inadvertently dropped beginning in 1.4.0.
 - Fix use of the image cache, when the home directory contains `@` characters.

--- a/scripts/ci-deb-build-test
+++ b/scripts/ci-deb-build-test
@@ -7,7 +7,7 @@
 # this script runs as root under docker --privileged
 
 OS_MAJOR=$(grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI' | cut -d'.' -f1)
-OS_NAME=$(grep ^NAME /etc/os-release | cut -d '=' -f2 | sed 's/\"//gI')
+OS_NAME=$(grep ^NAME /etc/os-release | cut -d '=' -f2 | sed 's/\"//gI;s/ .*//')
 OS_VERSION=$(grep ^VERSION_ID /etc/os-release | cut -d'=' -f2 | sed 's/\"//gI')
 
 # install dependencies


### PR DESCRIPTION
This adds additional trixie+ .deb files for running on Debian 13 or later.

- Fixes #3012 