### PR TITLE
Extend mksquashfs segfault workaround to many cores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Changes since 1.5.x
 
 ## v1.5.x changes
 
+- Extended the mksquashfs segmentation fault workaround for cases where
+  mksquashfs uses many processor cores.
+
 ## v1.5.1 - \[2026-06-04\]
 
 ### Security fix

--- a/internal/pkg/image/packer/squashfs.go
+++ b/internal/pkg/image/packer/squashfs.go
@@ -88,9 +88,10 @@ func (s Squashfs) create(files []string, dest string, opts []string) error {
 			// Add the MALLOC settings to workaround segfaults seen
 			// in mksquashfs on Ubuntu 22.04
 			// https://github.com/apptainer/apptainer/issues/3486
+			// https://github.com/apptainer/apptainer/issues/3560
 			extraEnv = append(extraEnv,
 				"MALLOC_MMAP_MAX_=0",
-				"MALLOC_ARENA_MAX=32",
+				"MALLOC_ARENA_MAX=1000000",
 			)
 		} else {
 			args = append(args, "-all-root")


### PR DESCRIPTION
Increase the value of MALLOC_ARENA_MAX to make the mksquashfs segmentation fault workaround effective also when there are many cores.

- Fixes #3560

and extends #3535