### PR TITLE
Don't look for @ character in layout directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Changes since 1.4.1
   and related files.  This had been inadvertently dropped beginning in 1.4.0.
 - Add support of automatic triggering of Ubuntu PPA builds.
 - Fix the signature verification failure for unsigned images.
+- Fix use of the image cache, when the home directory contains `@` characters.
+  Previously it would assume that it was the start of a digest in the oci-dir.
 
 ## v1.4.1 - \[2025-05-14\]
 

--- a/internal/pkg/ociimage/sourcesink.go
+++ b/internal/pkg/ociimage/sourcesink.go
@@ -12,6 +12,7 @@ package ociimage
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	progressClient "github.com/apptainer/apptainer/internal/pkg/client"
@@ -123,9 +124,11 @@ func getDockerImage(ctx context.Context, src string, tOpts *TransportOptions, rt
 // If no digest is provided, and there is only one image in the layout, it will be returned.
 // A digest must be specified when retrieving an image from a layout containing multiple images.
 func getOCIImage(src string, tOpts *TransportOptions) (v1.Image, error) {
-	refParts := strings.SplitN(src, "@", 2)
+	dir, base := filepath.Split(src)
+	refParts := strings.SplitN(base, "@", 2)
 
-	lp, err := layout.FromPath(refParts[0])
+	file := filepath.Join(dir, refParts[0])
+	lp, err := layout.FromPath(file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

There might be false positives, if the home directory contains @ characters. So only look in the file name.

### This fixes or addresses the following GitHub issues:

 * Cherry-pick: #2977
