### PR TITLE
Combine bar and size into struct in progress display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changes since 1.5.x
   trying to compile and run proot. As a result original owners and groups
   of files will not be preserved in SIF images built by unprivileged
   users, as was the case for all architectures prior to 1.5.0.
+- Fix panic encountered during progress bar update while pulling image
 
 ## v1.5.0 - \[2026-05-06\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -115,6 +115,7 @@
 - Richard Hattersley <richard.hattersley@metoffice.gov.uk>
 - Richard Neuboeck <hawk@tbi.univie.ac.at>
 - Rémy Dernat <remy.dernat@umontpellier.fr>
+- Robert Clarke <robert.clarke@bristol.ac.uk>
 - Sasha Yakovtseva <sasha@sylabs.io>, <sashayakovtseva@gmail.com>
 - Satish Chebrolu  <satish@sylabs.io>
 - Shane Loretz <sloretz@openrobotics.org>, <shane.loretz@gmail.com>

--- a/internal/pkg/client/progress_roundtrip.go
+++ b/internal/pkg/client/progress_roundtrip.go
@@ -21,11 +21,15 @@ import (
 
 const contentSizeThreshold = 64 * 1024
 
+type barSize struct {
+	bar  *mpb.Bar
+	size int64
+}
+
 type RoundTripper struct {
-	inner http.RoundTripper
-	p     *mpb.Progress
-	bars  []*mpb.Bar
-	sizes []int64
+	inner    http.RoundTripper
+	p        *mpb.Progress
+	barSizes []barSize
 }
 
 // NewRoundTripper wraps inner (or http.DefaultTransport if inner is nil) with
@@ -61,8 +65,7 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.inner.RoundTrip(req)
 	if resp != nil && resp.Body != nil && resp.ContentLength >= contentSizeThreshold {
 		bar := t.p.AddBar(resp.ContentLength, defaultOption...)
-		t.bars = append(t.bars, bar)
-		t.sizes = append(t.sizes, resp.ContentLength)
+		t.barSizes = append(t.barSizes, barSize{bar, resp.ContentLength})
 		resp.Body = bar.ProxyReader(resp.Body)
 	}
 	return resp, err
@@ -71,8 +74,8 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 // ProgressComplete overrides all progress bars, setting them to 100% complete.
 func (t *RoundTripper) ProgressComplete() {
 	if t.p != nil {
-		for i, bar := range t.bars {
-			bar.SetCurrent(t.sizes[i])
+		for _, barSize := range t.barSizes {
+			barSize.bar.SetCurrent(barSize.size)
 		}
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Combines `mpb.Bar` pointer and size for each progress bar into an array of `barSize` struct. This avoids a panic if `ProgressComplete` is called when the `bars` and `sizes` arrays are out of sync.

Attempted to test locally but tests fail locally with what appear to be unrelated issues.

Running the from-source binary shows no issues with progress bars.

### This fixes or addresses the following GitHub issues:

 - Fixes #3515

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
