### PR TITLE
Sync writable extfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Changes since 1.5.x
   without having to push extra copies (it also works for image indexes).
 - Change the implementation of extended globbing patterns in the %files
   section to use a safer method.
+- Add a `sync writable extfs` directive to apptainer.conf. When enabled,
+  writable extfs image mounts use the `sync` mount option.
 
 ## v1.5.x changes
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -118,6 +118,7 @@
 - Richard Neuboeck <hawk@tbi.univie.ac.at>
 - Rémy Dernat <remy.dernat@umontpellier.fr>
 - Robert Clarke <robert.clarke@bristol.ac.uk>
+- Rushil Patel <rushil.patel@gsacapital.com>
 - Sasha Yakovtseva <sasha@sylabs.io>, <sashayakovtseva@gmail.com>
 - Satish Chebrolu  <satish@sylabs.io>
 - Shane Loretz <sloretz@openrobotics.org>, <shane.loretz@gmail.com>

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -844,8 +844,29 @@ func (c configTests) configGlobal(t *testing.T) {
 }
 
 // Tests that require combinations of directives to be set
+//
+//nolint:maintidx
 func (c configTests) configGlobalCombination(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
+	require.Filesystem(t, "overlay")
+
+	tmpDir, cleanup := e2e.MakeTempDir(t, "", "config-combination-", "CONFIG")
+	defer cleanup(t)
+
+	ext3OverlayImage := filepath.Join(tmpDir, "ext3-overlay.img")
+	createExt3Overlay := func(t *testing.T) {
+		if err := os.Remove(ext3OverlayImage); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("Error removing existing ext3 overlay image: %v", err)
+		}
+
+		c.env.RunApptainer(
+			t,
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.WithCommand("overlay"),
+			e2e.WithArgs("create", "--size", "64", "--create-dir", "/sync-test", ext3OverlayImage),
+			e2e.ExpectExit(0),
+		)
+	}
 
 	setDirectives := func(t *testing.T, directives map[string]string) {
 		for k, v := range directives {
@@ -870,10 +891,43 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 		profile           e2e.Profile
 		addRequirementsFn func(*testing.T)
 		cwd               string
+		recreateOverlay   bool
 		directives        map[string]string
 		exit              int
 		resultOp          e2e.ApptainerCmdResultOp
 	}{
+		{
+			name:            "SyncWritableExtfsNoSetuidExtfs",
+			argv:            []string{"--overlay", ext3OverlayImage, c.env.ImagePath, "true"},
+			profile:         e2e.UserProfile,
+			recreateOverlay: true,
+			directives: map[string]string{
+				"allow setuid-mount extfs": "yes",
+				"sync writable extfs":      "no",
+			},
+			exit: 0,
+		},
+		{
+			name:            "SyncWritableExtfsYesSetuidExtfs",
+			argv:            []string{"--overlay", ext3OverlayImage, c.env.ImagePath, "true"},
+			profile:         e2e.UserProfile,
+			recreateOverlay: true,
+			directives: map[string]string{
+				"allow setuid-mount extfs": "yes",
+				"sync writable extfs":      "yes",
+			},
+			exit: 0,
+		},
+		{
+			name:            "SyncWritableExtfsYesUserns",
+			argv:            []string{"--overlay", ext3OverlayImage, c.env.ImagePath, "true"},
+			profile:         e2e.UserNamespaceProfile,
+			recreateOverlay: true,
+			directives: map[string]string{
+				"sync writable extfs": "yes",
+			},
+			exit: 0,
+		},
 		{
 			name:    "AllowNetUsersNobody",
 			argv:    []string{"--net", c.env.ImagePath, "true"},
@@ -1060,6 +1114,9 @@ func (c configTests) configGlobalCombination(t *testing.T) {
 			e2e.PreRun(func(t *testing.T) {
 				if tt.addRequirementsFn != nil {
 					tt.addRequirementsFn(t)
+				}
+				if tt.recreateOverlay {
+					createExt3Overlay(t)
 				}
 				setDirectives(t, tt.directives)
 			}),

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -940,6 +940,10 @@ func (c *container) mountImage(mnt *mount.Point, system *mount.System) error {
 	}
 
 	mountType := mnt.Type
+	if mountType == "ext3" && flags&syscall.MS_RDONLY != 1 && c.engine.EngineConfig.File.SyncWritableExtfs {
+		opts = append(opts, "sync")
+		optsString = strings.Join(opts, ",")
+	}
 
 	if mountType == "encryptfs" || mountType == "gocryptfs" {
 		key, err = mount.GetKey(mnt.InternalOptions)

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -102,6 +102,7 @@ type File struct {
 	AllowSetuidMountEncrypted bool     `default:"yes" authorized:"yes,no" directive:"allow setuid-mount encrypted"`
 	AllowSetuidMountSquashfs  string   `default:"iflimited" authorized:"yes,no,iflimited" directive:"allow setuid-mount squashfs"`
 	AllowSetuidMountExtfs     bool     `default:"no" authorized:"yes,no" directive:"allow setuid-mount extfs"`
+	SyncWritableExtfs         bool     `default:"no" authorized:"yes,no" directive:"sync writable extfs"`
 	AlwaysUseNv               bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
 	UseNvCCLI                 bool     `default:"no" authorized:"yes,no" directive:"use nvidia-container-cli"`
 	AlwaysUseRocm             bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
@@ -455,6 +456,16 @@ allow container dir = {{ if eq .AllowContainerDir true }}yes{{ else }}no{{ end }
 # this option is enabled in setuid mode. That is why this option defaults to
 # "no".  Change it at your own risk.
 {{ if eq .AllowSetuidMountExtfs false}}# {{ end }}allow setuid-mount extfs = {{ if eq .AllowSetuidMountExtfs true}}yes{{ else }}no{{ end }}
+
+# SYNC WRITABLE EXTFS: [BOOL]
+# DEFAULT: no
+# Mount writable extfs image mounts with the sync option. This keeps sparse
+# extfs images on the kernel loop/extfs path, but forces writes through close
+# to the caller so quota/ENOSPC is observed before a large dirty/writeback
+# backlog can build up. This can avoid pathological D-state writeback storms
+# under heavy writable-overlay fanout, at the cost of slower metadata-heavy
+# writes.
+{{ if eq .SyncWritableExtfs false}}# {{ end }}sync writable extfs = {{ if eq .SyncWritableExtfs true}}yes{{ else }}no{{ end }}
 
 # ALLOW NET USERS: [STRING]
 # DEFAULT: NULL

--- a/pkg/util/apptainerconf/parser_test.go
+++ b/pkg/util/apptainerconf/parser_test.go
@@ -124,6 +124,7 @@ func TestGetConfig(t *testing.T) {
 	directives["download concurrency"] = []string{"42"}
 	directives["download part size"] = []string{"1234"}
 	directives["download buffer size"] = []string{"4567"}
+	directives["sync writable extfs"] = []string{"yes"}
 
 	config, err := GetConfig(directives)
 	if err != nil {
@@ -150,6 +151,9 @@ func TestGetConfig(t *testing.T) {
 	if config.DownloadBufferSize != 4567 {
 		t.Errorf("bad value for DownloadBufferSize: %v", config.DownloadPartSize)
 	}
+	if config.SyncWritableExtfs != true {
+		t.Errorf("bad value for SyncWritableExtfs: %v", config.SyncWritableExtfs)
+	}
 }
 
 func TestHasDirective(t *testing.T) {
@@ -158,6 +162,9 @@ func TestHasDirective(t *testing.T) {
 	}
 	if !HasDirective("bind path") {
 		t.Errorf("'bind path' should be present")
+	}
+	if !HasDirective("sync writable extfs") {
+		t.Errorf("'sync writable extfs' should be present")
 	}
 	if HasDirective("fake directive") {
 		t.Errorf("'fake directive' should not be present")


### PR DESCRIPTION
Add a sync writable extfs apptainer.conf directive. When enabled, writable ext3 image mounts use the sync mount option, while default behavior remains unchanged.

## Description of the Pull Request (PR):

We want to enable sync for loop devices (specifically writeable overlays). Problem comes from:
- we write to many writeable overlays (ext3 loop devs)
- the lvm the loops live on fills up
- writing processes are in D state, since the loop devs are trying to writeback their dirty pages (huge on a high-mem host), and kernel doesn't propagate ENOSPC - likely a kernel bug
- to get around this, we want the optionality to set sync on the loop devices to be a bit more aggressive during writeback, so that we don't enter this deadlock (there's not as much in dirty pagecache).

### This fixes or addresses the following GitHub issues:

No issue reported. We found this, patched and have seen it solves the problem.


#### Before submitting a PR, make sure you have done the following:

- [X] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [X] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [X] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [X] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [X] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [X] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
