### PR TITLE
Fix run-help when unprivileged install from different OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changes since v1.5.0-rc.1
 - Apptainer now supports the `loong64` architecture.
 - Add `APPTAINER_BUILDKIT_HOST` environment variable for selecting
   or overriding what backend to use for the BuildKit bootstrap.
+- When apptainer reinvokes itself on behalf of the `run-help` command,
+  pass through LD_LIBRARY_PATH.  This makes it work correctly when it
+  was installed with install-unprivileged.sh on a host operating system
+  that's different than the one the installed binaries were built on.
 - Update minimum go version to 1.25.7.
 
 ## v1.5.0-rc.1 - \[2026-03-12\]

--- a/cmd/internal/cli/run_help_linux.go
+++ b/cmd/internal/cli/run_help_linux.go
@@ -59,7 +59,12 @@ var RunHelpCmd = &cobra.Command{
 
 		execCmd := exec.Command(filepath.Join(buildcfg.BINDIR, "apptainer"), cmdArgs...)
 		execCmd.Stderr = os.Stderr
-		execCmd.Env = []string{}
+		execCmd.Env = []string{
+			// Needed for running under install-unprivileged.sh
+			// when the installed binaries are from a different
+			// OS than the host's OS
+			"LD_LIBRARY_PATH=" + os.Getenv("LD_LIBRARY_PATH"),
+		}
 
 		out, err := execCmd.Output()
 		if err != nil {


### PR DESCRIPTION
This passes in LD_LIBRARY_PATH when apptainer invokes itself for the `run-help` command.  That makes it work when it was installed by `install-unprivileged.sh` on a different host OS than the binaries are from.

- Fixes #3369