### PR TITLE
Extend mksquashfs segfault workaround to many cores (release-1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## v1.5.x changes
+
+- Extended the mksquashfs segmentation fault workaround for cases where
+  mksquashfs uses many processor cores.
+
 ## v1.5.1 - \[2026-06-04\]
 
 ### Security fix

--- a/internal/pkg/image/packer/squashfs.go
+++ b/internal/pkg/image/packer/squashfs.go
@@ -88,9 +88,10 @@ func (s Squashfs) create(files []string, dest string, opts []string) error {
 			// Add the MALLOC settings to workaround segfaults seen
 			// in mksquashfs on Ubuntu 22.04
 			// https://github.com/apptainer/apptainer/issues/3486
+			// https://github.com/apptainer/apptainer/issues/3560
 			extraEnv = append(extraEnv,
 				"MALLOC_MMAP_MAX_=0",
-				"MALLOC_ARENA_MAX=32",
+				"MALLOC_ARENA_MAX=1000000",
 			)
 		} else {
 			args = append(args, "-all-root")


### PR DESCRIPTION
Cherry-pick #3572 to the release-1.5 branch