### PR TITLE
Skip downloading PRoot on unsupported architectures (release-1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ For older changes see the [archived Singularity change log](https://github.com/a
 - Update bundled PRoot to version 5.4.0-rootless.3 in order to fix a
   problem where SIF files could be corrupted when mksquashfs died with
   a signal.  The proot command was not passing back an error exit code.
+- Change the `download-dependencies` script to skip downloading the PRoot
+  source code on architectures that it is known to not support (that is:
+  ppc*, s390*, and riscv*).  In those situations Apptainer will skip
+  trying to compile and run proot. As a result original owners and groups
+  of files will not be preserved in SIF images built by unprivileged
+  users, as was the case for all architectures prior to 1.5.0.
 
 ## v1.5.0 - \[2026-05-06\]
 

--- a/scripts/clean-dependencies
+++ b/scripts/clean-dependencies
@@ -9,5 +9,5 @@
 
 set -ex
 for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs PRoot; do
-    rm -rf $PKG-*
+    rm -rf ${PKG}[_-]*
 done

--- a/scripts/download-dependencies
+++ b/scripts/download-dependencies
@@ -40,6 +40,12 @@ sed -n -e '/^# URL:/{s/^# //;s/%%/%/g;p}' -e 's/^Source[1-9][0-9]*: //p' -e 's/^
 	# take the file name from the base of the URL
 	LINE="${LINE/*\//}"
     fi
+    if [[ "$LINE" = *PRoot* ]]; then
+        # skip architectures known to not be supported by PRoot
+        case $(arch) in
+            ppc*|s390*|riscv*) continue;;
+        esac
+    fi
     if [ -n "$GITHUB_TOKEN" ] && [[ "$URL" = *github.com/*.patch ]]; then
 	# use github API instead because the public URL downloads 
 	# sometimes hit server busy (429) when run in github actions


### PR DESCRIPTION
Cherry-pick #3518 to release-1.5