### PR TITLE
fix: ensure network e2e tests run, from sylabs 3477

### DIFF
--- a/internal/pkg/test/tool/require/require.go
+++ b/internal/pkg/test/tool/require/require.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apptainer/apptainer/pkg/network"
 	"github.com/apptainer/apptainer/pkg/util/fs/proc"
 	"github.com/apptainer/apptainer/pkg/util/slice"
+	"github.com/google/uuid"
 	"github.com/opencontainers/cgroups"
 )
 
@@ -102,8 +103,9 @@ func Network(t *testing.T) {
 		cniPath := new(network.CNIPath)
 		cniPath.Conf = filepath.Join(buildcfg.SYSCONFDIR, "apptainer", "network")
 		cniPath.Plugin = filepath.Join(buildcfg.LIBEXECDIR, "apptainer", "cni")
+		containerID := "apptainer-e2e-" + uuid.New().String()
 
-		setup, err := network.NewSetup([]string{"bridge"}, "_test_", nsPath, cniPath)
+		setup, err := network.NewSetup([]string{"bridge"}, containerID, nsPath, cniPath)
 		if err != nil {
 			logFn(err)
 			return

--- a/pkg/network/network_linux_test.go
+++ b/pkg/network/network_linux_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -353,14 +353,16 @@ func TestNewSetup(t *testing.T) {
 	}
 
 	for _, s := range testSetup {
-		setup, err := NewSetup(s.networks, s.id, s.nspath, s.cniPath)
-		if err != nil && s.success {
-			t.Errorf("unexpected failure for %q test: %s", s.desc, err)
-		} else if err == nil && !s.success {
-			t.Errorf("unexpected success for %q test", s.desc)
-		} else if s.subTest != nil {
-			s.subTest(setup, t)
-		}
+		t.Run(s.desc, func(t *testing.T) {
+			setup, err := NewSetup(s.networks, s.id, s.nspath, s.cniPath)
+			if err != nil && s.success {
+				t.Errorf("unexpected failure for %q test: %s", s.desc, err)
+			} else if err == nil && !s.success {
+				t.Errorf("unexpected success for %q test", s.desc)
+			} else if s.subTest != nil {
+				s.subTest(setup, t)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This pulls in sylabs PR

  * sylabs/singularity#3477

The original PR description was:
> Network e2e tests were failing to run due to an invalid container name (with newer CNI plugins / distro) in the `require.Network(t)` function.
> 
> Fix the container name so that the requirement function passes, and the tests will run properly.
> 
> While we are in this code, ensure some other network tests run with named subtests for convenience when reviewing the test logs.
> ### This fixes or addresses the following GitHub issues:
> 
>     * Fixes [el10: network tests are skipped #3457](https://github.com/sylabs/singularity/issues/3457)

 
This is one of the PRs listed in 
  * apptainer/apptainer#3281