### PR TITLE
Switch to get opensuse containers from registry.opensuse.org and update opensuse-leap to 16.0 (release-1.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,14 +227,14 @@ jobs:
 
       - name: Install and test unprivileged for openSUSE leap
         env:
-          OS_TYPE: opensuse/leap
+          OS_TYPE: registry.opensuse.org/opensuse/leap
           OS_VERSION: latest
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 
       - name: Install and test unprivileged for openSUSE tumbleweed
         env:
-          OS_TYPE: opensuse/tumbleweed
+          OS_TYPE: registry.opensuse.org/opensuse/tumbleweed
           OS_VERSION: latest
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
@@ -302,7 +302,7 @@ jobs:
 
       - name: Build and test rpm under docker
         env:
-          OS_TYPE: opensuse/leap
+          OS_TYPE: registry.opensuse.org/opensuse/leap
           OS_VERSION: latest
           GO_ARCH: linux-amd64
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -310,7 +310,7 @@ jobs:
 
       - name: Install and test unprivileged for openSUSE leap
         env:
-          OS_TYPE: opensuse/leap
+          OS_TYPE: registry.opensuse.org/opensuse/leap
           OS_VERSION: latest
           INS_OPTS: -o -d suse15
           TEST_TYPE: unpriv
@@ -326,7 +326,7 @@ jobs:
 
       - name: Build and test rpm under docker
         env:
-          OS_TYPE: opensuse/tumbleweed
+          OS_TYPE: registry.opensuse.org/opensuse/tumbleweed
           OS_VERSION: latest
           GO_ARCH: linux-amd64
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -334,7 +334,7 @@ jobs:
 
       - name: Install and test unprivileged for openSUSE tumbleweed
         env:
-          OS_TYPE: opensuse/tumbleweed
+          OS_TYPE: registry.opensuse.org/opensuse/tumbleweed
           OS_VERSION: latest
           INS_OPTS: -o -d opensuse-tumbleweed
           TEST_TYPE: unpriv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
         env:
           OS_TYPE: registry.opensuse.org/opensuse/leap
           OS_VERSION: latest
-          INS_OPTS: -o -d suse15
+          INS_OPTS: -o -d opensuse-leap
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -143,7 +143,7 @@ case "$DIST" in
 			DIST=el9
 		fi
 	;;
-	suse15|opensuse-leap)
+	suse15|suse16|opensuse-leap)
 		if $NOOPENSUSE; then
 			DIST=el8
 		fi
@@ -194,10 +194,16 @@ case $1 in
 	    EXTRASREPOURL=$OSREPOURL
 	    OSSPLIT=false
 	    ;;
-	suse15|opensuse-leap)
+	suse16|opensuse-leap)
+	    OSREPOURL="https://download.opensuse.org/distribution/leap/16.0/repo/oss/$ARCH"
+	    EPELREPOURL="https://download.opensuse.org/repositories/network:/cluster/16.0/$ARCH"
+	    EXTRASREPOURL="https://download.opensuse.org/repositories/filesystems/16.0/$ARCH"
+	    OSSPLIT=false
+	    ;;
+	suse15)
 	    OSREPOURL="https://download.opensuse.org/distribution/leap/15.6/repo/oss/$ARCH"
 	    EPELREPOURL="https://download.opensuse.org/repositories/network:/cluster/15.6/$ARCH"
-	    EXTRASREPOURL="https://download.opensuse.org/repositories/filesystems/15.6/$ARCH"
+	    EXTRASREPOURL="https://download.opensuse.org/repositories/filesystems/15.7/$ARCH"
 	    OSSPLIT=false
 	    ;;
 	*) fatal "$1 distribution not supported";;

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -12,9 +12,9 @@
 # Works with apptainer versions 1.1.4 and higher.
 
 REQUIREDCMDS="curl rpm2cpio cpio"
-
-# assumes at least a 1 Mbit connection
-CURLOPTS="--connect-timeout 5 -Y 125000 -y 10 -Ls"
+MAXRETRIES=5
+# assumes at least a 0.5 Mbit connection
+CURLOPTS="--connect-timeout 10 -Y 50000 -y 10 -Ls"
 
 usage()
 {
@@ -246,7 +246,7 @@ latesturl()
 		URL="${URL/\/Packages\///os/Packages/}"
 		latesturl "$URL" "$2" false false
 		return $?
-	elif [ $RETRY -lt 3 ]; then
+	elif [ $RETRY -lt $MAXRETRIES ]; then
 		RETRY=$((RETRY+1))
 		if $SHOWERRORS; then
 			echo "Retrying..." >&2
@@ -276,7 +276,7 @@ else
 	APPTAINERURL="$KOJIURL/$REL/$ARCH/apptainer-$VERSION-$REL.$ARCH.rpm"
 fi
 
-# Retry url to 3 times if download fails
+# Retry url up to $MAXTRIES times if download fails
 extracturl()
 {
 	typeset URL="$1"
@@ -288,7 +288,7 @@ extracturl()
 			break
 		fi
 		RETRY=$((RETRY+1))
-		if [ "$RETRY" -ge 3 ]; then
+		if [ "$RETRY" -ge $MAXRETRIES ]; then
 			fatal "Failure extracting $URL"
 		fi
 		if $SHOWERRORS; then


### PR DESCRIPTION
Cherry-pick #3573 to the release-1.5 branch.

Replacement for #3574 which was accidentally created against the main branch.