### PR TITLE
Add the new OCI Image metadata to the old labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Changes since 1.5.x
   Previously it was silently being ignored on the non-ARM architectures.
 - Change from arm32v7 to "arm", just like arm64v8 is now just "arm64".
 - Remove support for the old obsolete arm32v3 and arm32v4 architectures.
+- Add new the OCI labels: "org.opencontainers.image.created" and
+  "org.opencontainers.image.architecture" (optional ".variant").
+  The old deprecated labels: "org.label-schema.build-date" and
+  "org.label-schema.build-arch" are still set, for compatibility.
 
 ## v1.5.x changes
 

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -344,6 +344,7 @@ func addBuildLabels(labels map[string]string, b *types.Bundle) error {
 		// create reproducible timestamp
 		currentTime = b.SourceDateEpoch
 	}
+	labels["org.opencontainers.image.created"] = currentTime.Format(time.RFC3339)
 	year, month, day := currentTime.Date()
 	date := strconv.Itoa(day) + `_` + month.String() + `_` + strconv.Itoa(year)
 	hours, minutes, secs := currentTime.Clock()
@@ -376,6 +377,10 @@ func addBuildLabels(labels map[string]string, b *types.Bundle) error {
 
 	// Architecture of build
 	buildarch, _ := oci.LookupArch(b.Opts.Arch, b.Opts.Var)
+	labels["org.opencontainers.image.architecture"] = buildarch.Arch
+	if buildarch.Var != "" {
+		labels["org.opencontainers.image.variant"] = buildarch.Var
+	}
 	labels["org.label-schema.build-arch"] = buildarch.Arch
 
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add the new OCI Image metadata to the old labels

new: `org.opencontainers.image.*`

old: `org.label-schema.*`

https://github.com/opencontainers/image-spec/blob/main/annotations.md#back-compatibility-with-label-schema

### This fixes or addresses the following GitHub issues:

 - Fixes #3460 

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
