### PR TITLE
Add manifest annotation flag for push to oras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## v1.6.x changes
+
+- Add possibility to add description and annotations for oras.
+
 ## v1.5.x changes
 
 Changes since v1.5.0-rc.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Changes since 1.5.x
   "org.opencontainers.image.architecture" (optional ".variant").
   The old deprecated labels: "org.label-schema.build-date" and
   "org.label-schema.build-arch" are still set, for compatibility.
+- Add possibility to add description and annotations for oras,
+  when pushing images to a registry using the `push` command.
+  The --description flag sets "org.opencontainers.image.description",
+  and --annotation flag can be used multiple times with "key=value".
 
 ## v1.5.x changes
 

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -35,6 +35,9 @@ var (
 
 	// pushDescription holds a description to be set against a library container
 	pushDescription string
+
+	// pushAnnotations holds the annotations to be set against an oras image
+	pushAnnotations []string
 )
 
 // --library
@@ -65,7 +68,16 @@ var pushDescriptionFlag = cmdline.Flag{
 	DefaultValue: "",
 	Name:         "description",
 	ShortHand:    "D",
-	Usage:        "description for container image (library:// only)",
+	Usage:        "description for container image (library:// and oras:// only)",
+}
+
+// --annotation
+var pushAnnotationFlag = cmdline.Flag{
+	ID:           "pushAnnotationFlag",
+	Value:        &pushAnnotations,
+	DefaultValue: cmdline.StringArray{},
+	Name:         "annotation",
+	Usage:        "annotation for container image (oras:// only, key=val format)",
 }
 
 func init() {
@@ -75,6 +87,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&pushLibraryURIFlag, PushCmd)
 		cmdManager.RegisterFlagForCmd(&pushAllowUnsignedFlag, PushCmd)
 		cmdManager.RegisterFlagForCmd(&pushDescriptionFlag, PushCmd)
+		cmdManager.RegisterFlagForCmd(&pushAnnotationFlag, PushCmd)
 		cmdManager.RegisterFlagForCmd(&commonNoHTTPSFlag, PushCmd)
 
 		cmdManager.RegisterFlagForCmd(&dockerHostFlag, PushCmd)
@@ -161,14 +174,15 @@ var PushCmd = &cobra.Command{
 
 		case OrasProtocol:
 			if cmd.Flag(pushDescriptionFlag.Name).Changed {
-				sylog.Warningf("Description is not supported for push to oras. Ignoring it.")
+				description := fmt.Sprintf("%s=%s", "org.opencontainers.image.description", pushDescription)
+				pushAnnotations = append(pushAnnotations, description)
 			}
 			ociAuth, err := makeOCICredentials(cmd)
 			if err != nil {
 				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 			}
 
-			if err := oras.Push(cmd.Context(), file, ref, ociAuth, noHTTPS, reqAuthFile); err != nil {
+			if err := oras.Push(cmd.Context(), file, ref, ociAuth, noHTTPS, reqAuthFile, pushAnnotations); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")

--- a/e2e/pull/pull.go
+++ b/e2e/pull/pull.go
@@ -462,7 +462,8 @@ func orasPushNoCheck(path, ref, layerMediaType string) error {
 		return err
 	}
 
-	im, err := oras.NewImageFromSIF(path, types.MediaType(layerMediaType))
+	annotations := map[string]string{}
+	im, err := oras.NewImageFromSIF(path, types.MediaType(layerMediaType), annotations)
 	if err != nil {
 		return err
 	}

--- a/e2e/push/push.go
+++ b/e2e/push/push.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/e2e/internal/testhelper"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/pkg/errors"
 )
 
@@ -74,11 +76,14 @@ func (c ctx) testPushCmd(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc             string // case description
-		dstURI           string // destination URI for image
-		imagePath        string // src image path
-		expectedExitCode int    // expected exit code for the test
-		noHTTPS          bool   // --no-https/--nohttps flag
+		desc             string   // case description
+		dstURI           string   // destination URI for image
+		imagePath        string   // src image path
+		expectedExitCode int      // expected exit code for the test
+		noHTTPS          bool     // --no-https/--nohttps flag
+		description      string   // --description
+		annotations      []string // --annotation
+		expectedManifest string   // expected partial manifest content
 	}{
 		{
 			desc:             "non existent image",
@@ -112,6 +117,22 @@ func (c ctx) testPushCmd(t *testing.T) {
 			noHTTPS:          true,
 			expectedExitCode: 0,
 		},
+		{
+			desc:             "standard SIF push with --description",
+			imagePath:        c.env.ImagePath,
+			dstURI:           fmt.Sprintf("oras://%s/standard_sif:test_description", c.env.InsecureRegistry),
+			description:      "description",
+			expectedExitCode: 0,
+			expectedManifest: `"org.opencontainers.image.description"`,
+		},
+		{
+			desc:             "standard SIF push with --annotation",
+			imagePath:        c.env.ImagePath,
+			dstURI:           fmt.Sprintf("oras://%s/standard_sif:test_annotation", c.env.InsecureRegistry),
+			annotations:      []string{"foo=x", "bar=y"},
+			expectedExitCode: 0,
+			expectedManifest: `"bar":"y","foo":"x"`, // alphabetical order
+		},
 	}
 
 	for _, tt := range tests {
@@ -134,6 +155,13 @@ func (c ctx) testPushCmd(t *testing.T) {
 			args = "--no-https" + " " + args
 		}
 
+		if tt.description != "" {
+			args = "--description=" + tt.description + " " + args
+		}
+		for _, annotation := range tt.annotations {
+			args = "--annotation=" + annotation + " " + args
+		}
+
 		c.env.RunApptainer(
 			t,
 			e2e.AsSubtest(tt.desc),
@@ -142,6 +170,25 @@ func (c ctx) testPushCmd(t *testing.T) {
 			e2e.WithArgs(strings.Split(args, " ")...),
 			e2e.ExpectExit(tt.expectedExitCode),
 		)
+
+		if tt.expectedManifest != "" {
+			ref := strings.TrimPrefix(tt.dstURI, "oras://")
+			ir, err := name.ParseReference(ref)
+			if err != nil {
+				t.Fatalf("error parsing image: %+v", err)
+			}
+			image, err := remote.Image(ir)
+			if err != nil {
+				t.Fatalf("error getting image: %+v", err)
+			}
+			manifest, err := image.RawManifest()
+			if err != nil {
+				t.Fatalf("error getting manifest: %+v", err)
+			}
+			if !strings.Contains(string(manifest), tt.expectedManifest) {
+				t.Errorf("did not find %s", tt.expectedManifest)
+			}
+		}
 	}
 }
 

--- a/internal/pkg/client/oras/image.go
+++ b/internal/pkg/client/oras/image.go
@@ -97,7 +97,7 @@ func (si *SifImage) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
 	return si.LayerByDigest(hash)
 }
 
-func NewImageFromSIF(file string, layerMediaType types.MediaType) (*SifImage, error) {
+func NewImageFromSIF(file string, layerMediaType types.MediaType, annotations map[string]string) (*SifImage, error) {
 	si := SifImage{}
 
 	sl, err := NewLayerFromSIF(file, layerMediaType)
@@ -163,6 +163,7 @@ func NewImageFromSIF(file string, layerMediaType types.MediaType) (*SifImage, er
 				},
 			},
 		},
+		Annotations: annotations,
 	}
 
 	return &si, nil

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -122,7 +122,7 @@ func DownloadImage(ctx context.Context, path, ref, arch string, ociAuth *authn.A
 
 // UploadImage uploads the image specified by path and pushes it to the provided oci reference,
 // it will use credentials if supplied
-func UploadImage(ctx context.Context, path, ref, arch string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) error {
+func UploadImage(ctx context.Context, path, ref, arch string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string, annotations []string) error {
 	// ensure that are uploading a SIF
 	if err := ensureSIF(path); err != nil {
 		return err
@@ -141,7 +141,17 @@ func UploadImage(ctx context.Context, path, ref, arch string, ociAuth *authn.Aut
 		return err
 	}
 
-	im, err := NewImageFromSIF(path, SifLayerMediaTypeV1) // nolint:contextcheck
+	annotationsMap := map[string]string{}
+	for _, annotation := range annotations {
+		key, value, found := strings.Cut(annotation, "=")
+		if !found {
+			sylog.Warningf("Value missing for %q, not setting", key)
+			continue
+		}
+		annotationsMap[key] = value
+	}
+
+	im, err := NewImageFromSIF(path, SifLayerMediaTypeV1, annotationsMap) // nolint:contextcheck
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/client/oras/push.go
+++ b/internal/pkg/client/oras/push.go
@@ -20,12 +20,12 @@ import (
 )
 
 // Push will push an oras image from the specified location
-func Push(ctx context.Context, path, ref string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string) error {
+func Push(ctx context.Context, path, ref string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string, annotations []string) error {
 	arch, err := sifArch(path)
 	if err != nil {
 		return err
 	}
-	return UploadImage(ctx, path, ref, arch, ociAuth, noHTTPS, reqAuthFile)
+	return UploadImage(ctx, path, ref, arch, ociAuth, noHTTPS, reqAuthFile, annotations)
 }
 
 func sifArch(filename string) (string, error) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Makes it possible to add OCI artifact annotations, for push to ORAS.

Similar to https://oras.land/docs/how_to_guides/manifest_annotations

Also implement `--description`, as a shorthand for description annotation:

`org.opencontainers.image.description`

### This fixes or addresses the following GitHub issues:

 - Fixes #3359

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
