### PR TITLE
Allow creating squashfs data partition instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Add support for APPTAINER_TMPDIR, also to the commands
   `apptainer overlay create` and `apptainer plugin compile`.
 - The oras transport now supports architectures beyond `amd64`.
+- Add `--data` flag to build, for sif creation with a squashfs data partition.
 
 ## v1.4.x changes
 

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -47,6 +47,7 @@ var buildArgs struct {
 	noTest              bool
 	sandbox             bool
 	update              bool
+	data                bool
 	nvidia              bool
 	nvccli              bool
 	rocm                bool
@@ -70,6 +71,16 @@ var buildSandboxFlag = cmdline.Flag{
 	ShortHand:    "s",
 	Usage:        "build image as sandbox format (chroot directory structure)",
 	EnvKeys:      []string{"SANDBOX"},
+}
+
+// --data
+var buildDataFlag = cmdline.Flag{
+	ID:           "buildDataFlag",
+	Value:        &buildArgs.data,
+	DefaultValue: false,
+	Name:         "data",
+	Usage:        "build image with data partition instead of system partition",
+	EnvKeys:      []string{"DATA"},
 }
 
 // --section
@@ -366,6 +377,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&buildNoCleanupFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildNoTestFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildSandboxFlag, buildCmd)
+		cmdManager.RegisterFlagForCmd(&buildDataFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildSectionFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&buildUpdateFlag, buildCmd)
 		cmdManager.RegisterFlagForCmd(&commonForceFlag, buildCmd)

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -355,6 +355,10 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 		sandboxTarget = true
 
 	}
+	dataPartition := false
+	if buildArgs.data {
+		dataPartition = true
+	}
 
 	arch, err := oci.ConvertArch(buildArgs.buildArch, buildArgs.buildArchVariant)
 	if err != nil {
@@ -390,6 +394,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 				EncryptionKeyInfo: keyInfo,
 				FixPerms:          buildArgs.fixPerms,
 				SandboxTarget:     sandboxTarget,
+				DataPartition:     dataPartition,
 				MksquashfsArgs:    buildArgs.mksquashfsArgs,
 				Binds:             buildArgs.bindPaths,
 				Unprivilege:       unprivilege,

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1262,6 +1262,21 @@ func (c *imgBuildTests) ensureImageIsGocryptfsEncrypted(t *testing.T, imgPath st
 	)
 }
 
+func (c *imgBuildTests) ensureImageHasDataPartition(t *testing.T, imgPath string) {
+	sifID := "3"
+	cmdArgs := []string{"info", sifID, imgPath}
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("sif"),
+		e2e.WithArgs(cmdArgs...),
+		e2e.ExpectExit(
+			0,
+			e2e.ExpectOutput(e2e.RegexMatch, "Partition Type:[ ]+Data"),
+		),
+	)
+}
+
 func (c imgBuildTests) buildEncryptPemFile(t *testing.T) {
 	busyboxSIF := e2e.BusyboxSIF(t)
 
@@ -2408,6 +2423,44 @@ func (c imgBuildTests) reproducibleBuild(t *testing.T) {
 	}
 }
 
+func (c imgBuildTests) buildDataPartition(t *testing.T) {
+	require.Command(t, "mksquashfs")
+
+	tmpdir, cleanup := c.tempDir(t, "build-data-part")
+
+	t.Cleanup(func() {
+		if !t.Failed() {
+			cleanup()
+		}
+	})
+
+	squashfsImage := filepath.Join(tmpdir, "test.squashfs")
+	squashDir, err := os.MkdirTemp(tmpdir, "squashfs-root-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = exec.Command("mksquashfs", squashDir, squashfsImage).Run()
+	if err != nil {
+		t.Fatalf("unexpected error while running command: %+v", err)
+	}
+
+	img := path.Join(tmpdir, "test.sif")
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserNamespaceProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--data", img, squashfsImage),
+		e2e.WithEnv(append(os.Environ(), "APPTAINER_VERBOSE=true")),
+		e2e.ExpectExit(
+			0,
+		),
+	)
+
+	c.ensureImageHasDataPartition(t, img)
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := imgBuildTests{
@@ -2456,5 +2509,6 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"auth":                                   np(c.buildWithAuth),                    // build with custom auth file
 		"issue 2607":                             c.issue2607,                            // https://github.com/sylabs/singularity/issues/2607
 		"reproducible build":                     c.reproducibleBuild,                    // build sifs as reproducible
+		"build with data part":                   c.buildDataPartition,                   // build sifs with data part
 	}
 }

--- a/internal/pkg/build/assemblers/sif.go
+++ b/internal/pkg/build/assemblers/sif.go
@@ -45,7 +45,7 @@ type encryptionOptions struct {
 	plaintext []byte
 }
 
-func createSIF(path string, b *types.Bundle, squashfile string, encOpts *encryptionOptions, arch string) (err error) {
+func createSIF(path string, b *types.Bundle, squashfile string, encOpts *encryptionOptions, arch string, data bool) (err error) {
 	var dis []sif.DescriptorInput
 
 	// data we need to create a definition file descriptor
@@ -95,9 +95,14 @@ func createSIF(path string, b *types.Bundle, squashfile string, encOpts *encrypt
 		fs = sif.FsGocryptfsSquashfs
 	}
 
-	// data we need to create a system partition descriptor
+	pt := sif.PartPrimSys
+	if data {
+		pt = sif.PartData
+	}
+
+	// data we need to create a system partition (or data) descriptor
 	parinput, err := sif.NewDescriptorInput(sif.DataPartition, fp,
-		sif.OptPartitionMetadata(fs, sif.PartPrimSys, arch),
+		sif.OptPartitionMetadata(fs, pt, arch),
 	)
 	if err != nil {
 		return err
@@ -214,22 +219,33 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 
 	flags = append(flags, extraArgs...)
 
-	arch := machine.ArchFromContainer(b.RootfsPath)
-	if arch == "" {
-		sylog.Infof("Architecture not recognized, use native")
-		arch = runtime.GOARCH
-	}
-	if buildarch, ok := oci.ArchMap[b.Opts.Arch]; ok {
-		if arch != buildarch.Arch {
-			// the container arch overrides the build arch (!), for backwards compatibility
-			sylog.Warningf("Architecture %s does not match build arch %s", arch, b.Opts.Arch)
+	data := b.Opts.DataPartition
+
+	arch := runtime.GOARCH
+
+	if !data {
+		arch = machine.ArchFromContainer(b.RootfsPath)
+		if arch == "" {
+			sylog.Infof("Architecture not recognized, use native")
+			arch = runtime.GOARCH
+		}
+		if buildarch, ok := oci.ArchMap[b.Opts.Arch]; ok {
+			if arch != buildarch.Arch {
+				// the container arch overrides the build arch (!), for backwards compatibility
+				sylog.Warningf("Architecture %s does not match build arch %s", arch, b.Opts.Arch)
+			}
 		}
 	}
 
 	sylog.Verbosef("Set SIF container architecture to %s", arch)
 
 	var encOpts *encryptionOptions
-	if b.Opts.Unprivilege {
+	if data {
+		sylog.Debugf("Copying squashfs image")
+
+		fsPath = b.RootfsImage
+
+	} else if b.Opts.Unprivilege {
 		sylog.Debugf("Creating squashfs image and will use gocryptfs")
 		if b.Opts.EncryptionKeyInfo == nil {
 			return fmt.Errorf("no encryption key environment variable or --passphrase provided")
@@ -285,7 +301,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 		}
 	}
 
-	err = createSIF(path, b, fsPath, encOpts, arch)
+	err = createSIF(path, b, fsPath, encOpts, arch, data)
 	if err != nil {
 		return fmt.Errorf("while creating SIF: %v", err)
 	}

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -378,8 +378,14 @@ func (b *Build) Full(ctx context.Context) error {
 		}
 
 		sylog.Debugf("Inserting Metadata")
-		if err := stage.insertMetadata(); err != nil {
-			return fmt.Errorf("while inserting metadata to bundle: %v", err)
+		if b.Conf.Opts.DataPartition {
+			if err := stage.insertMetadataForData(); err != nil {
+				return fmt.Errorf("while inserting metadata to bundle: %v", err)
+			}
+		} else {
+			if err := stage.insertMetadata(); err != nil {
+				return fmt.Errorf("while inserting metadata to bundle: %v", err)
+			}
 		}
 
 		if err := stage.runTestScript(sessionResolv, sessionHosts); err != nil {

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -66,7 +66,27 @@ func (s *stage) insertMetadata() error {
 	}
 
 	// insert JSON inspect metadata (must be the last call)
-	if err := insertJSONInspectMetadata(s.b); err != nil {
+	if err := insertJSONInspectMetadata(s.b, []string{"--all"}); err != nil {
+		return fmt.Errorf("while inserting JSON inspect metadata: %v", err)
+	}
+
+	return nil
+}
+
+func (s *stage) insertMetadataForData() error {
+	// insert labels
+	if err := insertLabelsJSON(s.b); err != nil {
+		return fmt.Errorf("while inserting labels json: %v", err)
+	}
+
+	// insert definition
+	if err := insertDefinition(s.b); err != nil {
+		return fmt.Errorf("while inserting definition: %v", err)
+	}
+
+	// insert JSON inspect metadata (must be the last call)
+	opts := []string{"--json", "--labels", "--deffile"}
+	if err := insertJSONInspectMetadata(s.b, opts); err != nil {
 		return fmt.Errorf("while inserting JSON inspect metadata: %v", err)
 	}
 
@@ -264,11 +284,14 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 	return err
 }
 
-func insertJSONInspectMetadata(b *types.Bundle) error {
+func insertJSONInspectMetadata(b *types.Bundle, inspectOpt []string) error {
 	metadata := new(inspect.Metadata)
 
 	exe := filepath.Join(buildcfg.BINDIR, "apptainer")
-	cmd := exec.Command(exe, "inspect", "--all", b.RootfsPath)
+	opt := []string{"inspect"}
+	opt = append(opt, inspectOpt...)
+	opt = append(opt, b.RootfsPath)
+	cmd := exec.Command(exe, opt...)
 	cmd.Stderr = os.Stderr
 
 	out, err := cmd.Output()

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -32,6 +32,16 @@ type LocalConveyorPacker struct {
 	localPacker LocalPacker
 }
 
+type CopyPacker struct {
+	srcfile string
+	b       *types.Bundle
+}
+
+func (cp *CopyPacker) Pack(_ context.Context) (*types.Bundle, error) {
+	cp.b.RootfsImage = cp.srcfile
+	return cp.b, nil
+}
+
 // GetLocalPacker ...
 func GetLocalPacker(ctx context.Context, src string, b *types.Bundle) (LocalPacker, error) {
 	imageObject, err := image.Init(src, false)
@@ -81,6 +91,13 @@ func GetLocalPacker(ctx context.Context, src string, b *types.Bundle) (LocalPack
 		}, nil
 	case image.SQUASHFS:
 		sylog.Debugf("Packing from Squashfs")
+
+		if b.Opts.DataPartition {
+			return &CopyPacker{
+				srcfile: src,
+				b:       b,
+			}, nil
+		}
 
 		return &SquashfsPacker{
 			srcfile: src,

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -54,8 +54,9 @@ type Bundle struct {
 	Recipe      Definition        `json:"rawDeffile"`
 	Opts        Options           `json:"opts"`
 
-	RootfsPath string `json:"rootfsPath"` // where actual fs to chroot will appear
-	TmpDir     string `json:"tmpPath"`    // where temp files required during build will appear
+	RootfsPath  string `json:"rootfsPath"`            // where actual fs to chroot will appear
+	RootfsImage string `json:"rootfsImage,omitempty"` // external squashfs to be used for data partition
+	TmpDir      string `json:"tmpPath"`               // where temp files required during build will appear
 
 	SourceDateEpoch time.Time // SOURCE_DATE_EPOCH, or Zero (`time.Time{}`) for Now
 
@@ -109,6 +110,8 @@ type Options struct {
 	// To warn when the above is needed, we need to know if the target of this
 	// bundle will be a sandbox
 	SandboxTarget bool
+	// Create a data partition, instead of a system partition
+	DataPartition bool
 	// Binds stores bind mounts used for the post scripts
 	Binds []string
 	// whether using gocryptfs to build and run encrypted containers


### PR DESCRIPTION
## Description of the Pull Request (PR):

Avoid the unsquashfs and mksquashfs steps, and just copy the original squashfs into the resulting sif as "Data".

```
------------------------------------------------------------------------------
ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
------------------------------------------------------------------------------
1    |1       |NONE    |32176-32219               |Def.FILE
2    |1       |NONE    |32219-34442               |JSON.Generic
3    |1       |NONE    |36864-40960               |FS (Squashfs/Data/amd64)
```

### This fixes or addresses the following GitHub issues:

 - Issue #2896

BEFORE

https://apptainer.org/docs/user/main/bind_paths_and_mounts.html#image-mounts

```shell
apptainer sif new inputs.sif
apptainer sif add --datatype 4 --partarch 2 --partfs 1 --parttype 3 inputs.sif inputs.squashfs
```

AFTER

```shell
apptainer build --data inputs.sif inputs.squashfs
```


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
