### PR TITLE
fix: use built-in C boolean type in starter, from sylabs 3562

### DIFF
--- a/cmd/starter/c/include/starter.h
+++ b/cmd/starter/c/include/starter.h
@@ -3,7 +3,7 @@
     Apptainer a Series of LF Projects LLC.
     For website terms of use, trademark policy, privacy policy and other
     project policies see https://lfprojects.org/policies
-  Copyright (c) 2018-2019, Sylabs, Inc. All rights reserved.
+  Copyright (c) 2018-2025, Sylabs, Inc. All rights reserved.
 
   This software is licensed under a 3-clause BSD license.  Please
   consult LICENSE.md file distributed with the sources of this project regarding
@@ -14,6 +14,7 @@
 #define _APPTAINER_STARTER_H
 
 #include <limits.h>
+#include <stdbool.h>
 #include <sys/user.h>
 
 #define fatalf(b...)     apptainer_message(ERROR, b); \
@@ -73,11 +74,6 @@ enum goexec {
 #define CLONE_NEWCGROUP     0x02000000
 #endif
 
-typedef enum {
-    False,
-    True
-} Bool;
-
 /* container capabilities */
 struct capabilities {
     unsigned long long permitted;
@@ -94,9 +90,9 @@ struct namespace {
     /* container mount namespace propagation */
     unsigned long mountPropagation;
     /* namespace join only */
-    Bool joinOnly;
+    bool joinOnly;
     /* should bring up loopback interface with network namespace */
-    Bool bringLoopbackInterface;
+    bool bringLoopbackInterface;
 
     /* namespaces inodes paths used to join namespaces */
     char network[MAX_PATH_SIZE];
@@ -111,12 +107,12 @@ struct namespace {
 /* container privileges */
 struct privileges {
     /* value for PR_SET_NO_NEW_PRIVS */
-    Bool noNewPrivs;
+    bool noNewPrivs;
 
     /* user namespace mappings and setgroups control */
     char uidMap[MAX_MAP_SIZE];
     char gidMap[MAX_MAP_SIZE];
-    Bool allowSetgroups;
+    bool allowSetgroups;
 
     /* path to external newuidmap/newgidmap binaries */
     char newuidmapPath[MAX_PATH_SIZE];
@@ -136,7 +132,7 @@ struct container {
     /* container process ID */
     pid_t pid;
     /* is container will run as instance */
-    Bool isInstance;
+    bool isInstance;
 
     /* container privileges */
     struct privileges privileges;
@@ -154,14 +150,14 @@ struct starter {
     int numfds;
 
     /* is starter run as setuid */
-    Bool isSuid;
+    bool isSuid;
     /* master process will share a mount namespace for container mount propagation */
-    Bool masterPropagateMount;
+    bool masterPropagateMount;
     /* hybrid workflow where master process and container doesn't share user namespace */
-    Bool hybridWorkflow;
+    bool hybridWorkflow;
 
     /* bounding capability set will include caps needed by nvidia-container-cli */
-    Bool nvCCLICaps;
+    bool nvCCLICaps;
 };
 
 /* engine configuration */

--- a/internal/pkg/runtime/engine/config/starter/starter_linux.go
+++ b/internal/pkg/runtime/engine/config/starter/starter_linux.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -10,6 +10,7 @@
 package starter
 
 /*
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -58,7 +59,7 @@ func NewConfig(config SConfig) *Config {
 // GetIsSUID returns True if the SUID workflow is enabled.
 // This field is set by starter at the very beginning of its execution.
 func (c *Config) GetIsSUID() bool {
-	return c.config.starter.isSuid == C.True
+	return c.config.starter.isSuid == true //nolint
 }
 
 // GetContainerPid returns the container PID (if any).
@@ -71,9 +72,9 @@ func (c *Config) GetContainerPid() int {
 // instead of a regular container if the passed value is True.
 func (c *Config) SetInstance(instance bool) {
 	if instance {
-		c.config.container.isInstance = C.True
+		c.config.container.isInstance = true
 	} else {
-		c.config.container.isInstance = C.False
+		c.config.container.isInstance = false
 	}
 }
 
@@ -81,9 +82,9 @@ func (c *Config) SetInstance(instance bool) {
 // flag for a container before it starts up if noprivs is True.
 func (c *Config) SetNoNewPrivs(noprivs bool) {
 	if noprivs {
-		c.config.container.privileges.noNewPrivs = C.True
+		c.config.container.privileges.noNewPrivs = true
 	} else {
-		c.config.container.privileges.noNewPrivs = C.False
+		c.config.container.privileges.noNewPrivs = false
 	}
 }
 
@@ -92,9 +93,9 @@ func (c *Config) SetNoNewPrivs(noprivs bool) {
 // is set to MS_SHARED if propagate is True.
 func (c *Config) SetMasterPropagateMount(propagate bool) {
 	if propagate {
-		c.config.starter.masterPropagateMount = C.True
+		c.config.starter.masterPropagateMount = true
 	} else {
-		c.config.starter.masterPropagateMount = C.False
+		c.config.starter.masterPropagateMount = false
 	}
 }
 
@@ -103,9 +104,9 @@ func (c *Config) SetMasterPropagateMount(propagate bool) {
 // `apptainer oci exec`) if join is True.
 func (c *Config) SetNamespaceJoinOnly(join bool) {
 	if join {
-		c.config.container.namespace.joinOnly = C.True
+		c.config.container.namespace.joinOnly = true
 	} else {
-		c.config.container.namespace.joinOnly = C.False
+		c.config.container.namespace.joinOnly = false
 	}
 }
 
@@ -113,9 +114,9 @@ func (c *Config) SetNamespaceJoinOnly(join bool) {
 // a loopback network interface during container creation if bring is True.
 func (c *Config) SetBringLoopbackInterface(bring bool) {
 	if bring {
-		c.config.container.namespace.bringLoopbackInterface = C.True
+		c.config.container.namespace.bringLoopbackInterface = true
 	} else {
-		c.config.container.namespace.bringLoopbackInterface = C.False
+		c.config.container.namespace.bringLoopbackInterface = false
 	}
 }
 
@@ -166,9 +167,9 @@ func (c *Config) KeepFileDescriptor(fd int) error {
 // nvidia-container-cli
 func (c *Config) SetNvCCLICaps(enabled bool) {
 	if enabled {
-		c.config.starter.nvCCLICaps = C.True
+		c.config.starter.nvCCLICaps = true
 	} else {
-		c.config.starter.nvCCLICaps = C.False
+		c.config.starter.nvCCLICaps = false
 	}
 }
 
@@ -179,18 +180,18 @@ func (c *Config) SetNvCCLICaps(enabled bool) {
 // lives in its own user namespace.
 func (c *Config) SetHybridWorkflow(hybrid bool) {
 	if hybrid {
-		c.config.starter.hybridWorkflow = C.True
+		c.config.starter.hybridWorkflow = true
 	} else {
-		c.config.starter.hybridWorkflow = C.False
+		c.config.starter.hybridWorkflow = false
 	}
 }
 
 // SetAllowSetgroups allows use of setgroups syscall from user namespace.
 func (c *Config) SetAllowSetgroups(allow bool) {
 	if allow {
-		c.config.container.privileges.allowSetgroups = C.True
+		c.config.container.privileges.allowSetgroups = true
 	} else {
-		c.config.container.privileges.allowSetgroups = C.False
+		c.config.container.privileges.allowSetgroups = false
 	}
 }
 


### PR DESCRIPTION
This pulls in sylabs PR
 * sylabs/singularity#3562
 
 The original PR description was:
> Replace use of a custom `bool` enum with the C `_Bool` aliased to `bool` via `<stdbool.h>` etc.
> 
> Fixes issues with `-std=c23` where `bool / true / false` are now defined by the language.
> ### This fixes or addresses the following GitHub issues:
> 
>     * Fixes [Fedora 42 - FTBFS # 3561] (https://github.com/sylabs/singularity/issues/3561)
>