### PR TITLE
Fix /etc/resolv.conf symlink crash and support symlinks to ../run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Changes since 1.5.x
   crash sometimes seen with apptainer in unprivileged docker.
 - Update bundled fuse2fs to version 1.47.4 instead of patching the bugs
   in 1.47.3.
+- Fix a crash that happened when `/etc/resolv.conf` was a symlink while
+  building from a definition file using the localimage bootstrap.
+- Support hosts that have an `/etc/resolv.conf` symlink pointing to `../run`
+  in addition to `/run".
 - Change the `download-dependencies` script to skip downloading the PRoot
   source code on architectures that it is known to not support (that is:
   ppc*, s390*, and riscv*).  In those situations Apptainer will skip

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -283,7 +283,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigResolvConfNo",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf.*- tmpfs", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "resolv.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config resolv_conf",
 			directiveValue: "no",
@@ -291,7 +291,7 @@ func (c configTests) configGlobal(t *testing.T) {
 		},
 		{
 			name:           "ConfigResolvConfYes",
-			argv:           []string{c.env.ImagePath, "grep", "/etc/resolv.conf.*- tmpfs", "/proc/self/mountinfo"},
+			argv:           []string{c.env.ImagePath, "grep", "resolv.*- tmpfs", "/proc/self/mountinfo"},
 			profile:        e2e.UserProfile,
 			directive:      "config resolv_conf",
 			directiveValue: "yes",

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2724,8 +2724,12 @@ func (c *container) addResolvConfMount(system *mount.System) error {
 				// If the symlink points to a file under /run, for example one made by
 				// systemd-resolved, then copy the symlink and bind in the parent
 				// directory of the file it points to as well.
-				if target[0:5] == "/run/" {
+				if strings.Contains(target, "/run/") && c.session.Layer != nil {
 					dst := filepath.Join(c.session.Layer.Dir(), resolvConf)
+					if target[0] != '/' {
+						// turn the relative path into an absolute path
+						target = filepath.Clean(filepath.Join(filepath.Dir(resolvConf), target))
+					}
 					if err = c.session.AddSymlink(dst, target); err != nil {
 						return fmt.Errorf("failed to create symlink %s", dst)
 					}


### PR DESCRIPTION
Fix a crash introduced in #3284 when /etc/resolv.conf is a symlink to a path starting with `/run` but when building an image using the `localimage` bootstrap.  At the same time, support symlinks beginning `../run` as well, as seen on Ubuntu 22.04 with systemd-resolved.

- Fixes #3503
