### PR TITLE
fix the issue that 'APPTAINER_TMPDIR' does not overwrite 'TMPDIR' when pulling or building image via oras protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Changes since 1.4.2
   `--workdir` usage description but the home directory has not actually
   been included at least since singularity-2.
 - Add support for building and publishing Apptainer for Ubuntu 25.04 PPA.
+- Fix reading images using the oras protocol to store temporary files in `APPTAINER_TMPDIR`
+  instead of `TMPDIR`.
 
 ## v1.4.2 - \[2025-07-07\]
 

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -11,6 +11,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -290,6 +291,8 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 		}
 
+		// need to pass tmpDir through to oras.PullToFile
+		ctx = context.WithValue(ctx, oras.TmpDirKey, tmpDir)
 		_, err = oras.PullToFile(ctx, imgCache, pullTo, pullFrom, ociAuth, noHTTPS, reqAuthFile, pullSandbox)
 		if err != nil {
 			sylog.Fatalf("While pulling image from oci registry: %v", err)

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -64,7 +64,14 @@ func DownloadImage(ctx context.Context, path, ref string, ociAuth *authn.AuthCon
 	}
 
 	// Retrieve image to a temporary OCI layout
-	tmpDir, err := os.MkdirTemp("", "oras-tmp-")
+	tmpDirFlag := ""
+	if v := ctx.Value(TmpDirKey); v != nil {
+		if s, ok := v.(string); ok {
+			tmpDirFlag = s
+		}
+	}
+	// if tmpDirFlag is still "", os.MkdirTemp will use the system default temp dir
+	tmpDir, err := os.MkdirTemp(tmpDirFlag, "oras-tmp-")
 	if err != nil {
 		rt.ProgressShutdown()
 		return err

--- a/internal/pkg/client/oras/pull.go
+++ b/internal/pkg/client/oras/pull.go
@@ -21,6 +21,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 )
 
+// contextKey is a custom type for context keys to avoid collisions
+type contextKey string
+
+// TmpDirKey is the context key for passing tmpDir
+const TmpDirKey contextKey = "tmpDir"
+
 // pull will pull an oras image into the cache if directTo="", or a specific file if directTo is set.
 func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) (imagePath string, err error) {
 	hash, err := RefHash(ctx, pullFrom, ociAuth, noHTTPS, reqAuthFile)
@@ -80,6 +86,8 @@ func Pull(ctx context.Context, imgCache *cache.Handle, pullFrom, tmpDir string, 
 		sylog.Infof("Downloading oras image to tmp cache: %s", directTo)
 	}
 
+	// always pass the tmpDir through context down to DownloadImage
+	ctx = context.WithValue(ctx, TmpDirKey, tmpDir)
 	return pull(ctx, imgCache, directTo, pullFrom, ociAuth, noHTTPS, reqAuthFile)
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix the issue that 'APPTAINER_TMPDIR' does not overwrite 'TMPDIR' when pulling or building image via oras protocol

### This fixes or addresses the following GitHub issues:

 - Fixes #3125


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).

## Test
```
➜  test TMPDIR=/tmp/nonapptainertmp APPTAINER_TMPDIR=/tmp/apptainer APPTAINER_CACHEDIR=/tmp/apptainer  strace -f apptainer build --force --sandbox /tmp/alpine-latest oras://ghcr.io/apptainer/alpine:latest 2>&1|grep oras-tmp;
[pid 338625] mkdirat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717", 0700 <unfinished ...>
[pid 338625] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717",  <unfinished ...>
[pid 338625] openat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/oci-layout", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0777 <unfinished ...>
[pid 338625] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717", {st_mode=S_IFDIR|0700, st_size=24, ...}, 0) = 0
[pid 338625] openat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/index.json", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0777 <unfinished ...>
[pid 338629] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256",  <unfinished ...>
[pid 338629] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs",  <unfinished ...>
[pid 338629] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717",  <unfinished ...>
[pid 338629] mkdirat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs", 0777 <unfinished ...>
[pid 338629] mkdirat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256", 0777 <unfinished ...>
[pid 338629] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/fe87570a187c1d0a49317d0653937a215edaa851178f39aaae4274ce16f5357d",  <unfinished ...>
[pid 338629] openat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/fe87570a187c1d0a49317d0653937a215edaa851178f39aaae4274ce16f5357d2999216358", O_RDWR|O_CREAT|O_EXCL|O_CLOEXEC, 0600 <unfinished ...>
[pid 338631] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/fe87570a187c1d0a49317d0653937a215edaa851178f39aaae4274ce16f5357d", 0xc00035a788, AT_SYMLINK_NOFOLLOW) = -1 ENOENT (No such file or directory)
[pid 338631] renameat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/fe87570a187c1d0a49317d0653937a215edaa851178f39aaae4274ce16f5357d2999216358", AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/fe87570a187c1d0a49317d0653937a215edaa851178f39aaae4274ce16f5357d" <unfinished ...>
[pid 338631] unlinkat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/fe87570a187c1d0a49317d0653937a215edaa851178f39aaae4274ce16f5357d2999216358", 0) = -1 ENOENT (No such file or directory)
[pid 338631] unlinkat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/fe87570a187c1d0a49317d0653937a215edaa851178f39aaae4274ce16f5357d2999216358", AT_REMOVEDIR) = -1 ENOENT (No such file or directory)
[pid 338625] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256",  <unfinished ...>
[pid 338625] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a", 0xc0004246b8, 0) = -1 ENOENT (No such file or directory)
[pid 338625] openat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a", O_RDWR|O_CREAT|O_TRUNC|O_CLOEXEC, 0666 <unfinished ...>
[pid 338625] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256",  <unfinished ...>
[pid 338625] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/8f838adc127eca88ed010153e54586f8c4f9e6aaf3ab8151789287c72b858591", 0xc000424858, 0) = -1 ENOENT (No such file or directory)
[pid 338625] openat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/8f838adc127eca88ed010153e54586f8c4f9e6aaf3ab8151789287c72b858591", O_RDWR|O_CREAT|O_TRUNC|O_CLOEXEC, 0666 <unfinished ...>
[pid 338625] openat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/index.json", O_RDONLY|O_CLOEXEC <unfinished ...>
[pid 338625] newfstatat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717",  <unfinished ...>
[pid 338625] openat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/index.json", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0777 <unfinished ...>
[pid 338625] openat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717/blobs/sha256/fe87570a187c1d0a49317d0653937a215edaa851178f39aaae4274ce16f5357d", O_RDONLY|O_CLOEXEC) = 8
[pid 338625] unlinkat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717", 0) = -1 EISDIR (Is a directory)
[pid 338625] unlinkat(AT_FDCWD, "/tmp/apptainer/oras-tmp-2291749717", AT_REMOVEDIR) = -1 ENOTEMPTY (Directory not empty)
[pid 338625] unlinkat(8, "oras-tmp-2291749717", 0) = -1 EISDIR (Is a directory)
[pid 338625] openat(8, "oras-tmp-2291749717", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY) = 9
[pid 338625] unlinkat(8, "oras-tmp-2291749717", AT_REMOVEDIR <unfinished ...>
```