### PR TITLE
Add `{PRE|AP}PEND_LD_LIBRARY_PATH` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,24 @@ For older changes see the [archived Singularity change log](https://github.com/a
   Also add the image name (ref) of the image from "docker", with registry and tag.
   This is useful for traceability, when using `docker.io` or a tag like `latest`.
   Unfortunately the feature does not work with "docker-archive" or "docker-daemon".
-- Whenever libraries are bound in to `/.singularity.d/libs` (such as with
-  GPU options like `--nv`) and `LD_LIBRARY_PATH` is not pre-set by
-  `APPTAINERENV_LD_LIBRARY_PATH`, add the container's default library search
-  directories to `LD_LIBRARY_PATH` ahead of `/.singularity.d/libs`.
-  This makes libraries pre-installed in the container take precedence over
-  libraries bound in from the host.  Works with glibc-based container operating
-  systems and reduces the chances of mismatched glibc versions.
+- If `PREPEND_LD_LIBRARY_PATH` is set in the container environment (through
+  an `--env` option, an `APPTAINERENV_` prefix from the host, or in the
+  container definition) then prepend that string to `:$LD_LIBRARY_PATH`.
+  Likewise if `APPEND_LD_LIBRARY_PATH` is set in the container environment
+  then append that string to `$LD_LIBRARY_PATH:`.  This is only done when
+  `LD_LIBRARY_PATH` is set, although if the container is based on glibc,
+  when `LD_LIBRARY_PATH` is not set it will first be filled with the
+  default library search path as found through `ldconfig`.
+- If libraries are bound in to `/.singularity.d/libs` (such as with GPU
+  options like `--nv`) and the container is based on glibc and
+  `LD_LIBRARY_PATH` is not already set, it is now set to the default
+  library search path.  Since `/.singularity.d/libs` is appended to
+  `LD_LIBRARY_PATH`, this makes libraries installed in the container
+  take precedence over libraries bound in from the host.  This reduces
+  the chances of mismatched glibc versions.  However, if there are
+  indeed libraries on the host that need to take precedence over
+  libraries in the container, that can be forced with
+  `PREPEND_LD_LIBRARY_PATH=/.singularity.d/libs`.
 - Change the default `arm` variant to `v7`, and stop using the GOARM environment
   variable. The variables GOOS, GOARCH and GOARM are only used when building.
 - Add new bootstrap `buildkit:` (and `buildkit:` URL) for building SIF images

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -137,10 +137,20 @@ func (c ctx) apptainerEnvOption(t *testing.T) {
 	customImage := c.env.ImagePath
 	customPath := defaultPath + ":/go/bin:/usr/local/go/bin"
 
+	// Use Debian for LD_LIBRARY_PATH tests because busybox and alpine
+	// don't use glibc and so with those Apptainer can't figure out a
+	// default LD_LIBRARY_PATH
+	e2e.EnsureDebianImage(t, c.env)
+	debianImage := c.env.DebianImagePath
+	// TODO: calculate the default path from the image the same
+	// way that Apptainer does
+	defaultLdLibPath := "/usr/local/lib:/lib/x86_64-linux-gnu:/lib"
+
 	tests := []struct {
 		name     string
 		image    string
 		envOpt   []string
+		execOpt  []string
 		hostEnv  []string
 		matchEnv string
 		matchVal string
@@ -289,20 +299,41 @@ func (c ctx) apptainerEnvOption(t *testing.T) {
 		},
 		{
 			name:     "TestDefaultLdLibraryPath",
-			image:    customImage,
+			image:    debianImage,
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: apptainerLibs,
 		},
 		{
+			name:     "TestDefaultLdLibraryPathWithBind",
+			image:    debianImage,
+			execOpt:  []string{"-B", "/etc/os-release:" + apptainerLibs + "/os-release"},
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: defaultLdLibPath + ":" + apptainerLibs,
+		},
+		{
+			name:     "TestPrependLdLibraryPath",
+			image:    debianImage,
+			envOpt:   []string{"PREPEND_LD_LIBRARY_PATH=/foo"},
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: "/foo:" + defaultLdLibPath + ":" + apptainerLibs,
+		},
+		{
+			name:     "TestAppendLdLibraryPath",
+			image:    debianImage,
+			envOpt:   []string{"APPEND_LD_LIBRARY_PATH=/foo"},
+			matchEnv: "LD_LIBRARY_PATH",
+			matchVal: defaultLdLibPath + ":" + apptainerLibs + ":/foo",
+		},
+		{
 			name:     "TestCustomTrailingCommaPath",
-			image:    customImage,
+			image:    debianImage,
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo,"},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo,:" + apptainerLibs,
 		},
 		{
 			name:     "TestCustomLdLibraryPath",
-			image:    customImage,
+			image:    debianImage,
 			envOpt:   []string{"LD_LIBRARY_PATH=/foo"},
 			matchEnv: "LD_LIBRARY_PATH",
 			matchVal: "/foo:" + apptainerLibs,
@@ -313,6 +344,9 @@ func (c ctx) apptainerEnvOption(t *testing.T) {
 		args := make([]string, 0)
 		if tt.envOpt != nil {
 			args = append(args, "--env", strings.Join(tt.envOpt, ","))
+		}
+		if tt.execOpt != nil {
+			args = append(args, tt.execOpt...)
 		}
 		args = append(args, tt.image, "/bin/sh", "-c", "echo \"${"+tt.matchEnv+"}\"")
 		c.env.RunApptainer(

--- a/internal/pkg/util/fs/files/action_script.sh
+++ b/internal/pkg/util/fs/files/action_script.sh
@@ -84,22 +84,35 @@ shopt -s expand_aliases
 
 # If /.singularity.d/libs isn't empty we want it to be searched last so it
 # doesn't hide libraries in the container.  The trouble is that LD_LIRARY_PATH
-# is always searched before system libraries.  So if LD_LIBRARY_PATH is also
-# empty, fill it with the default system library directories.  Then 99-base.sh
-# will append /.singularity.d/libs to it.
-if [ -z "${LD_LIBRARY_PATH:-}" ] && [ "$(cd /.singularity.d/libs && echo *)" != "*" ]; then
+# is always searched before system libraries.  So if LD_LIBRARY_PATH is the
+# default value set by 99-base.sh, prepend default system library directories.
+# Also prepend the default LD_LIBRARY_PATH if PREPEND_LD_LIBRARY_PATH or
+# APPEND_LD_LIBRARY_PATH are set.
+set_default_ld_library_path()
+{
+    # /.singularity.d/libs is the default setting at this point if no
+    # other value was given to LD_LIBRARY_PATH
+    if [ "$LD_LIBRARY_PATH" != "/.singularity.d/libs" ]; then
+        return
+    fi
+    if [ "$(cd /.singularity.d/libs 2>/dev/null && echo *)" = "*" ] &&
+      [ -z "${PREPEND_LD_LIBRARY_PATH:-}" ] && \
+      [ -z "${APPEND_LD_LIBRARY_PATH:-}" ]; then
+      return
+    fi
     # Only glibc's ldconfig lists these directories; musl from alpine, for
     # example, prints nothing, but this is mostly for GPU libraries and
     # those require glibc anyway.
+    typeset __dirs__
     __dirs__="$( (/sbin/ldconfig -Nv | /bin/sed '/^\t/d;s/:.*//') 2>/dev/null )"
     if [ -n "$__dirs__" ]; then
         # change newlines into spaces and spaces into colons
         # shellcheck disable=SC2116
         __dirs__="$(echo $__dirs__)"
-        export LD_LIBRARY_PATH="${__dirs__// /:}"
+        export LD_LIBRARY_PATH="${__dirs__// /:}:$LD_LIBRARY_PATH"
         sylog debug "Setting LD_LIBRARY_PATH to $LD_LIBRARY_PATH"
     fi
-fi
+}
 
 if test -d "/.singularity.d/env"; then
     for __script__ in /.singularity.d/env/*.sh; do
@@ -127,6 +140,9 @@ if test -d "/.singularity.d/env"; then
                 # Singularity 2.3, inject forwarded variables right after
                 source "${__script__}"
                 source "/.inject-apptainer-env.sh"
+                # set default LD_LIBRARY_PATH if it hasn't been set but needs
+                # to be
+                set_default_ld_library_path
                 ;;
             *)
                 source "${__script__}"
@@ -141,10 +157,22 @@ else
         export PATH="$(fixpath)"
     fi
     source "/.inject-apptainer-env.sh"
+    set_default_ld_library_path
 fi
 
 if ! test -f "/.singularity.d/env/99-runtimevars.sh"; then
     source "/.singularity.d/env/99-runtimevars.sh"
+fi
+
+if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+    if [ -n "${PREPEND_LD_LIBRARY_PATH:-}" ]; then
+        sylog debug "Prepending $PREPEND_LD_LIBRARY_PATH to LD_LIBRARY_PATH"
+        LD_LIBRARY_PATH="$PREPEND_LD_LIBRARY_PATH:$LD_LIBRARY_PATH"
+    fi
+    if [ -n "${APPEND_LD_LIBRARY_PATH:-}" ]; then
+        sylog debug "Appending $APPEND_LD_LIBRARY_PATH to LD_LIBRARY_PATH"
+        LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$APPEND_LD_LIBRARY_PATH"
+    fi
 fi
 
 shopt -u expand_aliases


### PR DESCRIPTION
This adds support for `PREPEND_LD_LIBRARY_PATH` and `APPEND_LD_LIBRARY_PATH` environment variables.

One of the benefits is that this gives a way to go back to the previous behavior from before #3293 of searching `/.singularity.d/libs` before a container's default library paths.