### PR TITLE
Fix a couple more typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes since v1.5.0-rc.1
   or overriding what backend to use for the BuildKit bootstrap.
 - Update minimum go version to 1.25.7.
 - Rename function `SetRunscriptTimout` to `SetRunscriptTimeout`.
+- Rename function `IsReadOnlyFilesytem` to `IsReadOnlyFilesystem`.
 
 ## v1.5.0-rc.1 - \[2026-03-12\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes since v1.5.0-rc.1
 - Add `APPTAINER_BUILDKIT_HOST` environment variable for selecting
   or overriding what backend to use for the BuildKit bootstrap.
 - Update minimum go version to 1.25.7.
+- Rename function `SetRunscriptTimout` to `SetRunscriptTimeout`.
 
 ## v1.5.0-rc.1 - \[2026-03-12\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ Changes since v1.5.0-rc.1
 - Add `APPTAINER_BUILDKIT_HOST` environment variable for selecting
   or overriding what backend to use for the BuildKit bootstrap.
 - Update minimum go version to 1.25.7.
-- Rename function `SetRunscriptTimout` to `SetRunscriptTimeout`.
-- Rename function `IsReadOnlyFilesytem` to `IsReadOnlyFilesystem`.
 
 ## v1.5.0-rc.1 - \[2026-03-12\]
 

--- a/internal/pkg/runtime/engine/apptainer/prepare_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/prepare_linux.go
@@ -1427,7 +1427,7 @@ func (e *EngineOperations) loadOverlayImages(starterConfig *starter.Config, writ
 		}
 
 		img, err := e.loadImage(splitted[0], writableOverlay, userNS, elevated)
-		if err != nil && !image.IsReadOnlyFilesytem(err) {
+		if err != nil && !image.IsReadOnlyFilesystem(err) {
 			return nil, fmt.Errorf("failed to open overlay image %s: %s", splitted[0], err)
 		}
 		if err != nil || (writableOverlay && !img.Writable) {
@@ -1485,7 +1485,7 @@ func (e *EngineOperations) loadBindImages(starterConfig *starter.Config, userNS 
 
 		writable := !binds[i].Readonly()
 		img, err := e.loadImage(imagePath, writable, userNS, elevated)
-		if err != nil && !image.IsReadOnlyFilesytem(err) {
+		if err != nil && !image.IsReadOnlyFilesystem(err) {
 			return nil, fmt.Errorf("failed to load data image %s: %s", imagePath, err)
 		}
 		if err != nil || (writable && !img.Writable) {

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -389,7 +389,7 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 	}
 
 	// Set runscript timeout
-	l.engineConfig.SetRunscriptTimout(l.cfg.RunscriptTimeout)
+	l.engineConfig.SetRunscriptTimeout(l.cfg.RunscriptTimeout)
 
 	// Set the required namespaces in the engine config.
 	l.setNamespaces()

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -87,9 +87,9 @@ func (e *readOnlyFilesystemError) Error() string {
 	return e.s
 }
 
-// IsReadOnlyFilesytem returns if the corresponding error
+// IsReadOnlyFilesystem returns if the corresponding error
 // is a read-only filesystem error or not.
-func IsReadOnlyFilesytem(err error) bool {
+func IsReadOnlyFilesystem(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -429,7 +429,7 @@ func Init(path string, writable bool) (*Image, error) {
 			sylog.Debugf("%s format initializer returned: %v", rf.name, initErr)
 			_ = img.File.Close()
 			continue
-		} else if initErr != nil && !IsReadOnlyFilesytem(initErr) {
+		} else if initErr != nil && !IsReadOnlyFilesystem(initErr) {
 			_ = img.File.Close()
 			return nil, initErr
 		}

--- a/pkg/image/squashfs.go
+++ b/pkg/image/squashfs.go
@@ -141,7 +141,7 @@ func (f *squashfsFormat) initializer(img *Image, fileinfo os.FileInfo) error {
 	if img.Writable {
 		// we set Writable to appropriate value to match the
 		// image open mode as some code may want to ignore this
-		// error by using IsReadOnlyFilesytem check
+		// error by using IsReadOnlyFilesystem check
 		img.Writable = false
 
 		return &readOnlyFilesystemError{

--- a/pkg/runtime/engine/apptainer/config/config.go
+++ b/pkg/runtime/engine/apptainer/config/config.go
@@ -983,8 +983,8 @@ func (e *EngineConfig) GetShareNSFd() int {
 	return e.JSON.ShareNSFd
 }
 
-// SetRunscriptTimout sets the runscript timeout
-func (e *EngineConfig) SetRunscriptTimout(timeout string) {
+// SetRunscriptTimeout sets the runscript timeout
+func (e *EngineConfig) SetRunscriptTimeout(timeout string) {
 	e.JSON.RunscriptTimeout = timeout
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix function names:
* `SetRunscriptTimout` → `SetRunscriptTimeout`
* `IsReadOnlyFilesytem` → `IsReadOnlyFilesystem`

I don't know whether these functions are part of some public API, in which case this change would break backwards compatibility.

#### Before submitting a PR, make sure you have done the following:

- [X] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [X] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
