### PR TITLE
Add common tmpdir flag to remaining commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   characters in them.  It now escapes them with single backslashes
   instead of double backslashes so they behave like they do in podman
   and docker.
+- Add support for APPTAINER_TMPDIR, also to the commands
+  `apptainer overlay create` and `apptainer plugin compile`.
 
 ## v1.4.x changes
 

--- a/cmd/internal/cli/overlay.go
+++ b/cmd/internal/cli/overlay.go
@@ -18,6 +18,7 @@ func init() {
 		cmdManager.RegisterCmd(OverlayCmd)
 		cmdManager.RegisterSubCmd(OverlayCmd, OverlayCreateCmd)
 
+		cmdManager.RegisterFlagForCmd(&commonTmpDirFlag, OverlayCreateCmd)
 		cmdManager.RegisterFlagForCmd(&overlaySizeFlag, OverlayCreateCmd)
 		cmdManager.RegisterFlagForCmd(&overlayCreateDirFlag, OverlayCreateCmd)
 		cmdManager.RegisterFlagForCmd(&overlayFakerootFlag, OverlayCreateCmd)

--- a/cmd/internal/cli/overlay_create.go
+++ b/cmd/internal/cli/overlay_create.go
@@ -65,7 +65,7 @@ var overlayFakerootFlag = cmdline.Flag{
 var OverlayCreateCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	RunE: func(_ *cobra.Command, args []string) error {
-		if err := apptainer.OverlayCreate(overlaySize, args[0], overlaySparse, isOverlayFakeroot, overlayDirs...); err != nil {
+		if err := apptainer.OverlayCreate(overlaySize, args[0], tmpDir, overlaySparse, isOverlayFakeroot, overlayDirs...); err != nil {
 			sylog.Fatalf("%v", err.Error())
 		}
 		return nil

--- a/cmd/internal/cli/plugin_compile_linux.go
+++ b/cmd/internal/cli/plugin_compile_linux.go
@@ -35,6 +35,7 @@ var pluginCompileOutFlag = cmdline.Flag{
 
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
+		cmdManager.RegisterFlagForCmd(&commonTmpDirFlag, PluginCompileCmd)
 		cmdManager.RegisterFlagForCmd(&pluginCompileOutFlag, PluginCompileCmd)
 	})
 }
@@ -66,7 +67,7 @@ var PluginCompileCmd = &cobra.Command{
 		buildTags := buildcfg.GO_BUILD_TAGS
 
 		sylog.Debugf("sourceDir: %s; sifPath: %s", sourceDir, destSif)
-		err = apptainer.CompilePlugin(sourceDir, destSif, buildTags)
+		err = apptainer.CompilePlugin(sourceDir, destSif, tmpDir, buildTags)
 		if err != nil {
 			sylog.Fatalf("Plugin compile failed with error: %s", err)
 		}

--- a/internal/app/apptainer/overlay_create.go
+++ b/internal/app/apptainer/overlay_create.go
@@ -104,7 +104,7 @@ func findConvertCommand(overlaySparse bool) (string, error) {
 // OverlayCreate creates the overlay with an optional size, image path, dirs, fakeroot and sparse option.
 //
 //nolint:maintidx
-func OverlayCreate(size int, imgPath string, overlaySparse bool, isFakeroot bool, overlayDirs ...string) error {
+func OverlayCreate(size int, imgPath string, tmpDir string, overlaySparse bool, isFakeroot bool, overlayDirs ...string) error {
 	if size < 64 {
 		return fmt.Errorf("image size must be equal or greater than 64 MiB")
 	}
@@ -201,7 +201,7 @@ func OverlayCreate(size int, imgPath string, overlaySparse bool, isFakeroot bool
 		return fmt.Errorf("while setting 0600 permission on %s: %s", tmpFile, err)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "overlay-")
+	tmpDir, err = os.MkdirTemp(tmpDir, "overlay-")
 	if err != nil {
 		return fmt.Errorf("while creating temporary overlay directory: %s", err)
 	}

--- a/internal/app/apptainer/plugin_compile_linux.go
+++ b/internal/app/apptainer/plugin_compile_linux.go
@@ -68,10 +68,11 @@ func getApptainerSrcDir() (string, error) {
 // checkGoVersion returns an error if the currently Go toolchain is
 // different from the one used to compile apptainer. Apptainer
 // and plugin must be compiled with the same toolchain.
-func checkGoVersion(goPath string) error {
+func checkGoVersion(goPath string, tmpDir string) error {
 	var out bytes.Buffer
+	var err error
 
-	tmpDir, err := os.MkdirTemp("", "plugin-")
+	tmpDir, err = os.MkdirTemp(tmpDir, "plugin-")
 	if err != nil {
 		return errors.New("temporary directory creation failed")
 	}
@@ -116,7 +117,7 @@ func pluginManifestPath(sourceDir string) string {
 // CompilePlugin compiles a plugin. It takes as input: sourceDir, the path to the
 // plugin's source code directory; and destSif, the path to the intended final
 // location of the plugin SIF file.
-func CompilePlugin(sourceDir, destSif, buildTags string) error {
+func CompilePlugin(sourceDir, destSif, tmpDir string, buildTags string) error {
 	apptainerSrc, err := getApptainerSrcDir()
 	if err != nil {
 		return fmt.Errorf("apptainer source directory not usable: %w", err)
@@ -142,7 +143,7 @@ func CompilePlugin(sourceDir, destSif, buildTags string) error {
 
 	// we need to use the exact same go runtime version used
 	// to compile Apptainer
-	if err := checkGoVersion(goPath); err != nil {
+	if err := checkGoVersion(goPath, tmpDir); err != nil {
 		return fmt.Errorf("while checking go version: %s", err)
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

`overlay`

`plugin compile`

### This fixes or addresses the following GitHub issues:

 - Fixes #3141

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
