### PR TITLE
e2e: fix: use Fedora version currently on mirrors, from sylabs 3792

### DIFF
--- a/examples/fedora-amd64/Apptainer
+++ b/examples/fedora-amd64/Apptainer
@@ -1,5 +1,5 @@
 BootStrap: yum
-OSVersion: 40
+OSVersion: 42
 MirrorURL: http://dfw.mirror.rackspace.com/fedora/releases/%{OSVERSION}/Everything/x86_64/os/
 Include: fedora-release-container dnf
 Setopt: install_weak_deps=False

--- a/examples/fedora-arm64/Apptainer
+++ b/examples/fedora-arm64/Apptainer
@@ -1,5 +1,5 @@
 BootStrap: yum
-OSVersion: 40
+OSVersion: 42
 MirrorURL: http://dfw.mirror.rackspace.com/fedora/releases/%{OSVERSION}/Everything/aarch64/os/
 Include: fedora-release-container dnf
 Setopt: install_weak_deps=False


### PR DESCRIPTION
This pulls in sylabs PR

   * sylabs/singularity#3792

The original PR description was:
> Fedora 40 is no longer on the main mirrors - it has been archived. Use current 42.


This is one of the PRs listed in 
  * apptainer/apptainer#3281
