### PR TITLE
Add generation of debugsource rpms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   a comma-separated list of device IDs (e.g., `"1,2,3"`) or "all" to
   import all of them.  The default if `HABANA_VISIBLE_DEVICES` is not
   set is "all".
+- debugsource rpms are now generated in addition to debuginfo rpms on
+  RHEL-derived and Fedora operating systems.
 
 ## v1.4.x changes
 

--- a/cmd/starter/main_linux.go
+++ b/cmd/starter/main_linux.go
@@ -10,7 +10,7 @@
 package main
 
 // Note that the inclusion of builddir here only works when mconfig -b has not
-//  renamed it; that is handled via a setting of CGO_CFLAGS in mconfig. It is
+//  renamed it; that is handled via a setting of CGO_CPPFLAGS in mconfig. It is
 //  included here also so that Go tools such as code editors and linters can
 //  find config.h when the default builddir is used.
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -25,10 +25,6 @@
 #
 #
 
-# Disable debugsource packages; otherwise it ends up with an empty %%files
-#   file in debugsourcefiles.list on Fedora
-%undefine _debugsource_packages
-
 # This can be slightly different than %%{version}.
 # For example, it has dash instead of tilde for release candidates.
 %global package_version @PACKAGE_VERSION@
@@ -192,7 +188,7 @@ fi
         --mandir=%{_mandir} \
         --infodir=%{_infodir}
 
-%make_build -C builddir V= old_config=
+%make_build -C builddir V= SUPPORT_PLUGINS= old_config=
 
 %install
 %if "%{?SOURCE1}" != ""

--- a/internal/app/apptainer/plugin_compile_linux.go
+++ b/internal/app/apptainer/plugin_compile_linux.go
@@ -150,7 +150,7 @@ func CompilePlugin(sourceDir, destSif, buildTags string) error {
 		buildTags: buildTags,
 		workPath:  apptainerSrc,
 		goPath:    goPath,
-		envs:      append(os.Environ(), "GO111MODULE=on"),
+		envs:      os.Environ(),
 	}
 
 	// build plugin object using go build

--- a/mconfig
+++ b/mconfig
@@ -106,7 +106,6 @@ usage_args () {
 	echo "     -S   build final target project binary statically"
 	echo "     -P   use config profile to configure the project:"
 	echo "            *release             normal release mode (production)"
-	echo "             release-stripped    release mode, stripped symbols (rpm packaging)"
 	echo "             debug               CGO objects built unoptimized, with symbols"
 	echo "     -b   build project in \`builddir'"
 	echo "     -c   build project with host C \`compiler'"
@@ -508,12 +507,10 @@ fi
 # config profile validation
 case $profile in
 	release);;
-	release-stripped);;
 	debug);;
 	*) echo "$profile: no such config profile"
 	   echo "       -P use config profile to configure the project:"
 	   echo "           release             (DEFAULT) normal release mode (production)"
-	   echo "           release-stripped    release mode, stripped symbols (rpm packaging)"
 	   echo "           debug               C portion of CGO built unoptimized, with symbols"
 	   exit 2;;
 esac
@@ -692,11 +689,10 @@ CFLAGS := $cflags
 
 GO := $hstgo
 
-CGO_CFLAGS := -I$builddir $CGO_CFLAGS
+CGO_CPPFLAGS := -I$builddir $CGO_CPPFLAGS
 CGO_LDFLAGS := $CGO_LDFLAGS
-CGO_CPPFLAGS := $CGO_CPPFLAGS
 CGO_CXXFLAGS := $CGO_CXXFLAGS
-export CGO_CFLAGS CGO_LDFLAGS CGO_CPPFLAGS CGO_CXXFLAGS
+export CGO_CPPFLAGS CGO_LDFLAGS CGO_CXXFLAGS
 EOF
 
 
@@ -817,16 +813,6 @@ case $profile in
 		if [ $lang_go -eq 1 ]; then
 			drawline $makeit_fragsdir/go_normal_opts.mk
 			cat $makeit_fragsdir/go_normal_opts.mk >> $makeit_makefile
-		fi
-		;;
-	release-stripped)
-		if [ $lang_c -eq 1 ]; then
-			drawline $makeit_fragsdir/release_opts.mk
-			cat $makeit_fragsdir/release_opts.mk >> $makeit_makefile
-		fi
-		if [ $lang_go -eq 1 ]; then
-			drawline $makeit_fragsdir/go_stripped_opts.mk
-			cat $makeit_fragsdir/go_stripped_opts.mk >> $makeit_makefile
 		fi
 		;;
 	debug)

--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -22,7 +22,8 @@ $(apptainer_deps): $(GO_MODFILES)
 apptainer := $(BUILDDIR_ABSPATH)/apptainer
 $(apptainer): $(apptainer_build_config) $(apptainer_deps) $(apptainer_SOURCE)
 	@echo " GO" $@; echo "    [+] GO_TAGS" \"$(GO_TAGS)\"
-	$(V)cd $(SOURCEDIR) && $(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS)" $(GO_LDFLAGS) \
+	$(V)cd $(SOURCEDIR) && $(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) \
+		$(GO_GCFLAGS) $(GO_LDFLAGS) -tags "$(GO_TAGS)" \
 		-o $@ $(SOURCEDIR)/cmd/apptainer
 
 apptainer_INSTALL := $(DESTDIR)$(BINDIR)/apptainer

--- a/mlocal/frags/build_network.mk
+++ b/mlocal/frags/build_network.mk
@@ -23,8 +23,8 @@ cniplugins:
 		cniplugin=$(cni_builddir)/$$name; \
 		if [ ! -f $$cniplugin ]; then \
 			echo " CNI PLUGIN" $$name; \
-		$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS)" $(GO_LDFLAGS) \
-			-o $$cniplugin $$p; \
+		$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) $(GO_GCFLAGS) \
+			$(GO_LDFLAGS) -tags "$(GO_TAGS)" -o $$cniplugin $$p; \
 		fi \
 	done
 

--- a/mlocal/frags/build_runtime.mk
+++ b/mlocal/frags/build_runtime.mk
@@ -25,7 +25,8 @@ $(BUILDDIR_ABSPATH)/.clean-starter: $(starter_CSOURCE)
 starter := $(BUILDDIR_ABSPATH)/cmd/starter/c/starter
 $(starter): $(BUILDDIR_ABSPATH)/.clean-starter $(apptainer_build_config) $(starter_deps) $(starter_SOURCE)
 	@echo " GO" $@
-	$(V)cd $(SOURCEDIR) && $(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS)" $(GO_LDFLAGS) \
+	$(V)cd $(SOURCEDIR) && $(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) \
+		$(GO_GCFLAGS) $(GO_LDFLAGS) -tags "$(GO_TAGS)" \
 		-o $@ cmd/starter/main_linux.go
 
 starter_INSTALL := $(DESTDIR)$(LIBEXECDIR)/apptainer/bin/starter

--- a/mlocal/frags/build_runtime_suid.mk
+++ b/mlocal/frags/build_runtime_suid.mk
@@ -7,7 +7,8 @@ starter_suid_INSTALL := $(DESTDIR)$(LIBEXECDIR)/apptainer/bin/starter-suid
 
 $(starter_suid): $(starter)
 	@echo " GO" $@; echo "    [+] GO_TAGS" \"$(GO_TAGS_SUID)\"
-	$(V)$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) -tags "$(GO_TAGS_SUID)" $(GO_LDFLAGS) \
+	$(V)$(GO) build $(GO_MODFLAGS) $(GO_BUILDMODE) $(GO_GCFLAGS) \
+		$(GO_LDFLAGS) -tags "$(GO_TAGS_SUID)" \
 		-o $@ $(SOURCEDIR)/cmd/starter/main_linux.go
 
 $(starter_suid_INSTALL): $(starter_suid)

--- a/mlocal/frags/build_scripts.mk
+++ b/mlocal/frags/build_scripts.mk
@@ -2,7 +2,6 @@
 
 # go-test script
 $(SOURCEDIR)/scripts/go-test: export GO := $(GO)
-$(SOURCEDIR)/scripts/go-test: export GO111MODULE := $(GO111MODULE)
 $(SOURCEDIR)/scripts/go-test: export GOFLAGS := $(GOFLAGS)
 $(SOURCEDIR)/scripts/go-test: export GO_TAGS := $(GO_TAGS)
 $(SOURCEDIR)/scripts/go-test: export SUDO_SCRIPT := $(SOURCEDIR)/scripts/test-sudo
@@ -16,7 +15,6 @@ ALL += $(SOURCEDIR)/scripts/go-test
 # go-generate script
 $(SOURCEDIR)/scripts/go-generate: export BUILDDIR := $(BUILDDIR_ABSPATH)
 $(SOURCEDIR)/scripts/go-generate: export GO := $(GO)
-$(SOURCEDIR)/scripts/go-generate: export GO111MODULE := $(GO111MODULE)
 $(SOURCEDIR)/scripts/go-generate: export GOFLAGS := $(GOFLAGS)
 $(SOURCEDIR)/scripts/go-generate: export GO_TAGS := $(GO_TAGS)
 $(SOURCEDIR)/scripts/go-generate: $(SOURCEDIR)/scripts/go-generate.in $(SOURCEDIR)/scripts/expand-env.go $(BUILDDIR_ABSPATH)/config.h

--- a/mlocal/frags/go_common_opts.mk
+++ b/mlocal/frags/go_common_opts.mk
@@ -1,5 +1,4 @@
 # go tool default build options
-GO111MODULE := on
 GO_TAGS := containers_image_openpgp sylog oci_engine apptainer_engine fakeroot_engine
 GO_TAGS_SUID := containers_image_openpgp sylog apptainer_engine fakeroot_engine
 GO_LDFLAGS :=
@@ -15,9 +14,14 @@ else
 GO_BUILDMODE := -buildmode=pie
 GO_RACE := -race
 endif
-GO_MODFLAGS := $(if $(wildcard $(SOURCEDIR)/vendor/modules.txt),-mod=vendor,-mod=readonly)
+# -trimpath is necessary for plugin compiles, but it interferes with
+# the generation of debugsource rpms.  So include it by default, but
+# override SUPPORT_PLUGINS to empty when building an rpm.  Plugins aren't
+# usable with rpms anyway because they have to be compiled from the exact
+# source directory that apptainer is originally compiled with.
+SUPPORT_PLUGINS := true
+GO_MODFLAGS := $(if $(SUPPORT_PLUGINS),-trimpath)
 GO_MODFILES := $(SOURCEDIR)/go.mod $(SOURCEDIR)/go.sum
-GOFLAGS := $(GO_MODFLAGS) -trimpath
 GOPROXY := https://proxy.golang.org
 
-export GOFLAGS GO111MODULE GOPROXY
+export GOPROXY

--- a/mlocal/frags/go_normal_opts.mk
+++ b/mlocal/frags/go_normal_opts.mk
@@ -1,3 +1,7 @@
-# This tells go's link command to add a GNU Build Id, needed for later
-#   symbol stripping for example as is done by rpmbuild.
-GO_LDFLAGS += -ldflags="-B gobuildid"
+# These are from the Red Hat rpm %gobuild macro.  Among other things, they
+# enable generation of debugsource packages in addition to debuginfo.
+# The libtrust_openssl tag is left out because it only works on Red Hat.
+# "-B gobuildid" is a simplification of the macro, to tell go's link
+# command to add a GNU Build Id itself.
+GO_TAGS += rpm_crashtraceback
+GO_LDFLAGS += -ldflags="-linkmode=external -compressdwarf=false -B gobuildid -extldflags '$(LDFLAGS)'"

--- a/mlocal/frags/go_runtime_opts.mk
+++ b/mlocal/frags/go_runtime_opts.mk
@@ -1,1 +1,1 @@
-CGO_CFLAGS += -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector --param ssp-buffer-size=4
+CGO_CPPFLAGS += -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector --param ssp-buffer-size=4

--- a/mlocal/frags/go_stripped_opts.mk
+++ b/mlocal/frags/go_stripped_opts.mk
@@ -1,1 +1,0 @@
-GO_LDFLAGS += -ldflags="-s -w"

--- a/mlocal/frags/release_opts.mk
+++ b/mlocal/frags/release_opts.mk
@@ -1,2 +1,1 @@
 CFLAGS += -O2
-LDFLAGS += -s

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -74,7 +74,13 @@ su testuser -c '
   export GOPATH=$BLD/gopath
   PATH=$GOPATH/bin:$PATH
 
+  # do a minimal test
   apptainer exec oras://ghcr.io/apptainer/alpine:3.15.0 /bin/true
+
+  if [[ '$OS_TYPE' != *suse* ]]; then
+    # make sure an example go source file is actually in the debugsource rpm 
+    rpm2cpio $HOME/rpmbuild/RPMS/$(arch)/apptainer-debugsource*.rpm | cpio -it | grep cmd/apptainer/cli.go
+  fi
 
   # copy the rpms into the current directory for later use
   cp $HOME/rpmbuild/SRPMS/*.rpm $HOME/rpmbuild/RPMS/*/*.rpm .

--- a/scripts/go-generate.in
+++ b/scripts/go-generate.in
@@ -5,7 +5,6 @@
 #   project policies see https://lfprojects.org/policies
 
 export BUILDDIR='@BUILDDIR@'
-export GO111MODULE='@GO111MODULE@'
 export GO_BUILD_TAGS='@GO_TAGS@'
 export GOFLAGS='@GOFLAGS@'
 export GO_TOOL='@GO@'

--- a/scripts/go-test.in
+++ b/scripts/go-test.in
@@ -42,7 +42,6 @@ gotest_postprocess() {
 }
 
 export GOFLAGS='@GOFLAGS@'
-export GO111MODULE='@GO111MODULE@'
 
 GO='@GO@'
 GO_TAGS='@GO_TAGS@'


### PR DESCRIPTION
This updates the rpm spec and the Makefile to generate useful `debugsource` rpms.  It also cleans up some unnecessary go build options and adds the use of `GO_GCFLAGS` so when debug options are set they actually get used.

There turned out to be multiple impediments to generating the debugsource rpms.  The ones that I confirmed were:
1. The missing `-ldflags="-linkmode=external` build option resulted in no go sources recognized.
2. The use of `$CGO_CFLAGS` instead of `$CGO_CPPFLAGS` resulted in no go sources recognized.
3. The `-trimpath` exported in `$GOFLAGS` resulted in no go sources recognized.  On the other hand this option is needed for compiling plugins, so this is removed only when building an rpm.  Plugins aren't useful with rpms anyway because they have to be compiled in the same source directory as the binaries were compiled in.
4. We deliberately disabled generation of the debugsource rpms because the above problems resulted in zero source files and caused it to fail, even though later on when we added bundled dependencies sources from them would have made made the debugsource rpms be successfully created, but only with those sources and not go sources.

Since it's so easy to stop including the go sources, I added a line to the ci check to make sure there's at least one included.