### PR TITLE
Work around segmentation fault in mksquashfs under proot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Changes since 1.5.x
 
 ## v1.5.x changes
 
+- Work around segmentation fault sometimes seen while mksquashfs under
+  proot is creating a SIF file.
 - Update bundled PRoot to version 5.4.0-rootless.3 in order to fix a
   problem where SIF files could be corrupted when mksquashfs died with
   a signal.  The proot command was not passing back an error exit code.

--- a/internal/pkg/image/packer/squashfs.go
+++ b/internal/pkg/image/packer/squashfs.go
@@ -73,6 +73,7 @@ func (s Squashfs) create(files []string, dest string, opts []string) error {
 	}
 
 	prog := s.MksquashfsPath
+	extraEnv := []string{}
 	if namespaces.IsUnprivileged() {
 		// building as unprivileged user, make the files appear as root
 		ignoreProot := os.Getenv("APPTAINER_IGNORE_PROOT")
@@ -84,6 +85,13 @@ func (s Squashfs) create(files []string, dest string, opts []string) error {
 			// https://github.com/apptainer/apptainer/issues/2830
 			args = append([]string{"-S", "/", prog}, args...)
 			prog = proot
+			// Add the MALLOC settings to workaround segfaults seen
+			// in mksquashfs on Ubuntu 22.04
+			// https://github.com/apptainer/apptainer/issues/3486
+			extraEnv = append(extraEnv,
+				"MALLOC_MMAP_MAX_=0",
+				"MALLOC_ARENA_MAX=32",
+			)
 		} else {
 			args = append(args, "-all-root")
 		}
@@ -93,6 +101,7 @@ func (s Squashfs) create(files []string, dest string, opts []string) error {
 	// (note: -reproducible is the default, there is also a -not-reproducible option)
 	sylog.Verbosef("Executing %s %s", prog, strings.Join(args, " "))
 	cmd := exec.Command(prog, args...)
+	cmd.Env = append(os.Environ(), extraEnv...)
 	if sylog.GetLevel() >= int(sylog.VerboseLevel) {
 		cmd.Stdout = os.Stdout
 	} else if hasPercentage {


### PR DESCRIPTION
Work around segmentation fault sometimes seen in mksquashfs under proot by setting some environment variables to change the behavior of malloc.

- Fixes #3486