### PR TITLE
Enable extglob for %files section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes since 1.5.x
   Not all registries support deleting images and manifests, though.
 - Add new `tag` command for tagging existing images in oras registries,
   without having to push extra copies (it also works for image indexes).
+- Add support for extended globbing patterns in the %files section
 
 ## v1.5.x changes
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -78,6 +78,7 @@
 - Kumar Sukhani <kumarsukhani@gmail.com>
 - Kundan Kumar <iamkundankumar28@gmail.com>
 - Linsen Zhou <i@lin.moe>
+- Lorenz Sieben <sieben@gea.mpg.de>
 - Maciej Sieczka <msieczka@sieczka.org>
 - Marcelo Magallon <marcelo@sylabs.io>
 - Marco Rubin <marco.rubin@protonmail.com>

--- a/internal/pkg/build/files/files.go
+++ b/internal/pkg/build/files/files.go
@@ -10,53 +10,36 @@
 package files
 
 import (
-	"bytes"
-	"context"
-	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
-	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/syntax"
 )
 
-const filenameExpansionScript = `
-for n in %[1]s ; do
-	echo -n "$n\0"
-done
-`
-
 func expandPath(path string) ([]string, error) {
-	var output, stderr bytes.Buffer
-
 	path = strings.ReplaceAll(path, " ", "\\ ")
-	cmdline := fmt.Sprintf(filenameExpansionScript, path)
-	parser, err := syntax.NewParser().Parse(strings.NewReader(cmdline), "")
+	parsedPath, err := syntax.NewParser().Document(strings.NewReader(path))
 	if err != nil {
 		return nil, err
 	}
 
-	runner, err := interp.New(
-		interp.StdIO(nil, &output, &stderr),
-	)
-	if err != nil {
-		return nil, err
+	expandConfig := expand.Config{
+		ExtGlob:  true,
+		GlobStar: true,
+		ReadDir2: os.ReadDir,
 	}
 
-	err = runner.Run(context.TODO(), parser)
-	if err != nil {
-		return nil, err
-	}
+	expandedPaths := expand.FieldsSeq(&expandConfig, parsedPath)
 
-	// parse expanded output and ignore empty strings from consecutive null bytes
-	paths := make([]string, 0, len(strings.Split(output.String(), "\\0")))
-
-	for _, s := range strings.Split(output.String(), "\\0") {
-		if s == "" {
-			continue
+	paths := make([]string, 0, 5)
+	for p, err := range expandedPaths {
+		if err != nil {
+			return nil, err
 		}
-		paths = append(paths, s)
+		paths = append(paths, p)
 	}
 
 	return paths, nil

--- a/internal/pkg/build/files/files_test.go
+++ b/internal/pkg/build/files/files_test.go
@@ -203,6 +203,11 @@ func TestExpandPath(t *testing.T) {
 			correct: []string{"dir\ttab", "dir\nnewline", "dir space", "dirL1", "file"},
 		},
 		{
+			name:    "extGlob",
+			path:    "?(dirL1|dir space)",
+			correct: []string{"dirL1", "dir space"},
+		},
+		{
 			name: "PathAndFilenameWhitespace",
 			path: "*/*",
 			correct: []string{


### PR DESCRIPTION
## Description of the Pull Request (PR):

I noticed that the path expansion in the %files section was done by executing a script with mvdan.cc/sh, which struck me as unnecessarily unsafe. Instead, we can use the mvdan.cc/sh/v3/expand package that is used by the package internally as well, and skip the rest of the shell, reducing the possibility of unexpected command injections via the %files section.

Doing that, I also enabled extglob for the %files section, allowing to make it more concise. Unfortunately negative matching is still not possible, see https://github.com/mvdan/sh/issues/1158#issuecomment-3316224634.

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
	- I did not run test which required me to run the test suite with sudo privileges, because I did not see how this was necessary for the changes I made and it struck me as unsafe. Maybe for local testing you should consider providing an option to skip privileged tests for local testing.
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
