### PR TITLE
Fix build issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ Changes since 1.5.x
   Not all registries support deleting images and manifests, though.
 - Add new `tag` command for tagging existing images in oras registries,
   without having to push extra copies (it also works for image indexes).
-- Add support for extended globbing patterns in the %files section
+- Change the implementation of extended globbing patterns in the %files
+  section to use a safer method.
 
 ## v1.5.x changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Changes since 1.5.x
 
 - Extended the mksquashfs segmentation fault workaround for cases where
   mksquashfs uses many processor cores.
+- Whe building an rpm using a Red Hat version of golang, set
+  GOEXPERIMENT=strictfipsruntime.  That makes attempting to run non-FIPS
+  compliant containers on a FIPS-enabled system exit with a helpful
+  error message instead of a crash.
 
 ## v1.5.1 - \[2026-06-04\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Changes since 1.5.x
   GOEXPERIMENT=strictfipsruntime.  That makes attempting to run non-FIPS
   compliant containers on a FIPS-enabled system exit with a helpful
   error message instead of a crash.
+- Skip building PRoot on x86_64 Fedora 45 because of difficult to fix
+  compilation problems.
 
 ## v1.5.1 - \[2026-06-04\]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,15 +37,27 @@ Including for libsubid support (requires at least Ubuntu Noble or Debian Bookwor
 sudo apt-get install -y libsubid-dev
 ```
 
-On RHEL or its derivatives or Fedora:
+On RHEL or its derivatives start with:
 
 ```sh
 # Install basic tools for compiling
 sudo dnf groupinstall -y 'Development Tools'
-# Ensure EPEL repository is available (skip on Fedora)
+# Ensure EPEL repository is available
 sudo dnf install -y epel-release
-# Enable the CodeReady Builder repository (skip on Fedora)
+# Enable the CodeReady Builder repository
 sudo crb enable
+```
+
+Or on Fedora start with:
+
+```sh
+# Install basic tools for compiling
+sudo dnf group install -y development-tools
+```
+
+Then on either Fedora or RHEL or its derivatives:
+
+```sh
 # Install RPM packages for dependencies
 sudo dnf install -y \
     libseccomp-devel \
@@ -57,8 +69,8 @@ sudo dnf install -y \
     wget git
 ```
 
-For including libsubid support, use --enablerepo=devel for el8 and el9 but not
-for el10 or fedora:
+For including libsubid support, use --enablerepo=devel for EL8 and EL9 but not
+for EL10 or Fedora:
 
 ```sh
 sudo dnf --enablerepo=devel install -y shadow-utils-subid-devel
@@ -211,7 +223,7 @@ sudo apt-get install -y autoconf automake libtool pkg-config libfuse3-dev \
     zlib1g-dev liblzo2-dev liblz4-dev liblzma-dev libzstd-dev
 ```
 
-On RHEL or derivatives:
+On Fedora or RHEL or derivatives:
 
 ```sh
 sudo dnf install -y fuse3-devel lzo-devel lz4-devel

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -184,6 +184,13 @@ rm -f $(dirname %{SOURCE10})/PRoot-*.tar.gz
 %endif
 
 %build
+if go version | grep -q "Red Hat"; then
+    # With Red Hat's golang this changes crashes when running non-FIPS
+    # compliant containers on FIPS-enabled machines into helpful error
+    # messages.
+    export GOEXPERIMENT=strictfipsruntime
+fi
+
 %if "%{?SOURCE1}" != ""
 GOVERSION="$(echo %SOURCE1|sed 's,.*/,,;s/go//;s/\.src.*//')"
 if ! ./mlocal/scripts/check-min-go-version go $GOVERSION; then

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -35,7 +35,12 @@
 %global fuse_overlayfs_version 1.16
 %global squashfs_tools_version 4.7.5
 %ifnarch ppc64le s390x
+%if 0%{?fedora} < 45 || "%{_arch}" != "x86_64"
+# On fedora45 x86_64 building PRoot dies with
+# "relocation truncated to fit: R_X86_64_PC32 against `.rodata'"
+# See https://github.com/proot-me/proot/issues/414
 %global PRoot_version 5.4.0-rootless.3
+%endif
 %endif
 
 # The last singularity version number in EPEL/Fedora

--- a/scripts/compile-dependencies
+++ b/scripts/compile-dependencies
@@ -21,8 +21,8 @@ set -ex
 for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs PRoot; do
     TGZ="$(echo $SRC/${PKG}[_-]*.tar.gz)"
     if [ ! -f "$TGZ" ]; then
-	echo "\$PKG[_-]*.tar.gz not found in $SRC, skipping" >&2
-	continue
+        echo "\$PKG[_-]*.tar.gz not found in $SRC, skipping" >&2
+        continue
     fi
     DIR=${TGZ%.tar.gz}
     DIR=${DIR/*\//}
@@ -30,49 +30,49 @@ for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs PRoot; d
     tar -xf $TGZ
     cd $DIR
     for PATCH in $(echo $SRC/$PKG-*.patch); do
-	if [ -f "$PATCH" ]; then
-	    patch -p1 <$PATCH
-	fi
+        if [ -f "$PATCH" ]; then
+            patch -p1 <$PATCH
+        fi
     done
     case "$PKG" in
-	squashfs-tools)
-	    make -C squashfs-tools mksquashfs unsquashfs GZIP_SUPPORT=1 \
-	    LZO_SUPPORT=1 LZ4_SUPPORT=1 XZ_SUPPORT=1 ZSTD_SUPPORT=1
-	    ;;
-	squashfuse)
-	    ./autogen.sh
-	    FLAGS=-std=c99 ./configure --enable-multithreading
-	    make squashfuse_ll
-	    ;;
-	e2fsprogs)
-	    ./configure
-	    make libs && make -C misc fuse2fs
-	    mv misc/fuse2fs .
-	    ;;
-	fuse-overlayfs)
-	    ./autogen.sh
-	    ./configure
-	    make
-	    ;;
-	gocryptfs)
-	    VER=${DIR/*-/}
-	    echo "v$VER" >VERSION
-	    # Don't hardcode the amd64 microarchitecture
-	    sed -e '/GOAMD64.*v2/d' -i.orig build.bash
-	    # GOPROXY=off makes sure we fail instead of making network requests
-	    # the -B ldflags prevent rpm complaints about "No build ID note found"
-	    CGO_ENABLED=0 GOPROXY=off ./build.bash \
-		-mod=vendor -tags without_openssl \
-		-buildvcs=false -ldflags="-X main.GitVersion=v$VER \
-		-B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`"
-	    ;;
-	PRoot)
-	    make -C src proot
-	    ;;
-	*)
-	    echo "unrecognized package $PKG" >&2
-	    exit 1
-	    ;;
+        squashfs-tools)
+            make -C squashfs-tools mksquashfs unsquashfs GZIP_SUPPORT=1 \
+            LZO_SUPPORT=1 LZ4_SUPPORT=1 XZ_SUPPORT=1 ZSTD_SUPPORT=1
+            ;;
+        squashfuse)
+            ./autogen.sh
+            FLAGS=-std=c99 ./configure --enable-multithreading
+            make squashfuse_ll
+            ;;
+        e2fsprogs)
+            ./configure
+            make libs && make -C misc fuse2fs
+            mv misc/fuse2fs .
+            ;;
+        fuse-overlayfs)
+            ./autogen.sh
+            ./configure
+            make
+            ;;
+        gocryptfs)
+            VER=${DIR/*-/}
+            echo "v$VER" >VERSION
+            # Don't hardcode the amd64 microarchitecture
+            sed -e '/GOAMD64.*v2/d' -i.orig build.bash
+            # GOPROXY=off makes sure we fail instead of making network requests
+            # the -B ldflags prevent rpm complaints about "No build ID note found"
+            CGO_ENABLED=0 GOPROXY=off ./build.bash \
+                -mod=vendor -tags without_openssl \
+                -buildvcs=false -ldflags="-X main.GitVersion=v$VER \
+                -B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`"
+            ;;
+        PRoot)
+            make -C src proot
+            ;;
+        *)
+            echo "unrecognized package $PKG" >&2
+            exit 1
+            ;;
     esac
     cd ..
 done

--- a/scripts/download-dependencies
+++ b/scripts/download-dependencies
@@ -44,6 +44,16 @@ sed -n -e '/^# URL:/{s/^# //;s/%%/%/g;p}' -e 's/^Source[1-9][0-9]*: //p' -e 's/^
         # skip architectures known to not be supported by PRoot
         case $(arch) in
             ppc*|s390*|riscv*) continue;;
+            x86*) if [ -f /etc/os-release ]; then
+                    . /etc/os-release
+                    if [ "$ID" = fedora ] && [ "$VERSION_ID" -ge 45 ]; then
+                        # On fedora45 x86_64 building PRoot dies with
+                        # "relocation truncated to fit: R_X86_64_PC32 against `.rodata'"
+                        # See https://github.com/proot-me/proot/issues/414
+                        continue
+                    fi
+                fi
+                ;;
         esac
     fi
     if [ -n "$GITHUB_TOKEN" ] && [[ "$URL" = *github.com/*.patch ]]; then

--- a/scripts/download-dependencies
+++ b/scripts/download-dependencies
@@ -32,13 +32,13 @@ sed -n -e '/^# URL:/{s/^# //;s/%%/%/g;p}' -e 's/^Source[1-9][0-9]*: //p' -e 's/^
           done
           echo "$LINE"))
     if [[ "$LINE" = *http* ]]; then
-	URL="${LINE/*http/http}"
-	if [[ "$LINE" = "URL:"*http* ]]; then
-	    # the file name is on the next line
-	    continue
-	fi
-	# take the file name from the base of the URL
-	LINE="${LINE/*\//}"
+        URL="${LINE/*http/http}"
+        if [[ "$LINE" = "URL:"*http* ]]; then
+            # the file name is on the next line
+            continue
+        fi
+        # take the file name from the base of the URL
+        LINE="${LINE/*\//}"
     fi
     if [[ "$LINE" = *PRoot* ]]; then
         # skip architectures known to not be supported by PRoot
@@ -47,15 +47,15 @@ sed -n -e '/^# URL:/{s/^# //;s/%%/%/g;p}' -e 's/^Source[1-9][0-9]*: //p' -e 's/^
         esac
     fi
     if [ -n "$GITHUB_TOKEN" ] && [[ "$URL" = *github.com/*.patch ]]; then
-	# use github API instead because the public URL downloads 
-	# sometimes hit server busy (429) when run in github actions
-	URL="$(echo "$URL"|sed -e 's,github.com/,api.github.com/repos/,' \
-			       -e 's,/pull/,/pulls/,' -e 's,\.patch,,')"
-	curl -f -L -sS -o $DIR/$LINE \
-	    -H "Accept: application/vnd.github.diff" \
-	    -H "Authorization: Bearer $GITHUB_TOKEN" $URL
+        # use github API instead because the public URL downloads
+        # sometimes hit server busy (429) when run in github actions
+        URL="$(echo "$URL"|sed -e 's,github.com/,api.github.com/repos/,' \
+                               -e 's,/pull/,/pulls/,' -e 's,\.patch,,')"
+        curl -f -L -sS -o $DIR/$LINE \
+            -H "Accept: application/vnd.github.diff" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" $URL
     else
-	curl -f -L -sS -o $DIR/$LINE $URL
+        curl -f -L -sS -o $DIR/$LINE $URL
     fi
 done
 

--- a/scripts/install-dependencies
+++ b/scripts/install-dependencies
@@ -35,8 +35,8 @@ fi
 set -ex
 for CMD in squashfs-tools-*/squashfs-tools/{mksquashfs,unsquashfs} squashfuse-*/squashfuse_ll e2fsprogs-*/fuse2fs fuse-overlayfs-*/fuse-overlayfs gocryptfs[_-]*/gocryptfs PRoot-*/src/proot; do
     if [ ! -f "$CMD" ]; then
-	echo "$CMD not found, skipping" >&2
-	continue
+        echo "$CMD not found, skipping" >&2
+        continue
     fi
     cp -f $CMD $DIR
 done


### PR DESCRIPTION
Fix some issues that happened with the 1.5.1 apptainer build.  Stop building PRoot on fedora 45 x86_64, and improve the fedora build instructions.  Set `GOEXPERIMENT=strictfipsruntime` when the go version includes "Red Hat".

- Fixes #3347 