### PR TITLE
Add an arch parameter to oras pull and push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
   and docker.
 - Add support for APPTAINER_TMPDIR, also to the commands
   `apptainer overlay create` and `apptainer plugin compile`.
+- The oras transport now supports architectures beyond `amd64`.
 
 ## v1.4.x changes
 

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -103,7 +103,7 @@ func handleOras(ctx context.Context, imgCache *cache.Handle, cmd *cobra.Command,
 	if err != nil {
 		return "", fmt.Errorf("while creating docker credentials: %v", err)
 	}
-	return oras.Pull(ctx, imgCache, pullFrom, tmpDir, ociAuth, noHTTPS, reqAuthFile)
+	return oras.Pull(ctx, imgCache, pullFrom, runtime.GOARCH, tmpDir, ociAuth, noHTTPS, reqAuthFile)
 }
 
 func handleIpfs(ctx context.Context, imgCache *cache.Handle, pullFrom string) (string, error) {

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -296,7 +296,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 
 		// need to pass tmpDir through to oras.PullToFile
 		ctx = context.WithValue(ctx, oras.TmpDirKey, tmpDir)
-		_, err = oras.PullToFile(ctx, imgCache, pullTo, pullFrom, ociAuth, noHTTPS, reqAuthFile, pullSandbox)
+		_, err = oras.PullToFile(ctx, imgCache, pullTo, pullFrom, pullArch, ociAuth, noHTTPS, reqAuthFile, pullSandbox)
 		if err != nil {
 			sylog.Fatalf("While pulling image from oci registry: %v", err)
 		}

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -168,7 +168,7 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 			}
 
-			if err := oras.UploadImage(cmd.Context(), file, ref, ociAuth, noHTTPS, reqAuthFile); err != nil {
+			if err := oras.Push(cmd.Context(), file, ref, ociAuth, noHTTPS, reqAuthFile); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")

--- a/internal/pkg/build/sources/conveyorPacker_oras.go
+++ b/internal/pkg/build/sources/conveyorPacker_oras.go
@@ -12,6 +12,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/apptainer/apptainer/internal/pkg/client/oras"
 	"github.com/apptainer/apptainer/pkg/build/types"
@@ -33,7 +34,7 @@ func (cp *OrasConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 	// full uri for name determination and output
 	fullRef := "oras:" + ref
 
-	imagePath, err := oras.Pull(ctx, b.Opts.ImgCache, fullRef, b.Opts.TmpDir, b.Opts.OCIAuthConfig, b.Opts.NoHTTPS, b.Opts.ReqAuthFile)
+	imagePath, err := oras.Pull(ctx, b.Opts.ImgCache, fullRef, runtime.GOARCH, b.Opts.TmpDir, b.Opts.OCIAuthConfig, b.Opts.NoHTTPS, b.Opts.ReqAuthFile)
 	if err != nil {
 		return fmt.Errorf("while fetching library image: %v", err)
 	}

--- a/internal/pkg/client/oras/push.go
+++ b/internal/pkg/client/oras/push.go
@@ -1,0 +1,43 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2020, Control Command Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oras
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/apptainer/sif/v2/pkg/sif"
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+// Push will push an oras image from the specified location
+func Push(ctx context.Context, path, ref string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) error {
+	arch, err := sifArch(path)
+	if err != nil {
+		return err
+	}
+	return UploadImage(ctx, path, ref, arch, ociAuth, noHTTPS, reqAuthFile)
+}
+
+func sifArch(filename string) (string, error) {
+	f, err := sif.LoadContainerFromPath(filename, sif.OptLoadWithFlag(os.O_RDONLY))
+	if err != nil {
+		return "", fmt.Errorf("unable to open: %v: %w", filename, err)
+	}
+	defer f.UnloadContainer()
+
+	arch := f.PrimaryArch()
+	if arch == "unknown" {
+		return arch, fmt.Errorf("unknown architecture in SIF file")
+	}
+	return arch, nil
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

The default is to always use "amd64", pull the GOARCH instead. This is for resolving image index, into an image manifest.

When pushing an image, use the architecture of the SIF file. This intended to work the same way for oras, as for library.

### This fixes or addresses the following GitHub issues:

 - Fixes #3344

Tested locally:

BEFORE (running emulated)

```console
$ uname -sm
Linux aarch64
$ apptainer run oras://ghcr.io/afbjorklund/lolcow-multi.sif uname -sm
INFO:    Downloading oras image
2.2MiB / 2.2MiB [=================================================================================] 100 % 289.5 KiB/s 0s
Linux x86_64
```

AFTER (running natively)

```console
$ uname -sm
Linux aarch64
$ apptainer run oras://ghcr.io/afbjorklund/lolcow-multi.sif uname -sm
INFO:    Downloading oras image
1.9MiB / 1.9MiB [=================================================================================] 100 % 161.7 KiB/s 0s
INFO:    fuse2fs not found, will not be able to mount EXT3 filesystems
INFO:    gocryptfs not found, will not be able to use gocryptfs
Linux aarch64
```

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
