### PR TITLE
Add variant support for all architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.5.x
 
+- Add support for variant to more architectures, but without verification.
+  The previous arm32v5, arm32v6 and arm32v7 (= "arm") are still verified.
+- Any architecture variant, if used, is also included in the platform.
+  Previously it was silently being ignored on the non-ARM architectures.
+- Change from arm32v7 to "arm", just like arm64v8 is now just "arm64".
+- Remove support for the old obsolete arm32v3 and arm32v4 architectures.
+
 ## v1.5.x changes
 
 Changes since v1.5.0

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -73,6 +73,7 @@ var (
 	reqAuthFile string
 	// Platform for retrieving images
 	arch     string
+	variant  string
 	platform string
 )
 
@@ -923,7 +924,7 @@ func getOCIPlatform() ggcrv1.Platform {
 		p, err = ociplatform.DefaultPlatform()
 	}
 	if arch != "" {
-		p, err = ociplatform.PlatformFromArch(arch)
+		p, err = ociplatform.PlatformFromArch(arch, variant)
 	}
 	if platform != "" {
 		p, err = ociplatform.PlatformFromString(platform)

--- a/cmd/internal/cli/build_linux.go
+++ b/cmd/internal/cli/build_linux.go
@@ -369,12 +369,12 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 		dataPartition = true
 	}
 
-	arch, err := oci.ConvertArch(buildArgs.buildArch, buildArgs.buildArchVariant)
+	arch, variant, err := oci.ConvertArch(buildArgs.buildArch, buildArgs.buildArchVariant)
 	if err != nil {
 		sylog.Fatalf("While processing the arch and arch variant: %v", err)
 		return
 	}
-	dp, err := ociplatform.PlatformFromArch(arch)
+	dp, err := ociplatform.PlatformFromArch(arch, variant)
 	if err != nil {
 		sylog.Fatalf("%v", err)
 	}
@@ -404,6 +404,7 @@ func runBuildLocal(ctx context.Context, cmd *cobra.Command, dst, spec string, fa
 		Unprivilege:        unprivilege,
 		ReqAuthFile:        reqAuthFile,
 		Arch:               arch,
+		Var:                variant,
 		Platform:           *dp,
 		Reproducible:       buildArgs.reproducible,
 	}

--- a/cmd/internal/cli/pull.go
+++ b/cmd/internal/cli/pull.go
@@ -329,12 +329,12 @@ func pullRun(cmd *cobra.Command, args []string) {
 			sylog.Fatalf("While creating Docker credentials: %v", err)
 		}
 
-		arch, err := build_oci.ConvertArch(pullArch, pullArchVariant)
+		arch, variant, err := build_oci.ConvertArch(pullArch, pullArchVariant)
 		if err != nil {
 			sylog.Fatalf("While processing the arch and arch variant: %v", err)
 			return
 		}
-		platform, err := ociplatform.PlatformFromArch(arch)
+		platform, err := ociplatform.PlatformFromArch(arch, variant)
 		if err != nil {
 			sylog.Fatalf("While processing arch and platform: %v", err)
 			return
@@ -346,6 +346,7 @@ func pullRun(cmd *cobra.Command, args []string) {
 			NoHTTPS:      noHTTPS,
 			NoCleanUp:    buildArgs.noCleanUp,
 			Pullarch:     arch,
+			Pullvar:      variant,
 			ReqAuthFile:  reqAuthFile,
 			Platform:     *platform,
 			Reproducible: pullReproducible,

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -323,8 +323,8 @@ func (c cacheTests) testMultipleArch(t *testing.T) {
 		e2e.AsSubtest("pull image failure because of wrong --arch-variant"),
 		e2e.WithProfile(e2e.UserProfile),
 		e2e.WithCommand("pull"),
-		e2e.WithArgs([]string{"--force", "--arch", "arm64", "--arch-variant", "v9", sifname, "docker://alpine:3.6"}...),
-		e2e.ExpectExit(255, e2e.ExpectError(e2e.ContainMatch, "arch: arm64v9 is not valid")),
+		e2e.WithArgs([]string{"--force", "--arch", "arm", "--arch-variant", "9", sifname, "docker://alpine:3.6"}...),
+		e2e.ExpectExit(255, e2e.ExpectError(e2e.ContainMatch, "arch: arm32v9 is not valid")),
 	)
 
 	// ok cases

--- a/internal/pkg/build/assemblers/sif.go
+++ b/internal/pkg/build/assemblers/sif.go
@@ -224,7 +224,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 			sylog.Infof("Architecture not recognized, use native")
 			arch = runtime.GOARCH
 		}
-		if buildarch, ok := oci.ArchMap[b.Opts.Arch]; ok {
+		if buildarch, ok := oci.LookupArch(b.Opts.Arch); ok {
 			if arch != buildarch.Arch {
 				// the container arch overrides the build arch (!), for backwards compatibility
 				sylog.Warningf("Architecture %s does not match build arch %s", arch, b.Opts.Arch)

--- a/internal/pkg/build/assemblers/sif.go
+++ b/internal/pkg/build/assemblers/sif.go
@@ -224,7 +224,7 @@ func (a *SIFAssembler) Assemble(b *types.Bundle, path string) error {
 			sylog.Infof("Architecture not recognized, use native")
 			arch = runtime.GOARCH
 		}
-		if buildarch, ok := oci.LookupArch(b.Opts.Arch); ok {
+		if buildarch, ok := oci.LookupArch(b.Opts.Arch, b.Opts.Var); ok {
 			if arch != buildarch.Arch {
 				// the container arch overrides the build arch (!), for backwards compatibility
 				sylog.Warningf("Architecture %s does not match build arch %s", arch, b.Opts.Arch)

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -375,7 +375,7 @@ func addBuildLabels(labels map[string]string, b *types.Bundle) error {
 	}
 
 	// Architecture of build
-	buildarch, _ := oci.LookupArch(b.Opts.Arch)
+	buildarch, _ := oci.LookupArch(b.Opts.Arch, b.Opts.Var)
 	labels["org.label-schema.build-arch"] = buildarch.Arch
 
 	return nil

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -375,7 +375,7 @@ func addBuildLabels(labels map[string]string, b *types.Bundle) error {
 	}
 
 	// Architecture of build
-	buildarch := oci.ArchMap[b.Opts.Arch]
+	buildarch, _ := oci.LookupArch(b.Opts.Arch)
 	labels["org.label-schema.build-arch"] = buildarch.Arch
 
 	return nil

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -41,6 +41,10 @@ type GoArch struct {
 }
 
 var archMap = map[string]GoArch{
+	"arm": {
+		Arch: "arm",
+		Var:  "",
+	},
 	"arm64": {
 		Arch: "arm64",
 		Var:  "",
@@ -88,14 +92,20 @@ var archMap = map[string]GoArch{
 }
 
 // LookupArch looks up an architecture
-func LookupArch(a string) (GoArch, bool) {
+func LookupArch(a string, v string) (GoArch, bool) {
 	arch, ok := archMap[a]
+	if ok && v != "" {
+		arch.Var = v
+	}
 	return arch, ok
 }
 
 // SupportedArch returns architectures
-func SupportedArch() []reflect.Value {
-	keys := reflect.ValueOf(archMap).MapKeys()
+func SupportedArch() []string {
+	keys := []string{}
+	for _, value := range reflect.ValueOf(archMap).MapKeys() {
+		keys = append(keys, value.String())
+	}
 	return keys
 }
 
@@ -297,28 +307,13 @@ func getArchFromURI(uri string) (arch *GoArch) {
 	return
 }
 
-// Convert CLI options GOARCH and arch variant to recognized docker arch
-func ConvertArch(arch, archVariant string) (string, error) {
+// Convert CLI options GOARCH and arch variant (GOARM, GOARM64, GOAMD64, etc) to recognized docker arch
+func ConvertArch(arch, archVariant string) (string, string, error) {
 	supportedArchs := []string{"arm", "arm64", "amd64", "386", "ppc64le", "s390x", "riscv64", "loong64"}
 	switch arch {
-	case "arm64":
-		if archVariant == "" {
-			return "arm64", nil
-		}
-		tmpArch := ""
-		if strings.HasPrefix(archVariant, "v") {
-			tmpArch = fmt.Sprintf("%s%s", arch, archVariant)
-		} else {
-			tmpArch = fmt.Sprintf("%sv%s", arch, archVariant)
-		}
-		// verification
-		if _, ok := ArchMap[tmpArch]; !ok {
-			return "", fmt.Errorf("arch: %s is not valid, supported archs are: %v, supported variants are [8], please remove --arch-variant option", tmpArch, supportedArchs)
-		}
-		return tmpArch, nil
 	case "arm":
 		if archVariant == "" {
-			return "arm32v7", nil
+			return "arm", "", nil
 		}
 		tmpArch := ""
 		if strings.HasPrefix(archVariant, "v") {
@@ -328,14 +323,14 @@ func ConvertArch(arch, archVariant string) (string, error) {
 		}
 		// verification
 		if _, ok := archMap[tmpArch]; !ok {
-			return "", fmt.Errorf("arch: %s is not valid, supported archs are: %v, supported variants are [5, 6, 7], please remove --arch-variant option", tmpArch, supportedArchs)
+			return "", "", fmt.Errorf("arch: %s is not valid, supported archs are: %v, supported variants are [5, 6, 7], please remove --arch-variant option", tmpArch, supportedArchs)
 		}
-		return tmpArch, nil
+		return tmpArch, "", nil
 	default:
 		if _, ok := archMap[arch]; !ok {
-			return "", fmt.Errorf("arch: %s is not valid, supported archs are: %v", arch, supportedArchs)
+			return "", "", fmt.Errorf("arch: %s is not valid, supported archs are: %v", arch, supportedArchs)
 		}
 
-		return arch, nil
+		return arch, archVariant, nil
 	}
 }

--- a/internal/pkg/build/oci/oci.go
+++ b/internal/pkg/build/oci/oci.go
@@ -15,6 +15,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 
 	"github.com/apptainer/apptainer/internal/pkg/cache"
@@ -39,7 +40,7 @@ type GoArch struct {
 	Var  string
 }
 
-var ArchMap = map[string]GoArch{
+var archMap = map[string]GoArch{
 	"arm64": {
 		Arch: "arm64",
 		Var:  "",
@@ -84,6 +85,18 @@ var ArchMap = map[string]GoArch{
 		Arch: "loong64",
 		Var:  "",
 	},
+}
+
+// LookupArch looks up an architecture
+func LookupArch(a string) (GoArch, bool) {
+	arch, ok := archMap[a]
+	return arch, ok
+}
+
+// SupportedArch returns architectures
+func SupportedArch() []reflect.Value {
+	keys := reflect.ValueOf(archMap).MapKeys()
+	return keys
 }
 
 // ConvertReference converts a source reference into a cache.ImageReference to cache its blobs
@@ -276,7 +289,7 @@ func getArchFromURI(uri string) (arch *GoArch) {
 		archURI = uriComponents[1]
 	}
 
-	val, ok := ArchMap[archURI]
+	val, ok := archMap[archURI]
 	if ok {
 		arch = &val
 	}
@@ -314,12 +327,12 @@ func ConvertArch(arch, archVariant string) (string, error) {
 			tmpArch = fmt.Sprintf("arm32v%s", archVariant)
 		}
 		// verification
-		if _, ok := ArchMap[tmpArch]; !ok {
+		if _, ok := archMap[tmpArch]; !ok {
 			return "", fmt.Errorf("arch: %s is not valid, supported archs are: %v, supported variants are [5, 6, 7], please remove --arch-variant option", tmpArch, supportedArchs)
 		}
 		return tmpArch, nil
 	default:
-		if _, ok := ArchMap[arch]; !ok {
+		if _, ok := archMap[arch]; !ok {
 			return "", fmt.Errorf("arch: %s is not valid, supported archs are: %v", arch, supportedArchs)
 		}
 

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -230,6 +230,30 @@ func createInvalidImageRef(t *testing.T, invalidRef string) types.ImageReference
 	return srcRef
 }
 
+func TestLookupArch(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	arch, ok := LookupArch("arm64v8")
+	if !ok {
+		t.Fatalf("cannot lookup arch")
+	}
+	if arch.Arch != "arm64" || arch.Var != "v8" {
+		t.Fatalf("wrong arch returned")
+	}
+}
+
+func TestSupportedArch(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	keys := SupportedArch()
+	t.Log(keys)
+	if len(keys) == 0 {
+		t.Fatalf("cannot get all arch")
+	}
+}
+
 func TestConvertReference(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)

--- a/internal/pkg/build/oci/oci_test.go
+++ b/internal/pkg/build/oci/oci_test.go
@@ -234,12 +234,79 @@ func TestLookupArch(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	arch, ok := LookupArch("arm64v8")
-	if !ok {
-		t.Fatalf("cannot lookup arch")
+	tests := []struct {
+		name         string
+		architecture string
+		variant      string
+		arch         GoArch
+		shouldPass   bool
+	}{
+		{
+			name:         "foo",
+			architecture: "foo",
+			variant:      "",
+			arch:         GoArch{},
+			shouldPass:   false,
+		},
+		{
+			name:         "arm",
+			architecture: "arm",
+			variant:      "",
+			arch:         GoArch{Arch: "arm", Var: ""},
+			shouldPass:   true,
+		},
+		{
+			name:         "arm32v7",
+			architecture: "arm32v7",
+			variant:      "",
+			arch:         GoArch{Arch: "arm", Var: "v7"},
+			shouldPass:   true,
+		},
+		{
+			name:         "arm64",
+			architecture: "arm64",
+			variant:      "",
+			arch:         GoArch{Arch: "arm64", Var: ""},
+			shouldPass:   true,
+		},
+		{
+			name:         "arm64v8",
+			architecture: "arm64v8",
+			variant:      "",
+			arch:         GoArch{Arch: "arm64", Var: "v8"},
+			shouldPass:   true,
+		},
+		{
+			name:         "amd64",
+			architecture: "amd64",
+			variant:      "",
+			arch:         GoArch{Arch: "amd64", Var: ""},
+			shouldPass:   true,
+		},
+		{
+			name:         "amd64/v3",
+			architecture: "amd64",
+			variant:      "v3",
+			arch:         GoArch{Arch: "amd64", Var: "v3"},
+			shouldPass:   true,
+		},
 	}
-	if arch.Arch != "arm64" || arch.Var != "v8" {
-		t.Fatalf("wrong arch returned")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			arch, ok := LookupArch(tt.architecture, tt.variant)
+			if tt.shouldPass == true && !ok {
+				t.Fatalf("test expected to succeeded but failed")
+				return
+			}
+			if tt.shouldPass == false && ok {
+				t.Fatal("test expected to fail but succeeded")
+				return
+			}
+			if arch.Arch != tt.arch.Arch || arch.Var != tt.arch.Var {
+				t.Fatalf("wrong arch returned")
+			}
+		})
 	}
 }
 

--- a/internal/pkg/build/sources/conveyorPacker_buildkit.go
+++ b/internal/pkg/build/sources/conveyorPacker_buildkit.go
@@ -72,7 +72,7 @@ func (cp *BuildKitConveyorPacker) Get(_ context.Context, b *types.Bundle) (err e
 	cp.topts.Platform = *dp
 
 	if cp.b.Opts.Arch != "" {
-		if arch, ok := build_oci.LookupArch(cp.b.Opts.Arch); ok {
+		if arch, ok := build_oci.LookupArch(cp.b.Opts.Arch, cp.b.Opts.Var); ok {
 			cp.topts.Platform = v1.Platform{
 				OS:           dp.OS,
 				Architecture: arch.Arch,

--- a/internal/pkg/build/sources/conveyorPacker_buildkit.go
+++ b/internal/pkg/build/sources/conveyorPacker_buildkit.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	build_oci "github.com/apptainer/apptainer/internal/pkg/build/oci"
@@ -73,14 +72,14 @@ func (cp *BuildKitConveyorPacker) Get(_ context.Context, b *types.Bundle) (err e
 	cp.topts.Platform = *dp
 
 	if cp.b.Opts.Arch != "" {
-		if arch, ok := build_oci.ArchMap[cp.b.Opts.Arch]; ok {
+		if arch, ok := build_oci.LookupArch(cp.b.Opts.Arch); ok {
 			cp.topts.Platform = v1.Platform{
 				OS:           dp.OS,
 				Architecture: arch.Arch,
 				Variant:      arch.Var,
 			}
 		} else {
-			keys := reflect.ValueOf(build_oci.ArchMap).MapKeys()
+			keys := build_oci.SupportedArch()
 			return fmt.Errorf("failed to parse the arch value: %s, should be one of %v", cp.b.Opts.Arch, keys)
 		}
 	}

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -161,7 +161,7 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 	cp.topts.Platform = *dp
 
 	if cp.b.Opts.Arch != "" {
-		if arch, ok := build_oci.LookupArch(cp.b.Opts.Arch); ok {
+		if arch, ok := build_oci.LookupArch(cp.b.Opts.Arch, cp.b.Opts.Var); ok {
 			cp.topts.Platform = v1.Platform{
 				OS:           dp.OS,
 				Architecture: arch.Arch,

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"strings"
 	"text/template"
@@ -162,14 +161,14 @@ func (cp *OCIConveyorPacker) Get(ctx context.Context, b *sytypes.Bundle) (err er
 	cp.topts.Platform = *dp
 
 	if cp.b.Opts.Arch != "" {
-		if arch, ok := build_oci.ArchMap[cp.b.Opts.Arch]; ok {
+		if arch, ok := build_oci.LookupArch(cp.b.Opts.Arch); ok {
 			cp.topts.Platform = v1.Platform{
 				OS:           dp.OS,
 				Architecture: arch.Arch,
 				Variant:      arch.Var,
 			}
 		} else {
-			keys := reflect.ValueOf(build_oci.ArchMap).MapKeys()
+			keys := build_oci.SupportedArch()
 			return fmt.Errorf("failed to parse the arch value: %s, should be one of %v", cp.b.Opts.Arch, keys)
 		}
 	}

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -37,6 +37,7 @@ type PullOptions struct {
 	NoHTTPS      bool
 	NoCleanUp    bool
 	Pullarch     string
+	Pullvar      string
 	ReqAuthFile  string
 	Platform     v1.Platform
 	Reproducible bool
@@ -64,7 +65,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 	// https://github.com/apptainer/singularity/issues/5172
 	to := transportOptions(opts)
 	if opts.Pullarch != "" {
-		if arch, ok := oci.LookupArch(opts.Pullarch); ok {
+		if arch, ok := oci.LookupArch(opts.Pullarch, opts.Pullvar); ok {
 			to.Platform = v1.Platform{
 				Architecture: arch.Arch,
 				Variant:      arch.Var,
@@ -134,6 +135,7 @@ func convertOciToSIF(ctx context.Context, imgCache *cache.Handle, image, cachedI
 				DockerDaemonHost: opts.DockerHost,
 				ImgCache:         imgCache,
 				Arch:             opts.Pullarch,
+				Var:              opts.Pullvar,
 				ReqAuthFile:      opts.ReqAuthFile,
 				Platform:         opts.Platform,
 				Reproducible:     opts.Reproducible,

--- a/internal/pkg/client/oci/pull.go
+++ b/internal/pkg/client/oci/pull.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/apptainer/apptainer/internal/pkg/build"
@@ -65,13 +64,13 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 	// https://github.com/apptainer/singularity/issues/5172
 	to := transportOptions(opts)
 	if opts.Pullarch != "" {
-		if arch, ok := oci.ArchMap[opts.Pullarch]; ok {
+		if arch, ok := oci.LookupArch(opts.Pullarch); ok {
 			to.Platform = v1.Platform{
 				Architecture: arch.Arch,
 				Variant:      arch.Var,
 			}
 		} else {
-			keys := reflect.ValueOf(oci.ArchMap).MapKeys()
+			keys := oci.SupportedArch()
 			return "", fmt.Errorf("failed to parse the arch value: %s, should be one of %v", opts.Pullarch, keys)
 		}
 	}

--- a/internal/pkg/ociplatform/cpuinfo_linux.go
+++ b/internal/pkg/ociplatform/cpuinfo_linux.go
@@ -100,10 +100,6 @@ func getCPUVariantFromArch(arch string) (string, error) {
 			variant = "6"
 		case "v5":
 			variant = "5"
-		case "v4":
-			variant = "4"
-		case "v3":
-			variant = "3"
 		default:
 			variant = "unknown"
 		}
@@ -155,10 +151,6 @@ func getCPUVariant() (string, error) {
 		variant = "v6"
 	case "5", "5t", "5te", "5tej":
 		variant = "v5"
-	case "4", "4t":
-		variant = "v4"
-	case "3":
-		variant = "v3"
 	default:
 		variant = "unknown"
 	}

--- a/internal/pkg/ociplatform/cpuinfo_linux.go
+++ b/internal/pkg/ociplatform/cpuinfo_linux.go
@@ -87,9 +87,7 @@ func getCPUVariantFromArch(arch string) (string, error) {
 
 	arch = strings.ToLower(arch)
 
-	if arch == "aarch64" {
-		variant = "8"
-	} else if arch[0:4] == "armv" && len(arch) >= 5 {
+	if arch[0:4] == "armv" && len(arch) >= 5 {
 		// Valid arch format is in form of armvXx
 		switch arch[3:5] {
 		case "v8":
@@ -143,7 +141,7 @@ func getCPUVariant() (string, error) {
 	}
 
 	switch strings.ToLower(variant) {
-	case "8", "aarch64":
+	case "8":
 		variant = "v8"
 	case "7", "7m", "?(12)", "?(13)", "?(14)", "?(15)", "?(16)", "?(17)":
 		variant = "v7"

--- a/internal/pkg/ociplatform/cpuinfo_linux_test.go
+++ b/internal/pkg/ociplatform/cpuinfo_linux_test.go
@@ -31,7 +31,7 @@ func TestCPUVariant(t *testing.T) {
 		t.Skip("only relevant on linux/arm")
 	}
 
-	variants := []string{"v8", "v7", "v6", "v5", "v4", "v3"}
+	variants := []string{"v8", "v7", "v6", "v5"}
 
 	p, err := getCPUVariant()
 	if err != nil {
@@ -84,18 +84,6 @@ func TestGetCPUVariantFromArch(t *testing.T) {
 			name:        "Test armv5",
 			input:       "armv5",
 			output:      "5",
-			expectedErr: nil,
-		},
-		{
-			name:        "Test armv4",
-			input:       "armv4",
-			output:      "4",
-			expectedErr: nil,
-		},
-		{
-			name:        "Test armv3",
-			input:       "armv3",
-			output:      "3",
 			expectedErr: nil,
 		},
 		{

--- a/internal/pkg/ociplatform/cpuinfo_linux_test.go
+++ b/internal/pkg/ociplatform/cpuinfo_linux_test.go
@@ -57,12 +57,6 @@ func TestGetCPUVariantFromArch(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name:        "Test aarch64",
-			input:       "aarch64",
-			output:      "8",
-			expectedErr: nil,
-		},
-		{
 			name:        "Test Armv8 with capital",
 			input:       "Armv8",
 			output:      "8",

--- a/internal/pkg/ociplatform/database.go
+++ b/internal/pkg/ociplatform/database.go
@@ -28,11 +28,7 @@ import (
 //
 // The arch value should be normalized before being passed to this function.
 func isArmArch(arch string) bool {
-	switch arch {
-	case "arm", "arm64":
-		return true
-	}
-	return false
+	return arch == "arm"
 }
 
 // normalizeArch normalizes the architecture.
@@ -41,16 +37,10 @@ func normalizeArch(arch, variant string) (string, string) {
 	switch arch {
 	case "i386":
 		arch = "386"
-		variant = ""
 	case "x86_64", "x86-64":
 		arch = "amd64"
-		variant = ""
 	case "aarch64", "arm64":
 		arch = "arm64"
-		switch variant {
-		case "8", "v8":
-			variant = ""
-		}
 	case "armhf":
 		arch = "arm"
 		variant = "v7"
@@ -59,9 +49,7 @@ func normalizeArch(arch, variant string) (string, string) {
 		variant = "v6"
 	case "arm":
 		switch variant {
-		case "", "7":
-			variant = "v7"
-		case "5", "6", "8":
+		case "5", "6", "7", "8":
 			variant = "v" + variant
 		}
 	}

--- a/internal/pkg/ociplatform/ociplatform.go
+++ b/internal/pkg/ociplatform/ociplatform.go
@@ -68,12 +68,12 @@ func PlatformFromString(p string) (*ggcrv1.Platform, error) {
 	return plat, nil
 }
 
-func PlatformFromArch(a string) (*ggcrv1.Platform, error) {
+func PlatformFromArch(a string, v string) (*ggcrv1.Platform, error) {
 	if runtime.GOOS != "linux" {
 		return nil, fmt.Errorf("%q is not a valid platform OS for apptainer", runtime.GOOS)
 	}
 
-	arch, variant := normalizeArch(a, "")
+	arch, variant := normalizeArch(a, v)
 
 	return &ggcrv1.Platform{
 		OS:           runtime.GOOS,

--- a/internal/pkg/ociplatform/ociplatform_test.go
+++ b/internal/pkg/ociplatform/ociplatform_test.go
@@ -36,21 +36,39 @@ func TestPlatformFromString(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "GoodAMD64",
+			name:    "NormalizeAMD64",
 			plat:    "linux/amd64",
 			want:    &ggcrv1.Platform{OS: "linux", Architecture: "amd64", Variant: ""},
 			wantErr: false,
 		},
 		{
+			name:    "NormalizeAMD64/v2",
+			plat:    "linux/amd64/v2",
+			want:    &ggcrv1.Platform{OS: "linux", Architecture: "amd64", Variant: "v2"},
+			wantErr: false,
+		},
+		{
 			name:    "NormalizeARM",
 			plat:    "linux/arm",
-			want:    &ggcrv1.Platform{OS: "linux", Architecture: "arm", Variant: "v7"},
+			want:    &ggcrv1.Platform{OS: "linux", Architecture: "arm", Variant: ""},
+			wantErr: false,
+		},
+		{
+			name:    "NormalizeARM/v6",
+			plat:    "linux/arm/v6",
+			want:    &ggcrv1.Platform{OS: "linux", Architecture: "arm", Variant: "v6"},
+			wantErr: false,
+		},
+		{
+			name:    "NormalizeARM64",
+			plat:    "linux/arm64",
+			want:    &ggcrv1.Platform{OS: "linux", Architecture: "arm64", Variant: ""},
 			wantErr: false,
 		},
 		{
 			name:    "NormalizeARM64/v8",
 			plat:    "linux/arm64/v8",
-			want:    &ggcrv1.Platform{OS: "linux", Architecture: "arm64", Variant: ""},
+			want:    &ggcrv1.Platform{OS: "linux", Architecture: "arm64", Variant: "v8"},
 			wantErr: false,
 		},
 		{

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -122,8 +122,10 @@ type Options struct {
 	Tag string
 	// Digest info (from RepoDigests)
 	Digest string
-	// Arch info
+	// Arch info (architecture)
 	Arch string
+	// Var info (variant)
+	Var string
 	// Authentication file for registry credentials
 	ReqAuthFile string
 	// Extra arguments for mksquashfs


### PR DESCRIPTION
## Description of the Pull Request (PR):

Make arm default to v7 and arm32 default to v8, but
without explicitly adding the variant unless asked to.
    
Pass any optional variant to the platform, for later
image selection but without hardcoding the variants.

### This fixes or addresses the following GitHub issues:

 - Fixes #3471

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
