### PR TITLE
fix: limit container paths using path prefix, not string prefix (release-1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 - Fix for [CVE-2026-48785 /
   [GHSA-cr2j-534f-mf3g](https://github.com/apptainer/apptainer/security/advisories/GHSA-cr2j-534f-mf3g)
-  Incorrect path matching for 'limit container paths' directive.
+  Incorrect path matching for `limit container paths` directive.
+  This is only applicable to suid installations that have paths listed
+  in `limit container paths` that are string prefixes of other paths
+  which are not desired to be included in the list. For example, if
+  `/scratch` is in the list but `/scratch2` also exists and contains
+  container images, previously the latter would match but now only
+  images under the exactly matching `/scratch` are included.
 
 ## Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 ## v1.5.1 - \[2026-06-04\]
 
+### Security fix
+
+- Fix for [CVE-2026-48785 /
+  [GHSA-cr2j-534f-mf3g](https://github.com/apptainer/apptainer/security/advisories/GHSA-cr2j-534f-mf3g)
+  Incorrect path matching for 'limit container paths' directive.
+
+## Other changes
+
 - Work around segmentation fault sometimes seen while mksquashfs under
   proot is creating a SIF file.
 - Update bundled PRoot to version 5.4.0-rootless.3 in order to fix a
@@ -167,7 +175,7 @@ Changes since 1.4.5
 
 ## v1.4.5 - \[2025-12-02\]
 
-## Security Related Fixes
+### Security related fixes
 
 - Fix for moderate severity [CVE-2025-65105 /
   GHSA-j3rw-fx6g-q46j](https://github.com/apptainer/apptainer/security/advisories/GHSA-j3rw-fx6g-q46j):

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
@@ -152,22 +151,27 @@ func (i *Image) ReInit() {
 	}
 }
 
-// AuthorizedPath checks if image is in a path supplied in paths
+// AuthorizedPath checks if the image is in a directory tree rooted at any of
+// the supplied paths. Paths must be absolute. Symlinks are resolved.
 func (i *Image) AuthorizedPath(paths []string) (bool, error) {
-	authorized := false
-	dirname := i.Path
-
 	for _, path := range paths {
-		match, err := filepath.EvalSymlinks(filepath.Clean(path))
+		abs, err := filepath.Abs(filepath.Clean(path))
 		if err != nil {
-			return authorized, fmt.Errorf("failed to resolve path %s: %s", path, err)
+			return false, fmt.Errorf("failed to resolve path %s: %w", path, err)
 		}
-		if strings.HasPrefix(dirname, match) {
-			authorized = true
-			break
+		match, err := filepath.EvalSymlinks(abs)
+		if err != nil {
+			return false, fmt.Errorf("failed to resolve path %s: %w", path, err)
+		}
+		rel, err := filepath.Rel(match, i.Path)
+		if err != nil {
+			return false, fmt.Errorf("failed to compare path %s against %s: %w", i.Path, match, err)
+		}
+		if rel == "." || filepath.IsLocal(rel) {
+			return true, nil
 		}
 	}
-	return authorized, nil
+	return false, nil
 }
 
 // AuthorizedOwner checks whether the image is owned by any user from the supplied users list.

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2019-2025, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -178,6 +178,34 @@ func TestAuthorizedPath(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
+	// Test image is in xxx/foobar/test.sif
+	testDir := t.TempDir()
+	imageDir := filepath.Join(testDir, "foobar")
+	if err := os.Mkdir(imageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Test image is not in xxx/foo ... which is a string prefix of xxx/foobar
+	stringPrefixPath := filepath.Join(testDir, "foo")
+	if err := os.Mkdir(stringPrefixPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Symlink xxx/link -> xxx/foobar, so the limit path resolves into the
+	// image directory via the symlink.
+	symlinkToImageDir := filepath.Join(testDir, "link")
+	if err := os.Symlink(imageDir, symlinkToImageDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// XXX(mem): This is what makes this test slow
+	path := filepath.Join(imageDir, "test.sif")
+	if err := fs.CopyFileAtomic(busyboxSIF, path, 0o755); err != nil {
+		t.Fatalf("Could not copy test image: %v", err)
+	}
+	img, err := Init(path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		name       string
 		path       []string
@@ -198,11 +226,34 @@ func TestAuthorizedPath(t *testing.T) {
 			path:       []string{"/"},
 			shouldPass: true,
 		},
+		{
+			name:       "parent path",
+			path:       []string{imageDir},
+			shouldPass: true,
+		},
+		{
+			name:       "parent path trailing slash",
+			path:       []string{imageDir + string(os.PathSeparator)},
+			shouldPass: true,
+		},
+		{
+			name:       "image file as limit path",
+			path:       []string{path},
+			shouldPass: true,
+		},
+		{
+			name:       "symlink to image dir",
+			path:       []string{symlinkToImageDir},
+			shouldPass: true,
+		},
+		// See GHSA-wqcr-7rf3-f64m
+		// Image in xxx/foobar must not be authorized for xxx/foo.
+		{
+			name:       "string prefix",
+			path:       []string{stringPrefixPath},
+			shouldPass: false,
+		},
 	}
-
-	// XXX(mem): This is what makes this test slow
-	img, path := createImage(t)
-	defer os.Remove(path)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -379,6 +379,8 @@ sessiondir max size = {{ .SessiondirMaxSize }}
 # Only allow containers to be used that are located within an allowed path
 # prefix. If this configuration is undefined (commented or set to NULL),
 # containers will be allowed to run from anywhere on the file system.
+# Does not match string prefixes; for example, if "/scratch" is listed,
+# it will not match "/scratch2".
 #
 # Only effective in setuid mode, with unprivileged user namespace creation
 # disabled.  Ignored for the root user.


### PR DESCRIPTION
The Image.AuthorizedPath function, which is passed the values of the 'limit container paths' apptainer.conf directive, previously used plain tring prefix matching. This meant an image in a sibling directory, e.g. /tmp/foobar would be allowed when the directive was set to /tmp/foo.

Because of explicit and implicit filepath.Clean it's also not possible to match on /tmp/foo/ as the final slash will be stripped by the Clean.

Modify the code to evaluate the relative path of the image from each limit path, and assess based on this.

Imported to Apptainer from https://github.com/sylabs/singularity/security/advisories/GHSA-wqcr-7rf3-f64m