### PR TITLE
Update openSUSE build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,6 +67,9 @@ sudo dnf --enablerepo=devel install -y shadow-utils-subid-devel
 On SLE/openSUSE
 
 ```sh
+# Install basic tools for compiling
+# --replacefiles is needed to avoid pam conflict on Tumbleweed
+sudo zypper install -y --replacefiles --allow-downgrade -t pattern devel_basis
 # Install RPM packages for dependencies
 sudo zypper install -y \
   libseccomp-devel \
@@ -78,9 +81,6 @@ sudo zypper install -y \
   fakeroot \
   cryptsetup sysuser-tools \
   diffutils wget which git
-# Install basic tools for compiling
-# --replacefiles is needed to avoid pam conflict on Tumbleweed
-sudo zypper install -y --replacefiles --allow-downgrade -t pattern devel_basis
 ```
 
 For libsubid support (requires openSUSE Tumbleweed):

--- a/scripts/ci-rpm-build-test
+++ b/scripts/ci-rpm-build-test
@@ -8,11 +8,11 @@
 
 # install dependencies
 if [[ $OS_TYPE == *suse* ]]; then
+  zypper install -y --replacefiles --allow-downgrade -t pattern devel_basis
   zypper install -y --allow-downgrade \
     libseccomp-devel libtalloc-devel libattr-devel libuuid-devel openssl-devel \
     libprotobuf-c-devel fakeroot cryptsetup sysuser-tools \
     diffutils wget which git
-  zypper install -y --replacefiles --allow-downgrade -t pattern devel_basis
   if [[ $OS_TYPE == *tumbleweed* ]]; then
     zypper install -y --allow-downgrade libsubid-devel
   fi


### PR DESCRIPTION
This swaps the order of two openSUSE zypper installs in the build instructions, because the second command started getting this error:
```
+ zypper install -y --replacefiles --allow-downgrade -t pattern devel_basis
Loading repository data...
Reading installed packages...
Resolving package dependencies...

Problem: 1: the to be installed pattern:devel_basis-20170319-13.3.x86_64 requires 'patterns-devel-base-devel_basis', but this requirement cannot be provided
not installable providers: patterns-devel-base-devel_basis-20170319-13.3.x86_64[repo-oss]

 Solution 1: deinstallation of busybox-gawk-1.37.0-41.4.noarch
 Solution 2: do not install pattern:devel_basis-20170319-13.3.x86_64
 Solution 3: break pattern:devel_basis-20170319-13.3.x86_64 by ignoring some of its dependencies

Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
```