### PR TITLE
Remove double backslashes in env variables imported from oci containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
   any local gateway will be picked up automatically (e.g. `http://127.0.0.1:8080`)
 - Create reproducible SIF images, if the environment variable `SOURCE_DATE_EPOCH`
   has been set (it is a Unix timestamp given as seconds, in the UTC timezone).
+- Fix long-time bug in importing environment variables from oci
+  containers (defined with `ENV` in their definition file) with shell
+  characters in them.  It now escapes them with single backslashes
+  instead of double backslashes so they behave like they do in podman
+  and docker.
 
 ## v1.4.x changes
 

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -402,9 +402,9 @@ func (cp *OCIConveyorPacker) insertEnv() error {
 			export = fmt.Sprintf("export %s=\"${%s:-}\"\n", envParts[0], envParts[0])
 		} else {
 			if envParts[0] == "PATH" {
-				export = fmt.Sprintf("export %s=%q\n", envParts[0], shell.Escape(envParts[1]))
+				export = fmt.Sprintf("export %s=\"%s\"\n", envParts[0], shell.Escape(envParts[1]))
 			} else {
-				export = fmt.Sprintf("export %s=\"${%s:-%q}\"\n", envParts[0], envParts[0], shell.Escape(envParts[1]))
+				export = fmt.Sprintf("export %s=\"${%s:-\"%s\"}\"\n", envParts[0], envParts[0], shell.Escape(envParts[1]))
 			}
 		}
 		_, err = f.WriteString(export)


### PR DESCRIPTION
## Description of the Pull Request (PR):

This fixes a problem introduced in apptainer-3.1.0 in apptainer/singularity#2751 where special shell characters resulted in double backslashes instead of single backslashes as intended.

### This fixes or addresses the following GitHub issues:

 - Fixes #3328
