### PR TITLE
The help page was renamed to support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,6 @@ Apptainer, check out the [guidelines for contributing](CONTRIBUTING.md).
 Please note we have a [code of conduct](CODE_OF_CONDUCT.md). Please follow it in
 all your interactions with the project members and users.
 
-Our roadmap, other documents, and user/developer meeting information can be
-found in the [apptainer community page](https://apptainer.org/help).
-
 We also welcome contributions to our [user
 guide](https://github.com/apptainer/apptainer-userdocs) and [admin
 guide](https://github.com/apptainer/apptainer-admindocs).
@@ -69,7 +66,7 @@ guide](https://github.com/apptainer/apptainer-admindocs).
 ## Support
 
 To get help with Apptainer, check out the [Apptainer
-Help](https://apptainer.org/help) web page.
+Support](https://apptainer.org/support) web page.
 
 ## Go Version Compatibility
 


### PR DESCRIPTION

## Description of the Pull Request (PR):

https://apptainer.org/help was moved to https://apptainer.org/support/

The information about "roadmap, other documents, and user/developer
meeting information" was moved... somewhere else. No "community" page?

### This fixes or addresses the following GitHub issues:

 - Fixes #3214

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
