### PR TITLE
Set created annotation for the oras image manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## v1.6.x changes
+
+- Add oras `org.opencontainers.image.created` annotation when pushing images.
+  The `org.label-schema.build-date` label from the SIF image is being used.
+
 ## v1.5.x changes
 
 Changes since v1.5.0-rc.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Changes since 1.5.x
   when pushing images to a registry using the `push` command.
   The --description flag sets "org.opencontainers.image.description",
   and --annotation flag can be used multiple times with "key=value".
+- Add oras `org.opencontainers.image.created` annotation when pushing images.
+  The `org.opencontainers.image.created` label from the SIF image is used.
 
 ## v1.5.x changes
 

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -462,7 +462,7 @@ func orasPushNoCheck(path, ref, layerMediaType string) error {
 		return err
 	}
 
-	im, err := oras.NewImageFromSIF(path, types.MediaType(layerMediaType))
+	im, err := oras.NewImageFromSIF(path, oras.SifConfigMediaTypeV1, types.MediaType(layerMediaType))
 	if err != nil {
 		return err
 	}

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -463,7 +463,7 @@ func orasPushNoCheck(path, ref, layerMediaType string) error {
 	}
 
 	annotations := map[string]string{}
-	im, err := oras.NewImageFromSIF(path, types.MediaType(layerMediaType), annotations)
+	im, err := oras.NewImageFromSIF(path, oras.SifConfigMediaTypeV1, types.MediaType(layerMediaType), annotations)
 	if err != nil {
 		return err
 	}

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -109,6 +109,7 @@ func (c ctx) testPushCmd(t *testing.T) {
 			imagePath:        c.env.ImagePath,
 			dstURI:           fmt.Sprintf("oras://%s/standard_sif:test", c.env.InsecureRegistry),
 			expectedExitCode: 0,
+			expectedManifest: `"org.opencontainers.image.created"`,
 		},
 		{
 			desc:             "standard SIF push with --no-https/--nohttps",

--- a/internal/pkg/client/oras/config.go
+++ b/internal/pkg/client/oras/config.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package oras
+
+import (
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+const (
+	// SifConfigMediaTypeV1 is the config descriptor mediaType for a SIF image.
+	SifConfigMediaTypeV1 = "application/vnd.sylabs.sif.config.v1+json"
+
+	// emptyConfig is the OCI empty value (JSON)
+	emptyConfig = "{}"
+	// emptyConfigSize is the size of the empty config
+	emptyConfigSize = 2
+	// emptyConfigDigest is the sha256 digest of the empty value
+	emptyConfigDigest = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+)
+
+// SifConfig implements a go-containerregistry v1.Descriptor representing an ORAS / OCI artifact.
+type SifConfig struct {
+	mediaType types.MediaType
+}
+
+func (sc *SifConfig) Digest() (v1.Hash, error) {
+	return v1.NewHash(emptyConfigDigest)
+}
+
+func (sc *SifConfig) Size() (int64, error) {
+	return emptyConfigSize, nil
+}
+
+func (sc *SifConfig) Data() ([]byte, error) {
+	return []byte(emptyConfig), nil
+}
+
+func (sc *SifConfig) MediaType() (types.MediaType, error) {
+	return sc.mediaType, nil
+}
+
+// NewConfigFromSIF creates a new config, with mt as the MediaType.
+// The MediaType should always be set SifConfigMediaTypeV1 in production.
+func NewConfigFromSIF(_ string, mt types.MediaType) (*SifConfig, error) {
+	sc := SifConfig{
+		mediaType: mt,
+	}
+
+	return &sc, nil
+}

--- a/internal/pkg/client/oras/image.go
+++ b/internal/pkg/client/oras/image.go
@@ -8,6 +8,7 @@ package oras
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -126,6 +127,10 @@ func NewImageFromSIF(file string, configMediaType, layerMediaType types.MediaTyp
 	if err != nil {
 		return nil, err
 	}
+	lCreated, err := si.layer.Created()
+	if err != nil {
+		return nil, err
+	}
 	lDigest, err := si.layer.Digest()
 	if err != nil {
 		return nil, err
@@ -151,7 +156,10 @@ func NewImageFromSIF(file string, configMediaType, layerMediaType types.MediaTyp
 	// 		  "org.opencontainers.image.title": "ubuntu_latest.sif"
 	// 		}
 	// 	  }
-	// 	]
+	// 	],
+	//      "annotations": {
+	//        "org.opencontainers.image.created": "2023-12-19T16:02:14Z"
+	//      }
 	//   }
 	si.manifest = v1.Manifest{
 		SchemaVersion: 2,
@@ -171,6 +179,9 @@ func NewImageFromSIF(file string, configMediaType, layerMediaType types.MediaTyp
 					"org.opencontainers.image.title": filepath.Base(file),
 				},
 			},
+		},
+		Annotations: map[string]string{
+			"org.opencontainers.image.created": lCreated.In(time.UTC).Format(time.RFC3339),
 		},
 	}
 

--- a/internal/pkg/client/oras/image.go
+++ b/internal/pkg/client/oras/image.go
@@ -14,21 +14,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-const (
-	// emptyConfig is the OCI empty value (JSON)
-	emptyConfig = "{}"
-	// emptyConfigSize is the size of the empty config
-	emptyConfigSize = 2
-	// emptyConfigDigest is the sha256 digest of the empty value
-	emptyConfigDigest = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
-
-	// SifConfigMediaTypeV1 is the config descriptor mediaType for a SIF image.
-	SifConfigMediaTypeV1 = "application/vnd.sylabs.sif.config.v1+json"
-)
-
 // SifImage implements a go-containerregistry v1.Image representing an ORAS / OCI artifact of a single SIF image.
 type SifImage struct {
 	manifest v1.Manifest
+	config   *SifConfig
 	layer    *SifLayer
 }
 
@@ -97,8 +86,31 @@ func (si *SifImage) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
 	return si.LayerByDigest(hash)
 }
 
-func NewImageFromSIF(file string, layerMediaType types.MediaType) (*SifImage, error) {
+func NewImageFromSIF(file string, configMediaType, layerMediaType types.MediaType) (*SifImage, error) {
 	si := SifImage{}
+
+	sc, err := NewConfigFromSIF(file, configMediaType)
+	if err != nil {
+		return nil, err
+	}
+	si.config = sc
+
+	cMediaType, err := si.config.MediaType()
+	if err != nil {
+		return nil, err
+	}
+	cSize, err := si.config.Size()
+	if err != nil {
+		return nil, err
+	}
+	cData, err := si.config.Data()
+	if err != nil {
+		return nil, err
+	}
+	cDigest, err := si.config.Digest()
+	if err != nil {
+		return nil, err
+	}
 
 	sl, err := NewLayerFromSIF(file, layerMediaType)
 	if err != nil {
@@ -119,11 +131,6 @@ func NewImageFromSIF(file string, layerMediaType types.MediaType) (*SifImage, er
 		return nil, err
 	}
 
-	emptyHash, err := v1.NewHash(emptyConfigDigest)
-	if err != nil {
-		return nil, err
-	}
-
 	//
 	// Example manifest - config is always empty JSON '{}'. Single SIF file layer.
 	//
@@ -132,7 +139,8 @@ func NewImageFromSIF(file string, layerMediaType types.MediaType) (*SifImage, er
 	// 	"config": {
 	// 	  "mediaType": "application/vnd.sylabs.sif.config.v1+json",
 	// 	  "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
-	// 	  "size": 2
+	// 	  "size": 2,
+	//        "data": "e30="
 	// 	},
 	// 	"layers": [
 	// 	  {
@@ -149,9 +157,10 @@ func NewImageFromSIF(file string, layerMediaType types.MediaType) (*SifImage, er
 		SchemaVersion: 2,
 		MediaType:     types.OCIManifestSchema1,
 		Config: v1.Descriptor{
-			MediaType: types.MediaType(SifConfigMediaTypeV1),
-			Digest:    emptyHash,
-			Size:      emptyConfigSize,
+			MediaType: cMediaType,
+			Digest:    cDigest,
+			Size:      cSize,
+			Data:      cData,
 		},
 		Layers: []v1.Descriptor{
 			{

--- a/internal/pkg/client/oras/image.go
+++ b/internal/pkg/client/oras/image.go
@@ -14,21 +14,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
-const (
-	// emptyConfig is the OCI empty value (JSON)
-	emptyConfig = "{}"
-	// emptyConfigSize is the size of the empty config
-	emptyConfigSize = 2
-	// emptyConfigDigest is the sha256 digest of the empty value
-	emptyConfigDigest = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
-
-	// SifConfigMediaTypeV1 is the config descriptor mediaType for a SIF image.
-	SifConfigMediaTypeV1 = "application/vnd.sylabs.sif.config.v1+json"
-)
-
 // SifImage implements a go-containerregistry v1.Image representing an ORAS / OCI artifact of a single SIF image.
 type SifImage struct {
 	manifest v1.Manifest
+	config   *SifConfig
 	layer    *SifLayer
 }
 
@@ -97,8 +86,31 @@ func (si *SifImage) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
 	return si.LayerByDigest(hash)
 }
 
-func NewImageFromSIF(file string, layerMediaType types.MediaType, annotations map[string]string) (*SifImage, error) {
+func NewImageFromSIF(file string, configMediaType, layerMediaType types.MediaType, annotations map[string]string) (*SifImage, error) {
 	si := SifImage{}
+
+	sc, err := NewConfigFromSIF(file, configMediaType)
+	if err != nil {
+		return nil, err
+	}
+	si.config = sc
+
+	cMediaType, err := si.config.MediaType()
+	if err != nil {
+		return nil, err
+	}
+	cSize, err := si.config.Size()
+	if err != nil {
+		return nil, err
+	}
+	cData, err := si.config.Data()
+	if err != nil {
+		return nil, err
+	}
+	cDigest, err := si.config.Digest()
+	if err != nil {
+		return nil, err
+	}
 
 	sl, err := NewLayerFromSIF(file, layerMediaType)
 	if err != nil {
@@ -119,11 +131,6 @@ func NewImageFromSIF(file string, layerMediaType types.MediaType, annotations ma
 		return nil, err
 	}
 
-	emptyHash, err := v1.NewHash(emptyConfigDigest)
-	if err != nil {
-		return nil, err
-	}
-
 	//
 	// Example manifest - config is always empty JSON '{}'. Single SIF file layer.
 	//
@@ -132,7 +139,8 @@ func NewImageFromSIF(file string, layerMediaType types.MediaType, annotations ma
 	// 	"config": {
 	// 	  "mediaType": "application/vnd.sylabs.sif.config.v1+json",
 	// 	  "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
-	// 	  "size": 2
+	// 	  "size": 2,
+	//        "data": "e30="
 	// 	},
 	// 	"layers": [
 	// 	  {
@@ -149,9 +157,10 @@ func NewImageFromSIF(file string, layerMediaType types.MediaType, annotations ma
 		SchemaVersion: 2,
 		MediaType:     types.OCIManifestSchema1,
 		Config: v1.Descriptor{
-			MediaType: types.MediaType(SifConfigMediaTypeV1),
-			Digest:    emptyHash,
-			Size:      emptyConfigSize,
+			MediaType: cMediaType,
+			Digest:    cDigest,
+			Size:      cSize,
+			Data:      cData,
 		},
 		Layers: []v1.Descriptor{
 			{

--- a/internal/pkg/client/oras/image.go
+++ b/internal/pkg/client/oras/image.go
@@ -8,6 +8,7 @@ package oras
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -126,9 +127,17 @@ func NewImageFromSIF(file string, configMediaType, layerMediaType types.MediaTyp
 	if err != nil {
 		return nil, err
 	}
+	lCreated, err := si.layer.Created()
+	if err != nil {
+		return nil, err
+	}
 	lDigest, err := si.layer.Digest()
 	if err != nil {
 		return nil, err
+	}
+
+	if !lCreated.IsZero() {
+		annotations["org.opencontainers.image.created"] = lCreated.In(time.UTC).Format(time.RFC3339)
 	}
 
 	//
@@ -151,7 +160,10 @@ func NewImageFromSIF(file string, configMediaType, layerMediaType types.MediaTyp
 	// 		  "org.opencontainers.image.title": "ubuntu_latest.sif"
 	// 		}
 	// 	  }
-	// 	]
+	// 	],
+	//      "annotations": {
+	//        "org.opencontainers.image.created": "2023-12-19T16:02:14Z"
+	//      }
 	//   }
 	si.manifest = v1.Manifest{
 		SchemaVersion: 2,

--- a/internal/pkg/client/oras/layer.go
+++ b/internal/pkg/client/oras/layer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
@@ -28,6 +29,7 @@ const (
 // ORAS / OCI artifact usage.
 type SifLayer struct {
 	size      int64
+	created   time.Time
 	rc        io.ReadCloser
 	hash      v1.Hash
 	mediaType types.MediaType
@@ -55,6 +57,10 @@ func (sl *SifLayer) Size() (int64, error) {
 	return sl.size, nil
 }
 
+func (sl *SifLayer) Created() (time.Time, error) {
+	return sl.created, nil
+}
+
 func (sl *SifLayer) MediaType() (types.MediaType, error) {
 	return sl.mediaType, nil
 }
@@ -73,6 +79,12 @@ func NewLayerFromSIF(file string, mt types.MediaType) (*SifLayer, error) {
 		return nil, err
 	}
 	sl.size = fi.Size()
+
+	created, err := ImageCreated(file)
+	if err != nil {
+		return nil, err
+	}
+	sl.created = created
 
 	hash, err := ImageHash(context.TODO(), file)
 	if err != nil {

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -276,7 +276,7 @@ func RefDigest(ctx context.Context, ref, arch string, ociAuth *authn.AuthConfig,
 func ImageCreated(filePath string) (time.Time, error) {
 	f, err := sif.LoadContainerFromPath(filePath, sif.OptLoadWithFlag(os.O_RDONLY))
 	if err != nil {
-		return time.Time{}, err
+		return time.Now(), nil
 	}
 	defer f.UnloadContainer()
 

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -141,7 +141,7 @@ func UploadImage(ctx context.Context, path, ref, arch string, ociAuth *authn.Aut
 		return err
 	}
 
-	im, err := NewImageFromSIF(path, SifLayerMediaTypeV1) // nolint:contextcheck
+	im, err := NewImageFromSIF(path, SifConfigMediaTypeV1, SifLayerMediaTypeV1) // nolint:contextcheck
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -14,16 +14,20 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/apptainer/apptainer/internal/pkg/client"
 	"github.com/apptainer/apptainer/internal/pkg/util/ociauth"
 	"github.com/apptainer/apptainer/pkg/image"
+	"github.com/apptainer/apptainer/pkg/inspect"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
+	"github.com/apptainer/sif/v2/pkg/sif"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -264,6 +268,75 @@ func RefDigest(ctx context.Context, ref, arch string, ociAuth *authn.AuthConfig,
 		return v1.Hash{}, err
 	}
 	return im.Digest()
+}
+
+// ImageCreated returns the created for a file
+func ImageCreated(filePath string) (time.Time, error) {
+	f, err := sif.LoadContainerFromPath(filePath, sif.OptLoadWithFlag(os.O_RDONLY))
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer f.UnloadContainer()
+
+	d, err := f.GetDescriptors(sif.WithDataType(sif.DataGenericJSON))
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	created := time.Now()
+	for _, desc := range d {
+		if desc.Name() != image.SIFDescInspectMetadataJSON {
+			continue
+		}
+
+		metadata := new(inspect.Metadata)
+		if err := json.NewDecoder(desc.GetReader()).Decode(metadata); err != nil {
+			return time.Time{}, err
+		}
+
+		buildDate := metadata.Attributes.Labels["org.label-schema.build-date"]
+		t, err := parseBuildDate(buildDate)
+		if err != nil {
+			return time.Time{}, err
+		}
+		created = t
+	}
+	return created, nil
+}
+
+func parseBuildDate(date string) (time.Time, error) {
+	// time.Parse uses underscores with a special meaning, so replace with space
+	buildTime := strings.ReplaceAll(date, "_", " ")
+	buildFormat := "Monday 2 January 2006 15:04:05 MST"
+	t, err := time.Parse(buildFormat, buildTime)
+	if err != nil {
+		return time.Time{}, err
+	}
+	// Try to convert ambiguous US timezone strings, otherwise parsing as UTC(!)
+	tz, err := time.LoadLocation(usTimezone(t.Zone()))
+	if err == nil {
+		t, err = time.ParseInLocation(buildFormat, buildTime, tz)
+		if err != nil {
+			return time.Time{}, err
+		}
+	}
+	return t, nil
+}
+
+func usTimezone(name string, offset int) string {
+	if offset == 0 {
+		switch name {
+		case "CDT", "CST":
+			return "US/Central"
+		case "EDT", "EST":
+			return "US/Eastern"
+		case "MDT", "MST":
+			return "US/Mountain"
+		case "PDT", "PST":
+			return "US/Pacific"
+		}
+	}
+	return name
 }
 
 // ImageDigest returns the digest for a file

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -307,6 +309,8 @@ func ImageCreated(filePath string) (time.Time, error) {
 func parseBuildDate(date string) (time.Time, error) {
 	// time.Parse uses underscores with a special meaning, so replace with space
 	buildTime := strings.ReplaceAll(date, "_", " ")
+	// unfortunately apptainer used a custom method to construct a time string
+	buildTime = addLeadingZeros(buildTime)
 	buildFormat := "Monday 2 January 2006 15:04:05 MST"
 	t, err := time.Parse(buildFormat, buildTime)
 	if err != nil {
@@ -321,6 +325,18 @@ func parseBuildDate(date string) (time.Time, error) {
 		}
 	}
 	return t, nil
+}
+
+func addLeadingZeros(date string) string {
+	re := regexp.MustCompile(`([0-9]+):([0-9]+):([0-9]+)`)
+	if groups := re.FindStringSubmatch(date); groups != nil {
+		h, _ := strconv.Atoi(groups[1])
+		m, _ := strconv.Atoi(groups[2])
+		s, _ := strconv.Atoi(groups[3])
+		return re.ReplaceAllString(date,
+			fmt.Sprintf("%02d:%02d:%02d", h, m, s))
+	}
+	return date
 }
 
 func usTimezone(name string, offset int) string {

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -14,16 +14,20 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/apptainer/apptainer/internal/pkg/client"
 	"github.com/apptainer/apptainer/internal/pkg/util/ociauth"
 	"github.com/apptainer/apptainer/pkg/image"
+	"github.com/apptainer/apptainer/pkg/inspect"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	useragent "github.com/apptainer/apptainer/pkg/util/user-agent"
+	"github.com/apptainer/sif/v2/pkg/sif"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -274,6 +278,44 @@ func RefDigest(ctx context.Context, ref, arch string, ociAuth *authn.AuthConfig,
 		return v1.Hash{}, err
 	}
 	return im.Digest()
+}
+
+// ImageCreated returns the created for a file
+func ImageCreated(filePath string) (time.Time, error) {
+	f, err := sif.LoadContainerFromPath(filePath, sif.OptLoadWithFlag(os.O_RDONLY))
+	if err != nil {
+		return time.Now(), nil
+	}
+	defer f.UnloadContainer()
+
+	d, err := f.GetDescriptors(sif.WithDataType(sif.DataGenericJSON))
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	created := time.Now()
+	for _, desc := range d {
+		if desc.Name() != image.SIFDescInspectMetadataJSON {
+			continue
+		}
+
+		metadata := new(inspect.Metadata)
+		if err := json.NewDecoder(desc.GetReader()).Decode(metadata); err != nil {
+			return time.Time{}, err
+		}
+
+		createdTime := metadata.Attributes.Labels["org.opencontainers.image.created"]
+		if createdTime == "" {
+			return time.Time{}, nil
+		}
+
+		t, err := time.Parse(time.RFC3339, createdTime)
+		if err != nil {
+			return time.Time{}, err
+		}
+		created = t
+	}
+	return created, nil
 }
 
 // ImageDigest returns the digest for a file

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -151,7 +151,7 @@ func UploadImage(ctx context.Context, path, ref, arch string, ociAuth *authn.Aut
 		annotationsMap[key] = value
 	}
 
-	im, err := NewImageFromSIF(path, SifLayerMediaTypeV1, annotationsMap) // nolint:contextcheck
+	im, err := NewImageFromSIF(path, SifConfigMediaTypeV1, SifLayerMediaTypeV1, annotationsMap) // nolint:contextcheck
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Refactor oras config into separate file and struct

Set created annotation for the oras image manifest

### This fixes or addresses the following GitHub issues:

 - Fixes #2404

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
