### PR TITLE
Make --workdir --contain include /home as documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.4.2
 
+- Include the home directory in the `--workdir` option (which is a
+  modifier of the `--contain` option).  This has always been in the
+  `--workdir` usage description but the home directory has not actually
+  been included at least since singularity-2.
+
 ## v1.4.2 - \[2025-07-07\]
 
 - Restore looking for registry mirrors in `/etc/containers/registry.conf`

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -1941,7 +1941,7 @@ func (c *container) addHomeStagingDir(system *mount.System, source string, dest 
 
 	bindSource := !c.engine.EngineConfig.GetContain() || c.engine.EngineConfig.GetCustomHome()
 
-	// use the session home directory is the user home directory doesn't exist (issue #4208)
+	// use the session home directory if the user home directory doesn't exist (issue #4208)
 	if _, err := os.Stat(source); os.IsNotExist(err) {
 		bindSource = false
 	}
@@ -1955,7 +1955,25 @@ func (c *container) addHomeStagingDir(system *mount.System, source string, dest 
 		system.Points.AddRemount(mount.HomeTag, homeStage, flags)
 		c.session.OverrideDir(dest, source)
 	} else {
-		sylog.Debugf("Using session directory for home directory")
+		// c.engine.EngineConfig.GetContain() is true here unless
+		// the home directory didn't exist.  We could let it always
+		// use the workdir if workdir was defined, but that might be
+		// surprising so check again.
+		workdir := c.engine.EngineConfig.GetWorkdir()
+		if workdir != "" && c.engine.EngineConfig.GetContain() {
+			sylog.Debugf("Using work directory for home directory")
+			workdir, err := filepath.Abs(filepath.Clean(workdir))
+			if err != nil {
+				return "", fmt.Errorf("can't determine absolute path of workdir %s: %s", workdir, err)
+			}
+
+			homeStage = filepath.Join(workdir, "home")
+			if err := fs.Mkdir(homeStage, 0o700); err != nil && !os.IsExist(err) {
+				return "", fmt.Errorf("failed to create %s: %s", homeStage, err)
+			}
+		} else {
+			sylog.Debugf("Using session directory for home directory")
+		}
 		c.session.OverrideDir(dest, homeStage)
 	}
 


### PR DESCRIPTION
This implements moving the home directory of `--contain` to the `--workdir` instead of the session directory, as documented with the `--workdir` option.

- Fixes #3112

As far as I can tell this has never been implemented in singularity-3 or apptainer so it must not be a very widely used feature.