### PR TITLE
Remove containerd group from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,10 +49,6 @@ updates:
         patterns:
           - "github.com/moby/*"
           - "github.com/docker/*"
-      containerd:
-        applies-to: "version-updates"
-        patterns:
-          - "github.com/containerd/*"
       opencontainers:
         applies-to: "version-updates"
         patterns:


### PR DESCRIPTION
This is a fix for a message I noticed in the [dependabot action output](https://github.com/apptainer/apptainer/actions/runs/17317037118/job/49161792542#step:3:170):
```
updater | 2025/08/29 07:01:00 WARN <job_1086606183> Please check your configuration as there are groups where no dependencies match:
- containerd

This can happen if:
- the group's 'pattern' rules are misspelled
- your configuration's 'allow' rules do not permit any of the dependencies that match the group
- the dependencies that match the group rules have been removed from your project
```