### PR TITLE
Update bundled tools to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Add `--data` flag to build, for sif creation with a squashfs data partition.
 - Add support for Container Device Interface (CDI) through new
   `--device` and `--cdi-dirs` run/shell/exec options.
+- Update the bundled gocryptfs to version 2.6.1.
+- Update the bundled squashfuse to version 0.6.1.
+- Update the bundled fuse-overlayfs to version 1.16.
+- Update the bundled squashfs-tools to version 4.7.5.
 
 ## v1.4.x changes
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -29,11 +29,11 @@
 # For example, it has dash instead of tilde for release candidates.
 %global package_version @PACKAGE_VERSION@
 
-%global gocryptfs_version 2.5.1
-%global squashfuse_version 0.6.0
+%global gocryptfs_version 2.6.1
+%global squashfuse_version 0.6.1
 %global e2fsprogs_version 1.47.3
-%global fuse_overlayfs_version 1.15
-%global squashfs_tools_version 4.6.1
+%global fuse_overlayfs_version 1.16
+%global squashfs_tools_version 4.7.5
 
 # The last singularity version number in EPEL/Fedora
 %global last_singularity_version 3.8.7-3


### PR DESCRIPTION
## Description of the Pull Request (PR):

gocryptfs

v2.6.1, 2025-08-10
v2.6.0, 2025-07-14
Upgrade to go-fuse v2.8.0
v2.5.4, 2025-04-13
v2.5.3, 2025-04-05
v2.5.2, 2025-03-19

squashfuse

0.6.1 (Apr 26, 2025)

fuse-overlayfs

v1.16 (Nov 5, 2025): fix incorrect directory entries due to unstable iteration order.

squashfs-tools

4.7.5 (01 MAR 2026): Bug fix release (mostly)
4.7.4 (09 NOV 2025): Bug fix release
4.7.3 (05 NOV 2025): Mksquashfs streaming output, optimised reading of Sparse files using SEEK_DATA, new aligned action, documentation formatted in markdown.
4.7.2 (18 AUG 2025):	Fix build with non-static inline
4.7.1 (18 AUG 2025): Minor improvements and bug fix release
4.7 (03 JUN 2025): Parallel file reading, new help system, new reproducible filesystem image options, removal of "fragment block stall"

### This fixes or addresses the following GitHub issues:

 - Fixes #3298

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
