### PR TITLE
Prepare for 1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,9 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
-## v1.5.0-rc.2 - \[2026-04-14\]
+## v1.5.0 - \[2026-05-06\]
 
-Changes since v1.5.0-rc.1
-
-- Apptainer now supports the `loong64` architecture.
-- Add `APPTAINER_BUILDKIT_HOST` environment variable for selecting
-  or overriding what backend to use for the BuildKit bootstrap.
-- When apptainer reinvokes itself on behalf of the `run-help` command,
-  pass through LD_LIBRARY_PATH.  This makes it work correctly when it
-  was installed with install-unprivileged.sh on a host operating system
-  that's different than the one the installed binaries were built on.
-- Update minimum go version to 1.25.7.
-
-## v1.5.0-rc.1 - \[2026-03-12\]
-
-Changes since 1.4.5
+Changes since v1.4.5
 
 ### New Features & Functionality
 
@@ -42,6 +29,8 @@ Changes since 1.4.5
   Requires BuildKit to be installed.  The full buildkit log file is
   included in the image, for traceability.  It is also shown on the
   console, as a progress update while building.
+  If an `APPTAINER_BUILDKIT_HOST` environment variable is set it will
+  select or override what backend to use for the BuildKit bootstrap.
 - Add support for downloading SIF images from an IPFS peer-to-peer
   cluster using an HTTP gateway (similar to the existing support for IPFS
   in the `curl` tool).  The address of the gateway can be set in the
@@ -100,6 +89,7 @@ Changes since 1.4.5
 - Add additional `.rpm` packages to the release assets that include
   `el10` in their names.  Those packages are necessary to work on EL10
   which has a newer libsubid library than older EL releases.
+- Apptainer now supports the `loong64` architecture.
 
 ### Changed defaults / behaviours
 
@@ -120,7 +110,7 @@ Changes since 1.4.5
   A progress bar is shown during the process.
 - Add support for APPTAINER_TMPDIR to the commands
   `apptainer overlay create` and `apptainer plugin compile`.
-- Update minimum go version to 1.25.6.
+- Update minimum go version to 1.25.7.
 - Update the bundled gocryptfs to version 2.6.1.
 - Update the bundled squashfuse to version 0.6.1.
 - Update the bundled fuse-overlayfs to version 1.16.
@@ -138,6 +128,10 @@ Changes since 1.4.5
 - The username in `/etc/passwd` inside a container now always corresponds
   to the username of the user on the host even if an entry with the same
   UID is found in the container.
+- When apptainer reinvokes itself on behalf of the `run-help` command,
+  it passes through LD_LIBRARY_PATH.  This makes it work correctly when it
+  was installed with install-unprivileged.sh on a host operating system
+  that's different than the one the installed binaries were built on.
 
 ## v1.4.x changes
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,7 +164,7 @@ To build a specific version of Apptainer, check out a
 for example:
 
 ```sh
-git checkout v1.5.0-rc.2
+git checkout v1.5.0
 ```
 
 ## Compiling Apptainer
@@ -333,7 +333,7 @@ Then download the latest
 <!-- markdownlint-disable MD013 -->
 
 ```sh
-VERSION=1.5.0-rc.2  # this is the apptainer version, change as you need
+VERSION=1.5.0  # this is the apptainer version, change as you need
 # Fetch the source
 wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/apptainer-${VERSION}.tar.gz
 ```


### PR DESCRIPTION
Update CHANGELOG and INSTALL in preparation for the 1.5.0 release.