### PR TITLE
Consistent use of `writable` vs. `writeable`

### DIFF
--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -1884,7 +1884,7 @@ func (c imgBuildTests) buildLibraryHost(t *testing.T) {
 	)
 }
 
-// testWritableTmpfs checks that we can run the build using a writeable tmpfs in the %test step
+// testWritableTmpfs checks that we can run the build using a writable tmpfs in the %test step
 func (c imgBuildTests) testWritableTmpfs(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -31,7 +31,7 @@ import (
 type launchOptions struct {
 	// Writable marks the container image itself as writable.
 	Writable bool
-	// WriteableTmpfs applies an ephemeral writable overlay to the container.
+	// WritableTmpfs applies an ephemeral writable overlay to the container.
 	WritableTmpfs bool
 	// OverlayPaths holds paths to image or directory overlays to be applied.
 	OverlayPaths []string


### PR DESCRIPTION
## Description of the Pull Request (PR):

* `writable` is more common than `writeable`:
  https://books.google.com/ngrams/graph?content=writable%2Cwriteable&year_start=1800&year_end=2022
* that's the preferred spelling of dictionaries such as [EOD](https://www.oed.com/search/dictionary/?q=writeable)

#### Before submitting a PR, make sure you have done the following:

- [X] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [ ] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
