### PR TITLE
add support for building and publishing apptainer for ubuntu 25.04 PPA (release-1.4.x)

### DIFF
--- a/.github/workflows/ubuntu-ppa-release.yml
+++ b/.github/workflows/ubuntu-ppa-release.yml
@@ -89,6 +89,8 @@ jobs:
     strategy:
       matrix:
         include:
+            - version: '25.04'
+              name: plucky
             - version: '24.04'
               name: noble
             - version: '22.04'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes since 1.4.2
   modifier of the `--contain` option).  This has always been in the
   `--workdir` usage description but the home directory has not actually
   been included at least since singularity-2.
+- Add support for building and publishing Apptainer for Ubuntu 25.04 PPA.
 
 ## v1.4.2 - \[2025-07-07\]
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

cherry picking 42e72b4008674c1f90f6e7758f1fd4dfc52bd357 from https://github.com/apptainer/apptainer/pull/3128


### This fixes or addresses the following GitHub issues:

 - Fixes #3110 


#### Before submitting a PR, make sure you have done the following:

- [ ] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [ ] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
