### PR TITLE
Fix incorrect propagation of APPTAINER_BINDPATH inside the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.5.x
 
+- Add `nonested` flag for `--mount` specifications to prevent individual
+  bind mounts from being passed to nested containers via `APPTAINER_BIND`.
+  Example: `--mount type=bind,source=/data,destination=/mnt,nonested`.
+- Remove stale comment about `--mount` binds not being exported for nested
+  containers.
 - Add support for variant to more architectures, but without verification.
   The previous arm32v5, arm32v6 and arm32v7 (= "arm") are still verified.
 - Any architecture variant, if used, is also included in the platform.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ Changes since 1.5.x
 - Add `nonested` flag for `--mount` specifications to prevent individual
   bind mounts from being passed to nested containers via `APPTAINER_BIND`.
   Example: `--mount type=bind,source=/data,destination=/mnt,nonested`.
-- Remove stale comment about `--mount` binds not being exported for nested
-  containers.
 - Add support for variant to more architectures, but without verification.
   The previous arm32v5, arm32v6 and arm32v7 (= "arm") are still verified.
 - Any architecture variant, if used, is also included in the platform.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -71,6 +71,7 @@
 - Josef Hrabal <josef.hrabal@vsb.cz>
 - Justin Cook <justin@sylabs.io>
 - Justin Riley <justin_riley@harvard.edu>
+- Karen Hambardzumyan <mahnerak@gmail.com>
 - Kir Kolyshkin <kolyshkin@gmail.com>
 - Kirill Priadko <kirill.priadko@intel.com>
 - Krishna Muriki <kmuriki@gmail.com>

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -131,7 +131,7 @@ var actionMountFlag = cmdline.Flag{
 	Value:        &mounts,
 	DefaultValue: cmdline.StringArray{},
 	Name:         "mount",
-	Usage:        "a mount specification e.g. 'type=bind,source=/opt,destination=/hostopt'.",
+	Usage:        "a mount specification e.g. 'type=bind,source=/opt,destination=/hostopt'.  The 'nonested' flag prevents the mount from being passed to nested containers via APPTAINER_BIND.",
 	EnvKeys:      []string{"MOUNT"},
 	Tag:          "<spec>",
 	EnvHandler:   cmdline.EnvAppendValue,

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -3319,6 +3319,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 5690":                   c.issue5690,             // https://github.com/apptainer/singularity/issues/5690
 		"issue 6165":                   c.issue6165,             // https://github.com/apptainer/singularity/issues/6165
 		"issue 619":                    c.issue619,              // https://github.com/apptainer/apptainer/issues/619
+		"issue 3501":                   c.issue3501,             // https://github.com/apptainer/apptainer/issues/3501
 		"issue 1097":                   c.issue1097,             // https://github.com/apptainer/apptainer/issues/1097
 		"issue 1848":                   c.issue1848,             // https://github.com/apptainer/apptainer/issues/1848
 		"network":                      c.actionNetwork,         // test basic networking

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -603,6 +603,41 @@ func (c actionTests) issue5690(t *testing.T) {
 	)
 }
 
+// Check that --mount with nonested prevents bind from being passed
+// to nested containers via APPTAINER_BIND, while normal mounts still propagate.
+func (c actionTests) issue3501(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "issue-3501-", "")
+	defer e2e.Privileged(cleanup)(t)
+
+	// nonested mount should not appear in APPTAINER_BIND
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("nonested"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--mount", "type=bind,source="+tmpDir+",destination=/hidden,nonested", c.env.ImagePath, "/usr/bin/env"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.UnwantedContainMatch, "APPTAINER_BIND=/hidden"),
+		),
+	)
+
+	// normal --bind and nonested --mount combined:
+	// only --bind destination should appear in APPTAINER_BIND
+	c.env.RunApptainer(
+		t,
+		e2e.AsSubtest("mixed"),
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs("--bind", tmpDir+":/visible", "--mount", "type=bind,source="+tmpDir+",destination=/hidden,nonested", c.env.ImagePath, "/usr/bin/env"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.ContainMatch, "APPTAINER_BIND=/visible"),
+			e2e.ExpectOutput(e2e.UnwantedContainMatch, "/hidden"),
+		),
+	)
+}
+
 // If an invalid remote is set, we should not pull a container from the default
 // library.
 // Github Security Advisories:

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -676,7 +676,6 @@ func (l *Launcher) setBinds(fakerootPath string) error {
 		return fmt.Errorf("while parsing bind path: %w", err)
 	}
 	// Now add binds from one or more --mount and env var.
-	// Note that these do not get exported for nested containers
 	for _, m := range l.cfg.Mounts {
 		bps, err := apptainerConfig.ParseMountString(m)
 		if err != nil {
@@ -701,10 +700,13 @@ func (l *Launcher) setBinds(fakerootPath string) error {
 
 	l.engineConfig.SetBindPath(binds)
 
-	// Pass only the destinations to nested binds
-	bindPaths := make([]string, len(binds))
-	for i, bind := range binds {
-		bindPaths[i] = bind.Destination
+	// Pass bind destinations to nested containers, skipping those marked nonested
+	var bindPaths []string
+	for _, bind := range binds {
+		if bind.Options != nil && bind.Options["nonested"] != nil {
+			continue
+		}
+		bindPaths = append(bindPaths, bind.Destination)
 	}
 	l.generator.SetProcessEnvWithPrefixes(env.ApptainerPrefixes, "BIND", strings.Join(bindPaths, ","))
 	return nil

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -701,7 +701,7 @@ func (l *Launcher) setBinds(fakerootPath string) error {
 	l.engineConfig.SetBindPath(binds)
 
 	// Pass bind destinations to nested containers, skipping those marked nonested
-	var bindPaths []string
+	bindPaths := make([]string, 0, len(binds))
 	for _, bind := range binds {
 		if bind.Options != nil && bind.Options["nonested"] != nil {
 			continue

--- a/pkg/runtime/engine/apptainer/config/mount.go
+++ b/pkg/runtime/engine/apptainer/config/mount.go
@@ -80,6 +80,8 @@ func ParseMountString(mount string) (bindPaths []BindPath, err error) {
 					return []BindPath{}, fmt.Errorf("id cannot be empty")
 				}
 				bp.Options["id"] = &BindOption{Value: val}
+			case "nonested":
+				bp.Options["nonested"] = &BindOption{}
 			case "bind-propagation":
 				return []BindPath{}, fmt.Errorf("bind-propagation not supported for individual mounts, check apptainer.conf for global setting")
 			default:

--- a/pkg/runtime/engine/apptainer/config/mount_test.go
+++ b/pkg/runtime/engine/apptainer/config/mount_test.go
@@ -213,6 +213,18 @@ func TestParseMountString(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:        "noPropagate",
+			mountString: "type=bind,source=/opt,destination=/hostopt,nonested",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/hostopt",
+					Options:     map[string]*BindOption{"nonested": {}},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:        "multiple",
 			mountString: "type=bind,source=/opt,destination=/opt\ntype=bind,source=/srv,destination=/srv",
 			want: []BindPath{


### PR DESCRIPTION
Add a `nonested` flag for `--mount` bind specifications that prevents individual mounts from being propagated to nested containers via `APPTAINER_BIND`. Example: `--mount type=bind,source=/data,destination=/mnt,nonested`. This gives users fine-grained control over which binds are inherited by nested Apptainer commands, without having to manually edit `APPTAINER_BIND` inside the container.

Also clarifies in the documentation that unlike in Singularity, `APPTAINER_BIND` and `APPTAINER_BINDPATH` are equivalent aliases in Apptainer — both propagate to nested containers. Removes a stale code comment that incorrectly claimed `--mount` binds were not exported for nested containers, and updates the user docs to reflect the current behavior and point users to `nonested` as the proper way to prevent propagation.

### This fixes or addresses the following GitHub issues:

 - Fixes #3500


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
