### PR TITLE
add subid call return code to error message, from sylabs 3498

### DIFF
--- a/internal/pkg/fakeroot/idtools_supported.go
+++ b/internal/pkg/fakeroot/idtools_supported.go
@@ -72,7 +72,7 @@ func readSubid(user *user.User, isUser bool) ([]*Entry, error) {
 		}
 	}
 	if nRanges < 0 {
-		return nil, errors.New("cannot read subids")
+		return nil, fmt.Errorf("subid_get_[ug]id_ranges call failed: %v", nRanges)
 	}
 	defer C.free(unsafe.Pointer(cRanges))
 


### PR DESCRIPTION
This pulls the `add subid call return code to error message` commit from sylabs PR

  * sylabs/singularity#3498

The original PR had no description.

---
This is one of the PRs listed in 
  * apptainer/apptainer#3281