### PR TITLE
Update fuse2fs to 1.47.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Changes since 1.5.x
   a signal.  The proot command was not passing back an error exit code.
 - Updated bundled squashfuse_ll to version 0.6.2 in order to fix a
   crash sometimes seen with apptainer in unprivileged docker.
+- Update bundled fuse2fs to version 1.47.4 instead of patching the bugs
+  in 1.47.3.
 - Change the `download-dependencies` script to skip downloading the PRoot
   source code on architectures that it is known to not support (that is:
   ppc*, s390*, and riscv*).  In those situations Apptainer will skip

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -31,7 +31,7 @@
 
 %global gocryptfs_version 2.6.1
 %global squashfuse_version 0.6.2
-%global e2fsprogs_version 1.47.3
+%global e2fsprogs_version 1.47.4
 %global fuse_overlayfs_version 1.16
 %global squashfs_tools_version 4.7.5
 %ifnarch ppc64le s390x
@@ -63,13 +63,6 @@ Source11: https://github.com/vasi/squashfuse/archive/%{squashfuse_version}/squas
 %if "%{?e2fsprogs_version}" != ""
 # URL: https://github.com/tytso/e2fsprogs/archive/refs/tags/v%%{e2fsprogs_version}.tar.gz
 Source12: e2fsprogs-%{e2fsprogs_version}.tar.gz
-# URL: https://github.com/tytso/e2fsprogs/pull/246.patch
-Patch121: e2fsprogs-246.patch
-# this is PR 250 from tytso/e2fsprogs backported to apply cleanly on v1.47.3
-# URL: https://github.com/DrDaveD/e2fsprogs/pull/2.patch
-Patch122: e2fsprogs-250.patch
-# URL: https://github.com/tytso/e2fsprogs/pull/251.patch
-Patch123: e2fsprogs-251.patch
 %endif
 %if "%{?fuse_overlayfs_version}" != ""
 Source13: https://github.com/containers/fuse-overlayfs/archive/v%{fuse_overlayfs_version}/fuse-overlayfs-%{fuse_overlayfs_version}.tar.gz

--- a/internal/pkg/image/driver/imagedriver.go
+++ b/internal/pkg/image/driver/imagedriver.go
@@ -652,6 +652,7 @@ func (i *fuseappsInstance) filterMsg() string {
 		"There may be file system corruption",
 		"the file system is not gracefully unmounted.",
 		"Mounting read-only.",
+		"mounted read-only.",
 		// from squashfuse_ll
 		"failed to clone device fd",
 		"continue without -o clone_fd",


### PR DESCRIPTION
Update fuse2fs to version 1.47.4 because it fixes the bugs that we previously needed to patch.