### PR TITLE
fix compiling warnings

### DIFF
--- a/cmd/starter/c/starter.c
+++ b/cmd/starter/c/starter.c
@@ -779,6 +779,7 @@ static int uts_namespace_init(struct namespace *nsconfig) {
         }
         return CREATE_NAMESPACE;
     }
+    return NO_NAMESPACE;
 }
 
 static int ipc_namespace_init(struct namespace *nsconfig) {
@@ -793,6 +794,7 @@ static int ipc_namespace_init(struct namespace *nsconfig) {
         }
         return CREATE_NAMESPACE;
     }
+    return NO_NAMESPACE;
 }
 
 static int cgroup_namespace_init(struct namespace *nsconfig) {
@@ -807,6 +809,7 @@ static int cgroup_namespace_init(struct namespace *nsconfig) {
         }
         return CREATE_NAMESPACE;
     }
+    return NO_NAMESPACE;
 }
 
 static int mount_namespace_init(struct namespace *nsconfig, Bool masterPropagateMount) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix compilation warnings in `cmd/starter/c/starter.c` for "non-void function does not return a value in all control paths" by adding missing return statements to namespace initialization functions.


### This fixes or addresses the following GitHub issues:

 - Fixes #3043


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
