### PR TITLE
Update to PRoot-5.4.0-rootless.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ Changes since 1.5.x
 
 ## v1.5.x changes
 
-Changes since v1.5.0
+- Update bundled PRoot to version 5.4.0-rootless.3 in order to fix a
+  problem where SIF files could be corrupted when mksquashfs died with
+  a signal.  The proot command was not passing back an error exit code.
 
 ## v1.5.0 - \[2026-05-06\]
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -35,7 +35,7 @@
 %global fuse_overlayfs_version 1.16
 %global squashfs_tools_version 4.7.5
 %ifnarch ppc64le s390x
-%global PRoot_version 5.4.0-rootless.2
+%global PRoot_version 5.4.0-rootless.3
 %endif
 
 # The last singularity version number in EPEL/Fedora


### PR DESCRIPTION
This fixes the SIF file corruption reported in #3486.