### PR TITLE
Revert "Try to cache the download dependencies"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,29 +360,11 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libseccomp-dev fakeroot cryptsetup dbus-user-session 
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf automake libtool pkg-config libfuse3-dev zlib1g-dev liblzo2-dev liblz4-dev liblzma-dev libzstd-dev
 
-      - uses: actions/cache/restore@v4
-        id: cache
-        with:
-          path: cache
-          key: ${{ hashFiles('dist/rpm/apptainer.spec.in') }}
-
-      - name: Download dependent packages
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Download, compile, and install dependent packages
         run: |
           set -ex
-          mkdir -p cache
-          ./scripts/download-dependencies cache
-
-      - uses: actions/cache/save@v4
-        if: steps.cache.outputs.cache-hit != 'true'
-        with:
-          path: cache
-          key: ${{ hashFiles('dist/rpm/apptainer.spec.in') }}
-
-      - name: Compile and install dependent packages
-        run: |
-          set -ex
-          ./scripts/compile-dependencies cache
+          ./scripts/download-dependencies
+          ./scripts/compile-dependencies
           sudo mkdir -p /usr/local/libexec/apptainer/bin
           sudo ./scripts/install-dependencies /usr/local/libexec
 


### PR DESCRIPTION
This reverts commit 3cfc3d412f9c3685109c99d9d18ce73e4c5b1e6b.

## Description of the Pull Request (PR):

The cache can only be used in the same PR, so it does not work.

### This fixes or addresses the following GitHub issues:

 - Issue #3387

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
