### PR TITLE
Avoid overwriting /etc/passwd in case of root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.5.x
 
+- Fix fakeroot overwriting root's username in `/etc/passwd` with the host
+  user's name, a regression introduced in v1.5.0.
 - Add `nonested` flag for `--mount` specifications to prevent individual
   bind mounts from being passed to nested containers via `APPTAINER_BIND`.
   Example: `--mount type=bind,source=/data,destination=/mnt,nonested`.

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -3320,6 +3320,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"issue 6165":                   c.issue6165,             // https://github.com/apptainer/singularity/issues/6165
 		"issue 619":                    c.issue619,              // https://github.com/apptainer/apptainer/issues/619
 		"issue 3501":                   c.issue3501,             // https://github.com/apptainer/apptainer/issues/3501
+		"issue 3502":                   c.issue3502,             // https://github.com/apptainer/apptainer/issues/3502
 		"issue 1097":                   c.issue1097,             // https://github.com/apptainer/apptainer/issues/1097
 		"issue 1848":                   c.issue1848,             // https://github.com/apptainer/apptainer/issues/1848
 		"network":                      c.actionNetwork,         // test basic networking

--- a/e2e/actions/regressions.go
+++ b/e2e/actions/regressions.go
@@ -638,6 +638,22 @@ func (c actionTests) issue3501(t *testing.T) {
 	)
 }
 
+// Check that fakeroot doesn't overwrite root's username in /etc/passwd
+// with the host user's name.
+func (c actionTests) issue3502(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.FakerootProfile),
+		e2e.WithCommand("exec"),
+		e2e.WithArgs(c.env.ImagePath, "whoami"),
+		e2e.ExpectExit(0,
+			e2e.ExpectOutput(e2e.ExactMatch, "root"),
+		),
+	)
+}
+
 // If an invalid remote is set, we should not pull a container from the default
 // library.
 // Github Security Advisories:

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2629,8 +2629,11 @@ func (c *container) addIdentityMount(system *mount.System) error {
 		uid = 0
 	}
 
-	if uid == 0 {
-		sylog.Verbosef("skipping bind-mount of /etc/passwd and /etc/group (running as root)")
+	if (uid == 0) &&
+		(c.engine.EngineConfig.GetWritableImage() ||
+			c.engine.EngineConfig.GetWritableTmpfs() ||
+			c.engine.EngineConfig.GetWritableOverlay()) {
+		sylog.Verbosef("skipping bind-mount of /etc/passwd and /etc/group (container is writable running as root)")
 		return nil
 	}
 

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2629,11 +2629,8 @@ func (c *container) addIdentityMount(system *mount.System) error {
 		uid = 0
 	}
 
-	if (uid == 0) &&
-		(c.engine.EngineConfig.GetWritableImage() ||
-			c.engine.EngineConfig.GetWritableTmpfs() ||
-			c.engine.EngineConfig.GetWritableOverlay()) {
-		sylog.Verbosef("skipping bind-mount of /etc/passwd and /etc/group (container is writable running as root)")
+	if uid == 0 {
+		sylog.Verbosef("skipping bind-mount of /etc/passwd and /etc/group (running as root)")
 		return nil
 	}
 

--- a/internal/pkg/util/fs/files/passwd.go
+++ b/internal/pkg/util/fs/files/passwd.go
@@ -87,6 +87,10 @@ func Passwd(path string, home string, uid int, customLookup UserGroupLookup) (co
 			if err != nil {
 				return nil, err
 			}
+			// If user already exists in container, change their username, gecos
+			// and home dir to those of the original user. Except for uid 0,
+			// where the original user is the unprivileged host user (e.g.
+			// fakeroot) and not root, so keep the container's existing values.
 			name := pwInfo.Name
 			gecos := pwInfo.Gecos
 			if uid == 0 {

--- a/internal/pkg/util/fs/files/passwd.go
+++ b/internal/pkg/util/fs/files/passwd.go
@@ -87,8 +87,13 @@ func Passwd(path string, home string, uid int, customLookup UserGroupLookup) (co
 			if err != nil {
 				return nil, err
 			}
-			// If user already exists in container, change their username and home dir to those of the original user
-			lines[i] = makePasswdLine(pwInfo.Name, uid32, gid32, pwInfo.Gecos, homeDir, entry.Shell())
+			name := pwInfo.Name
+			gecos := pwInfo.Gecos
+			if uid == 0 {
+				name = entry.Username()
+				gecos = entry.Info()
+			}
+			lines[i] = makePasswdLine(name, uid32, gid32, gecos, homeDir, entry.Shell())
 			break
 		}
 	}

--- a/internal/pkg/util/fs/files/passwd_test.go
+++ b/internal/pkg/util/fs/files/passwd_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/test"
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
-	"github.com/ccoveille/go-safecast"
+	"github.com/ccoveille/go-safecast/v2"
 )
 
 func TestPasswd(t *testing.T) {

--- a/internal/pkg/util/fs/files/passwd_test.go
+++ b/internal/pkg/util/fs/files/passwd_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/test"
 	"github.com/apptainer/apptainer/internal/pkg/util/user"
+	"github.com/ccoveille/go-safecast"
 )
 
 func TestPasswd(t *testing.T) {
@@ -58,7 +59,11 @@ func TestPasswd(t *testing.T) {
 	}
 
 	// For non-root users, username should be overwritten with host user's name
-	pwInfo, err := user.GetPwUID(uint32(uid))
+	uid32, err := safecast.Convert[uint32](uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pwInfo, err := user.GetPwUID(uid32)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/util/fs/files/passwd_test.go
+++ b/internal/pkg/util/fs/files/passwd_test.go
@@ -12,12 +12,12 @@ package files
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/test"
+	"github.com/apptainer/apptainer/internal/pkg/util/user"
 )
 
 func TestPasswd(t *testing.T) {
@@ -51,13 +51,28 @@ func TestPasswd(t *testing.T) {
 		t.Fatalf("Unexpected error in Passwd() when modifying root entry: %v", err)
 	}
 
-	rootUser, err := user.Lookup("root")
+	// Username and gecos should be preserved for uid 0 (fakeroot safety)
+	expectRootEntry := "root:x:0:0:root:/tmp:/bin/ash\n"
+	if !strings.HasPrefix(string(outputPasswd), expectRootEntry) {
+		t.Errorf("Expected root entry %q, not found in:\n%s", expectRootEntry, string(outputPasswd))
+	}
+
+	// For non-root users, username should be overwritten with host user's name
+	pwInfo, err := user.GetPwUID(uint32(uid))
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Also check that username got rewritten from toor to root
-	expectRootEntry := fmt.Sprintf("%s:x:0:0:%s:/tmp:/bin/ash\n", rootUser.Name, rootUser.Name)
-	if !strings.HasPrefix(string(outputPasswd), expectRootEntry) {
-		t.Errorf("Expected root entry %q, not found in:\n%s", expectRootEntry, string(outputPasswd))
+	passwdWithUser := filepath.Join(t.TempDir(), "passwd")
+	wrongName := fmt.Sprintf("wrongname:x:%d:%d:wrong gecos:/old/home:/bin/sh\n", uid, pwInfo.GID)
+	if err := os.WriteFile(passwdWithUser, []byte(wrongName), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outputPasswd, err = Passwd(passwdWithUser, "/new/home", uid, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error in Passwd() when modifying non-root entry: %v", err)
+	}
+	expectEntry := fmt.Sprintf("%s:x:%d:%d:%s:/new/home:/bin/sh\n", pwInfo.Name, uid, pwInfo.GID, pwInfo.Gecos)
+	if !strings.HasPrefix(string(outputPasswd), expectEntry) {
+		t.Errorf("Expected entry %q, not found in:\n%s", expectEntry, string(outputPasswd))
 	}
 }

--- a/internal/pkg/util/fs/files/testdata/passwd.in
+++ b/internal/pkg/util/fs/files/testdata/passwd.in
@@ -1,4 +1,4 @@
-toor:x:0:0:root:/root:/bin/ash
+root:x:0:0:root:/root:/bin/ash
 bin:x:1:1:bin:/bin:/sbin/nologin
 daemon:x:2:2:daemon:/sbin:/sbin/nologin
 adm:x:3:4:adm:/var/adm:/sbin/nologin


### PR DESCRIPTION
## Description of the Pull Request (PR):

Especially in case of fakeroot, if the uid inside the apptainer is 0 (root) we want to avoid mapping it back to the original username.


### This fixes or addresses the following GitHub issues:

 - Fixes #3502 


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
