### PR TITLE
build: use an os.Root for Mkdir / Writefile operations, from sylabs 4178

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -79,6 +79,7 @@
 - Kundan Kumar <iamkundankumar28@gmail.com>
 - Linsen Zhou <i@lin.moe>
 - Lorenz Sieben <sieben@gea.mpg.de>
+- Luís Simas <luis.simas@cern.ch>
 - Maciej Sieczka <msieczka@sieczka.org>
 - Marcelo Magallon <marcelo@sylabs.io>
 - Marco Rubin <marco.rubin@protonmail.com>

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -26,6 +25,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	securejoin "github.com/cyphar/filepath-securejoin"
 )
 
 const name = "apptainer_apps"
@@ -261,41 +261,41 @@ func (pl *BuildApp) createAllApps(b *types.Bundle) error {
 		globalEnv94 += globalAppEnv(b, app)
 	}
 
-	return os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/env/94-appsbase.sh"), []byte(globalEnv94), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(".singularity.d", "env", "94-appsbase.sh"), []byte(globalEnv94), 0o755)
 }
 
 func createAppRoot(b *types.Bundle, a *App) error {
-	if err := os.MkdirAll(appBase(b, a), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(appBase(a), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/scif/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appBase(a), "scif"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/bin/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appBase(a), "bin"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/lib/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appBase(a), "lib"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appBase(b, a), "/scif/env/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appBase(a), "scif", "env"), 0o755); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(appData(b, a), "/input/"), 0o755); err != nil {
+	if err := b.Rootfs.MkdirAll(filepath.Join(appData(a), "input"), 0o755); err != nil {
 		return err
 	}
 
-	return os.MkdirAll(filepath.Join(appData(b, a), "/output/"), 0o755)
+	return b.Rootfs.MkdirAll(filepath.Join(appData(a), "output"), 0o755)
 }
 
 // %appenv and 01-base.sh
 func writeEnvFile(b *types.Bundle, a *App) error {
 	content := fmt.Sprintf(scifEnv01Base, a.Name)
-	if err := os.WriteFile(filepath.Join(appMeta(b, a), "/env/01-base.sh"), []byte(content), 0o755); err != nil {
+	if err := b.Rootfs.WriteFile(filepath.Join(appMeta(a), "env", "01-base.sh"), []byte(content), 0o755); err != nil {
 		return err
 	}
 
@@ -303,7 +303,7 @@ func writeEnvFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/env/90-environment.sh"), []byte(a.Env), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "env", "90-environment.sh"), []byte(a.Env), 0o755)
 }
 
 func globalAppEnv(b *types.Bundle, a *App) string {
@@ -311,19 +311,19 @@ func globalAppEnv(b *types.Bundle, a *App) string {
 
 	content := fmt.Sprintf(globalEnv94Base, name)
 
-	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/env/90-environment.sh")); err == nil {
+	if _, err := b.Rootfs.Stat(filepath.Join(appMeta(a), "env", "90-environment.sh")); err == nil {
 		content += fmt.Sprintf(globalEnv94AppEnv, name)
 	}
 
-	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/labels.json")); err == nil {
+	if _, err := b.Rootfs.Stat(filepath.Join(appMeta(a), "labels.json")); err == nil {
 		content += fmt.Sprintf(globalEnv94AppLabels, name)
 	}
 
-	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/runscript")); err == nil {
+	if _, err := b.Rootfs.Stat(filepath.Join(appMeta(a), "runscript")); err == nil {
 		content += fmt.Sprintf(globalEnv94AppRun, name)
 	}
 
-	if _, err := os.Stat(filepath.Join(appMeta(b, a), "/startscript")); err == nil {
+	if _, err := b.Rootfs.Stat(filepath.Join(appMeta(a), "startscript")); err == nil {
 		content += fmt.Sprintf(globalEnv94AppStart, name)
 	}
 
@@ -337,7 +337,7 @@ func writeRunscriptFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifRunscriptBase, a.Run)
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/runscript"), []byte(content), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "runscript"), []byte(content), 0o755)
 }
 
 // %appstart
@@ -347,7 +347,7 @@ func writeStartscriptFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifStartscriptBase, a.Start)
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/startscript"), []byte(content), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "startscript"), []byte(content), 0o755)
 }
 
 // %apptest
@@ -357,7 +357,7 @@ func writeTestFile(b *types.Bundle, a *App) error {
 	}
 
 	content := fmt.Sprintf(scifTestBase, a.Test)
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/test"), []byte(content), 0o755)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "test"), []byte(content), 0o755)
 }
 
 // %apphelp
@@ -366,7 +366,7 @@ func writeHelpFile(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	return os.WriteFile(filepath.Join(appMeta(b, a), "/runscript.help"), []byte(a.Help), 0o644)
+	return b.Rootfs.WriteFile(filepath.Join(appMeta(a), "runscript.help"), []byte(a.Help), 0o644)
 }
 
 // %appfile
@@ -375,9 +375,7 @@ func copyFiles(b *types.Bundle, a *App) error {
 		return nil
 	}
 
-	appBase := filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
-	for _, line := range strings.Split(a.Files, "\n") {
-
+	for line := range strings.SplitSeq(a.Files, "\n") {
 		// skip empty or comment lines
 		if line = strings.TrimSpace(line); line == "" || strings.Index(line, "#") == 0 {
 			continue
@@ -397,7 +395,13 @@ func copyFiles(b *types.Bundle, a *App) error {
 			dst = splitLine[1]
 		}
 
-		if err := copyWithfLr(src, filepath.Join(appBase, dst)); err != nil {
+		dstRel := filepath.Join(appBase(a), dst)
+		dst, err := securejoin.SecureJoin(b.RootfsPath, dstRel)
+		if err != nil {
+			return err
+		}
+
+		if err := copyWithfLr(src, dst); err != nil {
 			return err
 		}
 	}
@@ -438,23 +442,22 @@ func writeLabels(b *types.Bundle, a *App) error {
 		return err
 	}
 
-	appBase := filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
-	err = os.WriteFile(filepath.Join(appBase, "scif/labels.json"), text, 0o644)
+	err = b.Rootfs.WriteFile(filepath.Join(appMeta(a), "labels.json"), text, 0o644)
 	return err
 }
 
 // util funcs
 
-func appBase(b *types.Bundle, a *App) string {
-	return filepath.Join(b.RootfsPath, "/scif/apps/", a.Name)
+func appBase(a *App) string {
+	return filepath.Join("scif", "apps", a.Name)
 }
 
-func appMeta(b *types.Bundle, a *App) string {
-	return filepath.Join(appBase(b, a), "/scif/")
+func appMeta(a *App) string {
+	return filepath.Join(appBase(a), "scif")
 }
 
-func appData(b *types.Bundle, a *App) string {
-	return filepath.Join(b.RootfsPath, "/scif/data/", a.Name)
+func appData(a *App) string {
+	return filepath.Join("scif", "data", a.Name)
 }
 
 func copyWithfLr(src, dst string) error {

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	iofs "io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -96,16 +97,16 @@ func (s *stage) insertMetadataForData() error {
 func insertEnvScript(b *types.Bundle) error {
 	if b.RunSection("environment") && b.Recipe.Environment.Script != "" {
 		sylog.Infof("Adding environment to container")
-		envScriptPath := filepath.Join(b.RootfsPath, "/.singularity.d/env/90-environment.sh")
-		_, err := os.Stat(envScriptPath)
+		envScriptPath := filepath.Join(".singularity.d", "env", "90-environment.sh")
+		_, err := b.Rootfs.Stat(envScriptPath)
 		if os.IsNotExist(err) {
-			err := os.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.Environment.Script+"\n"), 0o755)
+			err := b.Rootfs.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.Environment.Script+"\n"), 0o755)
 			if err != nil {
 				return err
 			}
 		} else {
 			// append to script if it already exists
-			f, err := os.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY, 0o755)
+			f, err := b.Rootfs.OpenFile(envScriptPath, os.O_APPEND|os.O_WRONLY, 0o755)
 			if err != nil {
 				return err
 			}
@@ -146,7 +147,7 @@ func insertRunScript(b *types.Bundle) error {
 	if b.RunSection("runscript") && b.Recipe.Runscript.Script != "" {
 		sylog.Infof("Adding runscript")
 		shebang, script := handleShebangScript(b.Recipe.Runscript)
-		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := b.Rootfs.WriteFile(filepath.Join(".singularity.d", "runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -158,7 +159,7 @@ func insertStartScript(b *types.Bundle) error {
 	if b.RunSection("startscript") && b.Recipe.Startscript.Script != "" {
 		sylog.Infof("Adding startscript")
 		shebang, script := handleShebangScript(b.Recipe.Startscript)
-		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := b.Rootfs.WriteFile(filepath.Join(".singularity.d", "startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -170,7 +171,7 @@ func insertTestScript(b *types.Bundle) error {
 	if b.RunSection("test") && b.Recipe.Test.Script != "" {
 		sylog.Infof("Adding testscript")
 		shebang, script := handleShebangScript(b.Recipe.Test)
-		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := b.Rootfs.WriteFile(filepath.Join(".singularity.d", "test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -180,10 +181,10 @@ func insertTestScript(b *types.Bundle) error {
 
 func insertHelpScript(b *types.Bundle) error {
 	if b.RunSection("help") && b.Recipe.Help.Script != "" {
-		_, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"))
+		_, err := b.Rootfs.Stat(filepath.Join(".singularity.d", "runscript.help"))
 		if err != nil || b.Opts.Force {
 			sylog.Infof("Adding help info")
-			err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.Help.Script+"\n"), 0o644)
+			err := b.Rootfs.WriteFile(filepath.Join(".singularity.d", "runscript.help"), []byte(b.Recipe.Help.Script+"\n"), 0o644)
 			if err != nil {
 				return err
 			}
@@ -196,17 +197,19 @@ func insertHelpScript(b *types.Bundle) error {
 
 func insertDefinition(b *types.Bundle) error {
 	// Check for existing definition and move it to bootstrap history
-	if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity")); err == nil {
+	defPath := filepath.Join(".singularity.d", "Singularity")
+	historyPath := filepath.Join(".singularity.d", "bootstrap_history")
+	if _, err := b.Rootfs.Stat(defPath); err == nil {
 		// make bootstrap_history directory if it doesn't exist
-		if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history")); err != nil {
-			err = os.Mkdir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"), 0o755)
+		if _, err := b.Rootfs.Stat(historyPath); err != nil {
+			err = b.Rootfs.Mkdir(historyPath, 0o755)
 			if err != nil {
 				return err
 			}
 		}
 
 		// look at number of files in bootstrap_history to give correct file name
-		files, err := os.ReadDir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"))
+		files, err := iofs.ReadDir(b.Rootfs.FS(), historyPath)
 		if err != nil {
 			return err
 		}
@@ -214,13 +217,13 @@ func insertDefinition(b *types.Bundle) error {
 		// name is "Apptainer" concatenated with an index based on number of other files in bootstrap_history
 		histName := "Apptainer" + strconv.Itoa(len(files))
 		// move old definition into bootstrap_history
-		err = os.Rename(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history", histName))
+		err = b.Rootfs.Rename(defPath, filepath.Join(historyPath, histName))
 		if err != nil {
 			return err
 		}
 	}
 
-	err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.FullRaw, 0o644)
+	err := b.Rootfs.WriteFile(defPath, b.Recipe.FullRaw, 0o644)
 	if err != nil {
 		return err
 	}
@@ -237,17 +240,17 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 	}
 
 	// get labels added through APPTAINER_LABELS environment variables
-	buildLabels := filepath.Join(b.RootfsPath, sLabelsPath)
-	content, err := os.ReadFile(buildLabels)
+	sLabelsRel := strings.TrimPrefix(sLabelsPath, "/")
+	content, err := b.Rootfs.ReadFile(sLabelsRel)
 	if err == nil {
-		if err := os.Remove(filepath.Join(b.RootfsPath, sLabelsPath)); err != nil {
+		if err := b.Rootfs.Remove(sLabelsRel); err != nil {
 			return err
 		}
 		for k, v := range parser.GetLabels(string(content)) {
 			labels[k] = v
 		}
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("while reading %s: %s", buildLabels, err)
+		return fmt.Errorf("while reading %s: %s", sLabelsRel, err)
 	}
 
 	if err = addBuildLabels(labels, b); err != nil {
@@ -280,7 +283,7 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 		return err
 	}
 
-	err = os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
+	err = b.Rootfs.WriteFile(filepath.Join(".singularity.d", "labels.json"), []byte(text), 0o644)
 	return err
 }
 
@@ -314,8 +317,8 @@ func insertJSONInspectMetadata(b *types.Bundle, inspectOpt []string) error {
 
 func getExistingLabels(labels map[string]string, b *types.Bundle) error {
 	// check for existing labels in bundle
-	if _, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json")); err == nil {
-		jsonFile, err := os.Open(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"))
+	if _, err := b.Rootfs.Stat(filepath.Join(".singularity.d", "labels.json")); err == nil {
+		jsonFile, err := b.Rootfs.Open(filepath.Join(".singularity.d", "labels.json"))
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/build/sources/base_environment.go
+++ b/internal/pkg/build/sources/base_environment.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	"github.com/apptainer/apptainer/pkg/build/types"
 	"github.com/apptainer/apptainer/pkg/sylog"
 )
 
@@ -79,80 +79,80 @@ var runscriptFileContent string
 //go:embed startscript.sh
 var startscriptFileContent string
 
-func makeDirs(rootPath string) error {
-	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "libs"), 0o755); err != nil {
-		return err
+// mkdirAllInRootfs creates dir, and any missing parents, within the bundle
+// rootfs. If the final path already exists it is left untouched. This tolerates
+// images that provide one of these paths as a symlink (e.g. var/tmp -> /tmp);
+// os.Root.MkdirAll returns an error for an existing symlink leaf, whereas the
+// plain os.MkdirAll this replaced resolved and accepted it.
+func mkdirAllInRootfs(b *types.Bundle, dir string) error {
+	if _, err := b.Rootfs.Lstat(dir); err == nil {
+		return nil
 	}
-	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "actions"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, ".singularity.d", "env"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "dev"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "proc"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "root"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "var", "tmp"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "tmp"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "etc"), 0o755); err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(rootPath, "sys"), 0o755); err != nil {
-		return err
-	}
-	return os.MkdirAll(filepath.Join(rootPath, "home"), 0o755)
+	return b.Rootfs.MkdirAll(dir, 0o755)
 }
 
-func makeSymlinks(rootPath string) error {
-	if _, err := os.Stat(filepath.Join(rootPath, "singularity")); err != nil {
-		if err = os.Symlink(".singularity.d/runscript", filepath.Join(rootPath, "singularity")); err != nil {
-			return err
-		}
+func makeDirs(b *types.Bundle) error {
+	dirs := []string{
+		filepath.Join(".singularity.d", "libs"),
+		filepath.Join(".singularity.d", "actions"),
+		filepath.Join(".singularity.d", "env"),
+		"dev",
+		"proc",
+		"root",
+		filepath.Join("var", "tmp"),
+		"tmp",
+		"etc",
+		"sys",
+		"home",
 	}
-	if _, err := os.Stat(filepath.Join(rootPath, ".run")); err != nil {
-		if err = os.Symlink(".singularity.d/actions/run", filepath.Join(rootPath, ".run")); err != nil {
-			return err
-		}
-	}
-	if _, err := os.Stat(filepath.Join(rootPath, ".exec")); err != nil {
-		if err = os.Symlink(".singularity.d/actions/exec", filepath.Join(rootPath, ".exec")); err != nil {
-			return err
-		}
-	}
-	if _, err := os.Stat(filepath.Join(rootPath, ".test")); err != nil {
-		if err = os.Symlink(".singularity.d/actions/test", filepath.Join(rootPath, ".test")); err != nil {
-			return err
-		}
-	}
-	if _, err := os.Stat(filepath.Join(rootPath, ".shell")); err != nil {
-		if err = os.Symlink(".singularity.d/actions/shell", filepath.Join(rootPath, ".shell")); err != nil {
-			return err
-		}
-	}
-	if _, err := os.Stat(filepath.Join(rootPath, "environment")); err != nil {
-		if err = os.Symlink(".singularity.d/env/90-environment.sh", filepath.Join(rootPath, "environment")); err != nil {
+	for _, dir := range dirs {
+		if err := mkdirAllInRootfs(b, dir); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func makeFile(name string, perm os.FileMode, s string, overwrite bool) (err error) {
+func makeSymlinks(b *types.Bundle) error {
+	if _, err := b.Rootfs.Stat("singularity"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/runscript", "singularity"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat(".run"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/actions/run", ".run"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat(".exec"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/actions/exec", ".exec"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat(".test"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/actions/test", ".test"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat(".shell"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/actions/shell", ".shell"); err != nil {
+			return err
+		}
+	}
+	if _, err := b.Rootfs.Stat("environment"); err != nil {
+		if err = b.Rootfs.Symlink("/.singularity.d/env/90-environment.sh", "environment"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func makeFile(b *types.Bundle, name string, perm os.FileMode, s string, overwrite bool) (err error) {
 	// #4532 - If the file already exists ensure it has requested permissions
 	// as OpenFile won't set on an existing file and some docker
 	// containers have hosts or resolv.conf without write perm.
-	if fs.IsFile(name) {
-		if err = os.Chmod(name, perm); err != nil {
+	if info, statErr := b.Rootfs.Stat(name); statErr == nil && info.Mode().IsRegular() {
+		if err = b.Rootfs.Chmod(name, perm); err != nil {
 			return
 		}
 		if !overwrite {
@@ -162,7 +162,7 @@ func makeFile(name string, perm os.FileMode, s string, overwrite bool) (err erro
 	}
 	// Create the file if it's not in the container, or truncate and write s
 	// into it otherwise.
-	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	f, err := b.Rootfs.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return
 	}
@@ -172,47 +172,47 @@ func makeFile(name string, perm os.FileMode, s string, overwrite bool) (err erro
 	return
 }
 
-func makeFiles(rootPath string, overwrite bool) error {
-	if err := makeFile(filepath.Join(rootPath, "etc", "hosts"), 0o644, "", overwrite); err != nil {
+func makeFiles(b *types.Bundle, overwrite bool) error {
+	if err := makeFile(b, filepath.Join("etc", "hosts"), 0o644, "", overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, "etc", "resolv.conf"), 0o644, "", overwrite); err != nil {
+	if err := makeFile(b, filepath.Join("etc", "resolv.conf"), 0o644, "", overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "exec"), 0o755, execFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "exec"), 0o755, execFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "run"), 0o755, runFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "run"), 0o755, runFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "shell"), 0o755, shellFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "shell"), 0o755, shellFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "start"), 0o755, startFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "start"), 0o755, startFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "actions", "test"), 0o755, testFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "actions", "test"), 0o755, testFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "01-base.sh"), 0o755, baseShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "01-base.sh"), 0o755, baseShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "90-environment.sh"), 0o755, environmentShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "90-environment.sh"), 0o755, environmentShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "95-apps.sh"), 0o755, appsShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "95-apps.sh"), 0o755, appsShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-base.sh"), 0o755, base99ShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "99-base.sh"), 0o755, base99ShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "env", "99-runtimevars.sh"), 0o755, base99runtimevarsShFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "env", "99-runtimevars.sh"), 0o755, base99runtimevarsShFileContent, overwrite); err != nil {
 		return err
 	}
-	if err := makeFile(filepath.Join(rootPath, ".singularity.d", "runscript"), 0o755, runscriptFileContent, overwrite); err != nil {
+	if err := makeFile(b, filepath.Join(".singularity.d", "runscript"), 0o755, runscriptFileContent, overwrite); err != nil {
 		return err
 	}
-	return makeFile(filepath.Join(rootPath, ".singularity.d", "startscript"), 0o755, startscriptFileContent, overwrite)
+	return makeFile(b, filepath.Join(".singularity.d", "startscript"), 0o755, startscriptFileContent, overwrite)
 }
 
 // makeBaseEnv inserts Apptainer specific directories, symlinks, and files
@@ -220,31 +220,31 @@ func makeFiles(rootPath string, overwrite bool) error {
 // will be overwritten with new content. If overwrite is false, existing files
 // (e.g. where the rootfs has been extracted from an existing image) will not be
 // modified.
-func makeBaseEnv(rootPath string, overwrite bool) (err error) {
+func makeBaseEnv(b *types.Bundle, overwrite bool) (err error) {
 	var info os.FileInfo
 
 	// Ensure we can write into the root of rootPath
-	if info, err = os.Stat(rootPath); err != nil {
+	if info, err = b.Rootfs.Stat("."); err != nil {
 		err = fmt.Errorf("build: failed to stat rootPath: %v", err)
 		return err
 	}
 	if info.Mode()&0o200 == 0 {
-		sylog.Infof("Adding owner write permission to build path: %s\n", rootPath)
-		if err = os.Chmod(rootPath, info.Mode()|0o200); err != nil {
+		sylog.Infof("Adding owner write permission to build path: %s\n", b.RootfsPath)
+		if err = b.Rootfs.Chmod(".", info.Mode()|0o200); err != nil {
 			err = fmt.Errorf("build: failed to make rootPath writable: %v", err)
 			return err
 		}
 	}
 
-	if err = makeDirs(rootPath); err != nil {
+	if err = makeDirs(b); err != nil {
 		err = fmt.Errorf("build: failed to make environment dirs: %v", err)
 		return err
 	}
-	if err = makeSymlinks(rootPath); err != nil {
+	if err = makeSymlinks(b); err != nil {
 		err = fmt.Errorf("build: failed to make environment symlinks: %v", err)
 		return err
 	}
-	if err = makeFiles(rootPath, overwrite); err != nil {
+	if err = makeFiles(b, overwrite); err != nil {
 		err = fmt.Errorf("build: failed to make environment files: %v", err)
 		return err
 	}

--- a/internal/pkg/build/sources/base_environment.go
+++ b/internal/pkg/build/sources/base_environment.go
@@ -11,6 +11,7 @@ package sources
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -114,37 +115,58 @@ func makeDirs(b *types.Bundle) error {
 }
 
 func makeSymlinks(b *types.Bundle) error {
-	if _, err := b.Rootfs.Stat("singularity"); err != nil {
-		if err = b.Rootfs.Symlink(".singularity.d/runscript", "singularity"); err != nil {
-			return err
-		}
+	symlinks := []struct {
+		oldname string
+		newname string
+	}{
+		{".singularity.d/runscript", "singularity"},
+		{".singularity.d/actions/run", ".run"},
+		{".singularity.d/actions/exec", ".exec"},
+		{".singularity.d/actions/test", ".test"},
+		{".singularity.d/actions/shell", ".shell"},
+		{".singularity.d/env/90-environment.sh", "environment"},
 	}
-	if _, err := b.Rootfs.Stat(".run"); err != nil {
-		if err = b.Rootfs.Symlink(".singularity.d/actions/run", ".run"); err != nil {
-			return err
-		}
-	}
-	if _, err := b.Rootfs.Stat(".exec"); err != nil {
-		if err = b.Rootfs.Symlink(".singularity.d/actions/exec", ".exec"); err != nil {
-			return err
-		}
-	}
-	if _, err := b.Rootfs.Stat(".test"); err != nil {
-		if err = b.Rootfs.Symlink(".singularity.d/actions/test", ".test"); err != nil {
-			return err
-		}
-	}
-	if _, err := b.Rootfs.Stat(".shell"); err != nil {
-		if err = b.Rootfs.Symlink(".singularity.d/actions/shell", ".shell"); err != nil {
-			return err
-		}
-	}
-	if _, err := b.Rootfs.Stat("environment"); err != nil {
-		if err = b.Rootfs.Symlink(".singularity.d/env/90-environment.sh", "environment"); err != nil {
+	for _, link := range symlinks {
+		if err := makeSymlink(b.Rootfs, link.oldname, link.newname); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// makeSymlink creates newname as a symbolic link to oldname idempotently.
+//
+// If newname already exists as a symlink that does not point to oldname, it is
+// recreated. If newname exists but is not a symlink, it is left untouched.
+func makeSymlink(root *os.Root, oldname, newname string) error {
+	// If it does not exist, create it.
+	fi, err := root.Lstat(newname)
+	if errors.Is(err, os.ErrNotExist) {
+		return root.Symlink(oldname, newname)
+	}
+	if err != nil {
+		return err
+	}
+
+	// If it's not a symlink, don't touch it.
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return nil
+	}
+
+	// If it already points to oldname, there's nothing to do.
+	target, err := root.Readlink(newname)
+	if err != nil {
+		return err
+	}
+	if target == oldname {
+		return nil
+	}
+
+	// If it points to anything else, recreate it.
+	if err := root.Remove(newname); err != nil {
+		return err
+	}
+	return root.Symlink(oldname, newname)
 }
 
 func makeFile(b *types.Bundle, name string, perm os.FileMode, s string, overwrite bool) (err error) {

--- a/internal/pkg/build/sources/base_environment.go
+++ b/internal/pkg/build/sources/base_environment.go
@@ -115,32 +115,32 @@ func makeDirs(b *types.Bundle) error {
 
 func makeSymlinks(b *types.Bundle) error {
 	if _, err := b.Rootfs.Stat("singularity"); err != nil {
-		if err = b.Rootfs.Symlink("/.singularity.d/runscript", "singularity"); err != nil {
+		if err = b.Rootfs.Symlink(".singularity.d/runscript", "singularity"); err != nil {
 			return err
 		}
 	}
 	if _, err := b.Rootfs.Stat(".run"); err != nil {
-		if err = b.Rootfs.Symlink("/.singularity.d/actions/run", ".run"); err != nil {
+		if err = b.Rootfs.Symlink(".singularity.d/actions/run", ".run"); err != nil {
 			return err
 		}
 	}
 	if _, err := b.Rootfs.Stat(".exec"); err != nil {
-		if err = b.Rootfs.Symlink("/.singularity.d/actions/exec", ".exec"); err != nil {
+		if err = b.Rootfs.Symlink(".singularity.d/actions/exec", ".exec"); err != nil {
 			return err
 		}
 	}
 	if _, err := b.Rootfs.Stat(".test"); err != nil {
-		if err = b.Rootfs.Symlink("/.singularity.d/actions/test", ".test"); err != nil {
+		if err = b.Rootfs.Symlink(".singularity.d/actions/test", ".test"); err != nil {
 			return err
 		}
 	}
 	if _, err := b.Rootfs.Stat(".shell"); err != nil {
-		if err = b.Rootfs.Symlink("/.singularity.d/actions/shell", ".shell"); err != nil {
+		if err = b.Rootfs.Symlink(".singularity.d/actions/shell", ".shell"); err != nil {
 			return err
 		}
 	}
 	if _, err := b.Rootfs.Stat("environment"); err != nil {
-		if err = b.Rootfs.Symlink("/.singularity.d/env/90-environment.sh", "environment"); err != nil {
+		if err = b.Rootfs.Symlink(".singularity.d/env/90-environment.sh", "environment"); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/build/sources/base_environment_test.go
+++ b/internal/pkg/build/sources/base_environment_test.go
@@ -10,21 +10,42 @@
 package sources
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/apptainer/apptainer/internal/pkg/test"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	"github.com/apptainer/apptainer/pkg/build/types"
 )
 
-func testWithGoodDir(t *testing.T, f func(d string) error) {
-	if err := f(t.TempDir()); err != nil {
+func testBundle(rootfsPath string) (*types.Bundle, error) {
+	rootfs, err := os.OpenRoot(rootfsPath)
+	if err != nil {
+		return nil, err
+	}
+	return &types.Bundle{RootfsPath: rootfsPath, Rootfs: rootfs}, nil
+}
+
+func testWithGoodBundle(t *testing.T, f func(b *types.Bundle) error) {
+	b, err := testBundle(t.TempDir())
+	if err != nil {
+		t.Fatalf("Unexpected failure: %v", err)
+	}
+	defer b.Rootfs.Close()
+
+	if err := f(b); err != nil {
 		t.Fatalf("Unexpected failure: %v", err)
 	}
 }
 
-func testWithBadDir(t *testing.T, f func(d string) error) {
-	if err := f("/this/will/be/a/problem"); err == nil {
+func testWithBadBundle(t *testing.T, f func(b *types.Bundle) error) {
+	b, err := testBundle("/does/not/exist")
+	if err == nil {
+		defer b.Rootfs.Close()
+		err = f(b)
+	}
+	if err == nil {
 		t.Fatalf("Unexpected success with bad directory")
 	}
 }
@@ -33,40 +54,40 @@ func TestMakeDirs(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	testWithGoodDir(t, makeDirs)
-	testWithBadDir(t, makeDirs)
+	testWithGoodBundle(t, makeDirs)
+	testWithBadBundle(t, makeDirs)
 }
 
 func TestMakeSymlinks(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	testWithGoodDir(t, makeSymlinks)
-	testWithBadDir(t, makeSymlinks)
+	testWithGoodBundle(t, makeSymlinks)
+	testWithBadBundle(t, makeSymlinks)
 }
 
 func TestMakeFiles(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	testWithGoodDir(t, func(d string) error {
-		if err := makeDirs(d); err != nil {
+	testWithGoodBundle(t, func(b *types.Bundle) error {
+		if err := makeDirs(b); err != nil {
 			return err
 		}
-		return makeFiles(d, false)
+		return makeFiles(b, false)
 	})
-	testWithBadDir(t, func(d string) error { return makeFiles(d, false) })
+	testWithBadBundle(t, func(b *types.Bundle) error { return makeFiles(b, false) })
 	// #4532 - Check that we can succeed with an existing file that doesn't have
 	// write permission.
-	testWithGoodDir(t, func(d string) error {
-		if err := makeDirs(d); err != nil {
+	testWithGoodBundle(t, func(b *types.Bundle) error {
+		if err := makeDirs(b); err != nil {
 			return err
 		}
-		err := fs.EnsureFileWithPermission(filepath.Join(d, "etc", "hosts"), 0o400)
+		err := fs.EnsureFileWithPermission(filepath.Join(b.RootfsPath, "etc", "hosts"), 0o400)
 		if err != nil {
 			t.Fatalf("Failed to make test hosts file: %s", err)
 		}
-		return makeFiles(d, false)
+		return makeFiles(b, false)
 	})
 }
 
@@ -74,6 +95,6 @@ func TestMakeBaseEnv(t *testing.T) {
 	test.DropPrivilege(t)
 	defer test.ResetPrivilege(t)
 
-	testWithGoodDir(t, func(d string) error { return makeBaseEnv(d, false) })
-	testWithBadDir(t, func(d string) error { return makeBaseEnv(d, false) })
+	testWithGoodBundle(t, func(b *types.Bundle) error { return makeBaseEnv(b, false) })
+	testWithBadBundle(t, func(b *types.Bundle) error { return makeBaseEnv(b, false) })
 }

--- a/internal/pkg/build/sources/base_environment_test.go
+++ b/internal/pkg/build/sources/base_environment_test.go
@@ -64,6 +64,92 @@ func TestMakeSymlinks(t *testing.T) {
 
 	testWithGoodBundle(t, makeSymlinks)
 	testWithBadBundle(t, makeSymlinks)
+	testWithGoodBundle(t, func(b *types.Bundle) error {
+		// makeSymlinks should be idempotent
+		if err := makeSymlinks(b); err != nil {
+			return err
+		}
+		return makeSymlinks(b)
+	})
+}
+
+func TestMakeSymlink(t *testing.T) {
+	test.DropPrivilege(t)
+	defer test.ResetPrivilege(t)
+
+	const oldname = ".singularity.d/runscript"
+	const newname = "singularity"
+
+	tests := []struct {
+		name  string
+		setup func(root *os.Root) error // setup the precondition at newname
+
+		wantSymlinkTo string // expected target if a symlink is expected
+		wantFile      bool   // expect a regular file (not a symlink) left in place
+	}{
+		{
+			name:          "Missing",
+			setup:         func(*os.Root) error { return nil },
+			wantSymlinkTo: oldname,
+		},
+		{
+			name:          "CorrectSymlink",
+			setup:         func(r *os.Root) error { return r.Symlink(oldname, newname) },
+			wantSymlinkTo: oldname,
+		},
+		{
+			name:          "WrongSymlink",
+			setup:         func(r *os.Root) error { return r.Symlink("/.singularity.d/wrong_link", newname) },
+			wantSymlinkTo: oldname,
+		},
+		{
+			name:     "RegularFile",
+			setup:    func(r *os.Root) error { return r.WriteFile(newname, []byte("legacy"), 0o644) },
+			wantFile: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := testBundle(t.TempDir())
+			if err != nil {
+				t.Fatalf("testBundle: %v", err)
+			}
+			defer b.Rootfs.Close()
+
+			if err := tt.setup(b.Rootfs); err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+
+			if err := makeSymlink(b.Rootfs, oldname, newname); err != nil {
+				t.Fatalf("makeSymlink: %v", err)
+			}
+
+			full := filepath.Join(b.RootfsPath, newname)
+			fi, err := os.Lstat(full)
+			if err != nil {
+				t.Fatalf("lstat %s: %v", full, err)
+			}
+
+			if tt.wantFile {
+				if fi.Mode()&os.ModeSymlink != 0 {
+					t.Fatalf("expected regular file, got a symlink")
+				}
+				return
+			}
+
+			if fi.Mode()&os.ModeSymlink == 0 {
+				t.Fatalf("expected symlink, got mode %v", fi.Mode())
+			}
+			target, err := os.Readlink(full)
+			if err != nil {
+				t.Fatalf("readlink: %v", err)
+			}
+			if target != tt.wantSymlinkTo {
+				t.Fatalf("symlink target = %q, want %q", target, tt.wantSymlinkTo)
+			}
+		})
+	}
 }
 
 func TestMakeFiles(t *testing.T) {

--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -237,14 +237,14 @@ func (cp *ArchConveyorPacker) getPacConf(pacmanConfURL string) (pacConf string, 
 }
 
 func (cp *ArchConveyorPacker) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *ArchConveyorPacker) insertRunScript() (err error) {
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = cp.b.Rootfs.WriteFile(".singularity.d/runscript", []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_buildkit.go
+++ b/internal/pkg/build/sources/conveyorPacker_buildkit.go
@@ -172,16 +172,19 @@ func buildkitBuild(ctx context.Context, tmpDir string, env []string, platform, o
 		"--opt", fmt.Sprintf("platform=%s", platform),
 	}
 	if opts.target != "" {
-		args = append(args,
+		args = append(
+			args,
 			"--opt", fmt.Sprintf("target=%s", opts.target),
 		)
 	}
 	for key, val := range opts.buildargs {
-		args = append(args,
+		args = append(
+			args,
 			"--opt", fmt.Sprintf("build-arg:%s=%s", key, val),
 		)
 	}
-	args = append(args,
+	args = append(
+		args,
 		"--output", fmt.Sprintf("type=oci,dest=%s", output),
 		"--ref-file", reffile.Name(),
 	)
@@ -220,12 +223,14 @@ func dockerBuild(ctx context.Context, env []string, platform, output string, opt
 		opts.context,
 	}
 	if opts.target != "" {
-		args = append(args,
+		args = append(
+			args,
 			"--target", opts.target,
 		)
 	}
 	for key, val := range opts.buildargs {
-		args = append(args,
+		args = append(
+			args,
 			"--build-arg", fmt.Sprintf("%s=%s", key, val),
 		)
 	}
@@ -325,11 +330,11 @@ func (cp *BuildKitConveyorPacker) buildImage(ctx context.Context, tmpDir string)
 				}
 			}
 		}
-		err = os.MkdirAll(filepath.Join(cp.b.RootfsPath, ".singularity.d"), 0o755)
+		err = cp.b.Rootfs.MkdirAll(".singularity.d", 0o755)
 		if err != nil {
 			return err
 		}
-		buildlog, err := os.OpenFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/buildkit_build.log"), os.O_CREATE|os.O_WRONLY, 0o644)
+		buildlog, err := cp.b.Rootfs.OpenFile(filepath.Join(".singularity.d", "buildkit_build.log"), os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -81,19 +81,21 @@ func (cp *BusyBoxConveyorPacker) Pack(context.Context) (b *types.Bundle, err err
 }
 
 func (c *BusyBoxConveyor) insertBaseFiles() error {
-	if err := os.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0o664); err != nil {
+	if err := c.b.Rootfs.WriteFile(filepath.Join("etc", "passwd"), []byte("root:!:0:0:root:/root:/bin/sh"), 0o664); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/group"), []byte(" root:x:0:"), 0o664); err != nil {
+	if err := c.b.Rootfs.WriteFile(filepath.Join("etc", "group"), []byte(" root:x:0:"), 0o664); err != nil {
 		return err
 	}
 
-	return os.WriteFile(filepath.Join(c.b.RootfsPath, "/etc/hosts"), []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0o664)
+	return c.b.Rootfs.WriteFile("etc/hosts", []byte("127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4"), 0o664)
 }
 
 func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, err error) {
-	os.Mkdir(filepath.Join(c.b.RootfsPath, "/bin"), 0o755)
+	if err := c.b.Rootfs.Mkdir("bin", 0o755); err != nil && !os.IsExist(err) {
+		return "", err
+	}
 
 	// Increase the TLS handshake timeout because the busybox server
 	//   is often slow to connect.
@@ -109,7 +111,7 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 	}
 	defer resp.Body.Close()
 
-	f, err := os.Create(filepath.Join(c.b.RootfsPath, "/bin/busybox"))
+	f, err := c.b.Rootfs.Create(filepath.Join("bin", "busybox"))
 	if err != nil {
 		return "", err
 	}
@@ -125,7 +127,7 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 		return "", fmt.Errorf("file received is not the right size. supposed to be: %v actually: %v", resp.ContentLength, bytesWritten)
 	}
 
-	err = os.Chmod(f.Name(), 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return "", err
 	}
@@ -134,14 +136,14 @@ func (c *BusyBoxConveyor) insertBusyBox(mirrorurl string) (busyBoxPath string, e
 }
 
 func (c *BusyBoxConveyor) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(c.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(c.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *BusyBoxConveyorPacker) insertRunScript() error {
-	return os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	return cp.b.Rootfs.WriteFile(".singularity.d/runscript", []byte("#!/bin/sh\n"), 0o755)
 }
 
 // CleanUp removes any tmpfs owned by the conveyorPacker on the filesystem

--- a/internal/pkg/build/sources/conveyorPacker_debootstrap.go
+++ b/internal/pkg/build/sources/conveyorPacker_debootstrap.go
@@ -120,7 +120,7 @@ func (cp *DebootstrapConveyorPacker) prepareFakerootEnv(ctx context.Context) (fu
 			case <-time.After(100 * time.Millisecond):
 				if _, err := os.Stat(makedevPath); err == nil {
 					os.Truncate(makedevPath, 0)
-					os.Create(filepath.Join(cp.b.RootfsPath, "/dev/tty1"))
+					cp.b.Rootfs.Create(filepath.Join("dev", "tty1"))
 					break
 				}
 			}
@@ -227,7 +227,7 @@ func (cp *DebootstrapConveyorPacker) Get(ctx context.Context, b *types.Bundle) (
 // Pack puts relevant objects in a Bundle!
 func (cp *DebootstrapConveyorPacker) Pack(context.Context) (*types.Bundle, error) {
 	// change root directory permissions to 0755
-	if err := os.Chmod(cp.b.RootfsPath, 0o755); err != nil {
+	if err := cp.b.Rootfs.Chmod(".", 0o755); err != nil {
 		return nil, fmt.Errorf("while changing bundle rootfs perms: %v", err)
 	}
 
@@ -273,14 +273,14 @@ func (cp *DebootstrapConveyorPacker) getRecipeHeaderInfo() (err error) {
 }
 
 func (cp *DebootstrapConveyorPacker) insertBaseEnv(b *types.Bundle) (err error) {
-	if err = makeBaseEnv(b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *DebootstrapConveyorPacker) insertRunScript(b *types.Bundle) (err error) {
-	f, err := os.Create(b.RootfsPath + "/.singularity.d/runscript")
+	f, err := b.Rootfs.Create(filepath.Join(".singularity.d", "runscript"))
 	if err != nil {
 		return
 	}
@@ -294,7 +294,7 @@ func (cp *DebootstrapConveyorPacker) insertRunScript(b *types.Bundle) (err error
 
 	f.Sync()
 
-	err = os.Chmod(b.RootfsPath+"/.singularity.d/runscript", 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_library.go
+++ b/internal/pkg/build/sources/conveyorPacker_library.go
@@ -79,7 +79,7 @@ func (cp *LibraryConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err 
 	}
 
 	// insert base metadata before unpacking fs
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_local.go
+++ b/internal/pkg/build/sources/conveyorPacker_local.go
@@ -140,10 +140,17 @@ func (cp *LocalConveyorPacker) Pack(ctx context.Context) (*types.Bundle, error) 
 		return nil, fmt.Errorf("while unpacking local image: %v", err)
 	}
 
+	// Extraction of a local image may remove and recreate the rootfs directory,
+	// invalidating the bundle's os.Root handle. Re-open it before we make any
+	// rooted modifications below.
+	if err := b.ReopenRootfs(); err != nil {
+		return nil, fmt.Errorf("while reopening rootfs: %v", err)
+	}
+
 	// Insert base metadata after unpacking fs to avoid unsquashfs failure on
 	// existing files/symlink. Call makeBaseEnv with overwrite=false so we don't
 	// overwrite runscripts etc. that were extracted from the image.
-	if err = makeBaseEnv(b.RootfsPath, false); err != nil {
+	if err = makeBaseEnv(b, false); err != nil {
 		return nil, fmt.Errorf("while inserting base environment: %v", err)
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -296,14 +296,14 @@ func (cp *OCIConveyorPacker) unpackRootfs(ctx context.Context) error {
 }
 
 func (cp *OCIConveyorPacker) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		sylog.Errorf("%v", err)
 	}
 	return
 }
 
 func (cp *OCIConveyorPacker) insertRunScript() error {
-	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/runscript")
+	f, err := cp.b.Rootfs.Create(filepath.Join(".singularity.d", "runscript"))
 	if err != nil {
 		return err
 	}
@@ -377,7 +377,7 @@ func (cp *OCIConveyorPacker) insertRunScript() error {
 
 	f.Sync()
 
-	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return err
 	}
@@ -386,7 +386,7 @@ func (cp *OCIConveyorPacker) insertRunScript() error {
 }
 
 func (cp *OCIConveyorPacker) insertEnv() error {
-	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/env/10-docker2singularity.sh")
+	f, err := cp.b.Rootfs.Create(filepath.Join(".singularity.d", "env", "10-docker2singularity.sh"))
 	if err != nil {
 		return err
 	}
@@ -423,7 +423,7 @@ func (cp *OCIConveyorPacker) insertEnv() error {
 
 	f.Sync()
 
-	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/env/10-docker2singularity.sh", 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return err
 	}
@@ -441,7 +441,7 @@ func (cp *OCIConveyorPacker) insertOCILabels() (err error) {
 		return err
 	}
 
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
+	err = cp.b.Rootfs.WriteFile(".singularity.d/labels.json", []byte(text), 0o644)
 	return err
 }
 

--- a/internal/pkg/build/sources/conveyorPacker_oras.go
+++ b/internal/pkg/build/sources/conveyorPacker_oras.go
@@ -40,7 +40,7 @@ func (cp *OrasConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 	}
 
 	// insert base metadata before unpacking fs
-	if err = makeBaseEnv(b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(b, true); err != nil {
 		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_scratch.go
+++ b/internal/pkg/build/sources/conveyorPacker_scratch.go
@@ -12,8 +12,6 @@ package sources
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/apptainer/apptainer/pkg/build/types"
 )
@@ -51,14 +49,14 @@ func (cp *ScratchConveyorPacker) Pack(context.Context) (b *types.Bundle, err err
 }
 
 func (c *ScratchConveyor) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(c.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(c.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *ScratchConveyorPacker) insertRunScript() (err error) {
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = cp.b.Rootfs.WriteFile(".singularity.d/runscript", []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_shub.go
+++ b/internal/pkg/build/sources/conveyorPacker_shub.go
@@ -38,7 +38,7 @@ func (cp *ShubConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err err
 	}
 
 	// insert base metadata before unpacking fs
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return fmt.Errorf("while inserting base environment: %v", err)
 	}
 

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	yumConf = "/etc/bootstrap-yum.conf"
+	yumConf = "etc/bootstrap-yum.conf"
 )
 
 // YumConveyor holds stuff that needs to be packed into the bundle

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -101,7 +101,9 @@ func (c *YumConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
 	}
 
 	// clean up bootstrap packages
-	os.RemoveAll(filepath.Join(c.b.RootfsPath, "/var/cache/yum-bootstrap"))
+	if err := c.b.Rootfs.RemoveAll(filepath.Join("var", "cache", "yum-bootstrap")); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -257,12 +259,12 @@ func (c *YumConveyor) genYumConfig() (err error) {
 		fileContent += "\n"
 	}
 
-	err = os.Mkdir(filepath.Join(c.b.RootfsPath, "/etc"), 0o775)
+	err = c.b.Rootfs.Mkdir("etc", 0o775)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, "/etc"), err)
 	}
 
-	err = os.WriteFile(filepath.Join(c.b.RootfsPath, yumConf), []byte(fileContent), 0o664)
+	err = c.b.Rootfs.WriteFile(yumConf, []byte(fileContent), 0o664)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(c.b.RootfsPath, yumConf), err)
 	}
@@ -345,14 +347,14 @@ func (c *YumConveyor) makePseudoDevices() (err error) {
 }
 
 func (cp *YumConveyorPacker) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *YumConveyorPacker) insertRunScript() (err error) {
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, "/.singularity.d/runscript"), []byte("#!/bin/sh\n"), 0o755)
+	err = cp.b.Rootfs.WriteFile(".singularity.d/runscript", []byte("#!/bin/sh\n"), 0o755)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	zypperConf    = "/etc/zypp/zypp.conf"
+	zypperConf    = "etc/zypp/zypp.conf"
 	osreleaseFile = "/etc/os-release"
 	// #nosec G101
 	ssccredentialsFile = "/etc/zypp/credentials.d/SCCcredentials"
@@ -262,24 +262,24 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) error 
 		}
 	}
 	if pgpfile != "" {
-		rpmbase := "/usr/lib/sysimage"
-		rpmsys := "/var/lib"
+		rpmbase := "usr/lib/sysimage"
+		rpmsys := "var/lib"
 		rpmrel := "../.."
 		if iosmajor == 12 {
 			rpmbase = "/var/lib"
 			rpmsys = "/usr/lib/sysimage"
 			rpmrel = "../../.."
 		}
-		if err = os.MkdirAll(cp.b.RootfsPath+rpmbase+`/rpm`, 0o755); err != nil {
+		if err = cp.b.Rootfs.MkdirAll(rpmbase+`/rpm`, 0o755); err != nil {
 			return fmt.Errorf("cannot recreate rpm directories: %v", err)
 		}
-		if err = os.MkdirAll(cp.b.RootfsPath+rpmsys, 0o755); err != nil {
+		if err = cp.b.Rootfs.MkdirAll(rpmsys, 0o755); err != nil {
 			return fmt.Errorf("cannot recreate rpm directories: %v", err)
 		}
-		if err = os.RemoveAll(cp.b.RootfsPath + rpmsys + `/rpm`); err != nil {
+		if err = cp.b.Rootfs.RemoveAll(rpmsys + `/rpm`); err != nil {
 			return fmt.Errorf("cannot remove rpm directory")
 		}
-		if err = os.Symlink(rpmrel+rpmbase+`/rpm`, cp.b.RootfsPath+rpmsys+`/rpm`); err != nil {
+		if err = cp.b.Rootfs.Symlink(rpmrel+rpmbase+`/rpm`, rpmsys+`/rpm`); err != nil {
 			return fmt.Errorf("cannot create rpm symlink")
 		}
 		cmd := exec.CommandContext(ctx, "rpmkeys", `--root`, cp.b.RootfsPath, `--import`, pgpfile)
@@ -393,14 +393,14 @@ func (cp *ZypperConveyorPacker) Pack(context.Context) (b *types.Bundle, err erro
 }
 
 func (cp *ZypperConveyorPacker) insertBaseEnv() (err error) {
-	if err = makeBaseEnv(cp.b.RootfsPath, true); err != nil {
+	if err = makeBaseEnv(cp.b, true); err != nil {
 		return
 	}
 	return nil
 }
 
 func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
-	f, err := os.Create(cp.b.RootfsPath + "/.singularity.d/runscript")
+	f, err := cp.b.Rootfs.Create(filepath.Join(".singularity.d", "runscript"))
 	if err != nil {
 		return
 	}
@@ -414,7 +414,7 @@ func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
 
 	f.Sync()
 
-	err = os.Chmod(cp.b.RootfsPath+"/.singularity.d/runscript", 0o755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return
 	}
@@ -423,12 +423,12 @@ func (cp *ZypperConveyorPacker) insertRunScript() (err error) {
 }
 
 func (cp *ZypperConveyorPacker) genZypperConfig() (err error) {
-	err = os.MkdirAll(filepath.Join(cp.b.RootfsPath, "/etc/zypp"), 0o775)
+	err = cp.b.Rootfs.MkdirAll(filepath.Join("etc", "zypp"), 0o775)
 	if err != nil {
 		return fmt.Errorf("while creating %v: %v", filepath.Join(cp.b.RootfsPath, "/etc/zypp"), err)
 	}
 
-	err = os.WriteFile(filepath.Join(cp.b.RootfsPath, zypperConf), []byte("[main]\ncachedir=/var/cache/zypp-bootstrap\n\n"), 0o664)
+	err = cp.b.Rootfs.WriteFile(zypperConf, []byte("[main]\ncachedir=/var/cache/zypp-bootstrap\n\n"), 0o664)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -342,10 +342,10 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) error 
 		args = append(args, `--installroot`, cp.b.RootfsPath)
 		include += " zypper"
 		if suseVars.HasScc {
-			if err = os.MkdirAll(filepath.Join(cp.b.RootfsPath, "/etc/zypp/credentials.d/"), 0o755); err != nil {
+			if err = cp.b.Rootfs.MkdirAll(filepath.Join("etc", "zypp", "credentials.d"), 0o755); err != nil {
 				return fmt.Errorf("cannot recreate /etc/zypp/credentials.d/ directories: %v", err)
 			}
-			sccF, err := os.Create(filepath.Join(cp.b.RootfsPath, "/etc/zypp/credentials.d/SCCcredentials"))
+			sccF, err := cp.b.Rootfs.Create(filepath.Join("etc", "zypp", "credentials.d", "SCCcredentials"))
 			if err != nil {
 				return fmt.Errorf("couldn't create SCCcredentials file: %v", err)
 			}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -266,20 +266,21 @@ func (cp *ZypperConveyorPacker) Get(ctx context.Context, b *types.Bundle) error 
 		rpmsys := "var/lib"
 		rpmrel := "../.."
 		if iosmajor == 12 {
-			rpmbase = "/var/lib"
-			rpmsys = "/usr/lib/sysimage"
+			rpmbase = "var/lib"
+			rpmsys = "usr/lib/sysimage"
 			rpmrel = "../../.."
 		}
-		if err = cp.b.Rootfs.MkdirAll(rpmbase+`/rpm`, 0o755); err != nil {
+
+		if err = cp.b.Rootfs.MkdirAll(filepath.Join(rpmbase, "rpm"), 0o755); err != nil {
 			return fmt.Errorf("cannot recreate rpm directories: %v", err)
 		}
 		if err = cp.b.Rootfs.MkdirAll(rpmsys, 0o755); err != nil {
 			return fmt.Errorf("cannot recreate rpm directories: %v", err)
 		}
-		if err = cp.b.Rootfs.RemoveAll(rpmsys + `/rpm`); err != nil {
+		if err = cp.b.Rootfs.RemoveAll(filepath.Join(rpmsys, "rpm")); err != nil {
 			return fmt.Errorf("cannot remove rpm directory")
 		}
-		if err = cp.b.Rootfs.Symlink(rpmrel+rpmbase+`/rpm`, rpmsys+`/rpm`); err != nil {
+		if err = cp.b.Rootfs.Symlink(filepath.Join(rpmrel, rpmbase, "rpm"), filepath.Join(rpmsys, "rpm")); err != nil {
 			return fmt.Errorf("cannot create rpm symlink")
 		}
 		cmd := exec.CommandContext(ctx, "rpmkeys", `--root`, cp.b.RootfsPath, `--import`, pgpfile)

--- a/pkg/build/types/bundle.go
+++ b/pkg/build/types/bundle.go
@@ -54,9 +54,10 @@ type Bundle struct {
 	Recipe      Definition        `json:"rawDeffile"`
 	Opts        Options           `json:"opts"`
 
-	RootfsPath  string `json:"rootfsPath"`            // where actual fs to chroot will appear
-	RootfsImage string `json:"rootfsImage,omitempty"` // external squashfs to be used for data partition
-	TmpDir      string `json:"tmpPath"`               // where temp files required during build will appear
+	RootfsPath  string   `json:"rootfsPath"`            // where actual fs to chroot will appear
+	RootfsImage string   `json:"rootfsImage,omitempty"` // external squashfs to be used for data partition
+	Rootfs      *os.Root `json:"-"`                     // rooted handle to RootfsPath for confined build modifications
+	TmpDir      string   `json:"tmpPath"`               // where temp files required during build will appear
 
 	SourceDateEpoch time.Time // SOURCE_DATE_EPOCH, or Zero (`time.Time{}`) for Now
 
@@ -161,8 +162,35 @@ func (b *Bundle) RunSection(s string) bool {
 	return false
 }
 
+// ReopenRootfs re-opens the os.Root handle to RootfsPath. It must be called
+// after any operation that removes and recreates the rootfs directory (e.g.
+// extraction of a local image), as the previous handle then refers to the old,
+// now-unlinked directory inode.
+func (b *Bundle) ReopenRootfs() error {
+	if b.Rootfs != nil {
+		if err := b.Rootfs.Close(); err != nil {
+			sylog.Errorf("Could not close rootfs %q: %v", b.RootfsPath, err)
+		}
+		b.Rootfs = nil
+	}
+
+	rootfsRoot, err := os.OpenRoot(b.RootfsPath)
+	if err != nil {
+		return fmt.Errorf("could not open rootfs %q: %v", b.RootfsPath, err)
+	}
+	b.Rootfs = rootfsRoot
+	return nil
+}
+
 // Remove cleans up any bundle files.
 func (b *Bundle) Remove() error {
+	if b.Rootfs != nil {
+		if err := b.Rootfs.Close(); err != nil {
+			sylog.Errorf("Could not close rootfs %q: %v", b.RootfsPath, err)
+		}
+		b.Rootfs = nil
+	}
+
 	var errors []string
 	for _, dir := range []string{b.TmpDir, b.parentPath} {
 		if err := fs.ForceRemoveAll(dir); err != nil {
@@ -292,11 +320,20 @@ func newBundle(parentPath, tempDir string, keyInfo *cryptkey.KeyInfo) (*Bundle, 
 		}
 	}
 
+	rootfsRoot, err := os.OpenRoot(rootfsPath)
+	if err != nil {
+		cleanupDir(tmpPath)
+		cleanupDir(rootfsPath)
+		cleanupDir(parentPath)
+		return nil, fmt.Errorf("could not open rootfs %q: %v", rootfsPath, err)
+	}
+
 	sylog.Debugf("Created directory %q for the bundle", rootfsPath)
 
 	return &Bundle{
 		parentPath:      parentPath,
 		RootfsPath:      rootfsPath,
+		Rootfs:          rootfsRoot,
 		SourceDateEpoch: sourceDateEpoch,
 		TmpDir:          tmpPath,
 		JSONObjects:     make(map[string][]byte),


### PR DESCRIPTION
## Description of the Pull Request (PR):

This pulls in the sylab PR https://github.com/sylabs/singularity/pull/4178 and fixes some issues introduced by it.

The original PR description was:

> In builds, we frequently create directories and write files into a rootfs dir. We can use os.Root to better restrict these operations to the rootfs directory.
> 
> This code was developed out of exploratory work using Claude Code, that has been manually reviewed and edited. The Co-authored-by trailer is added on this basis.
> 
> Co-authored-by: Claude Code


### This fixes or addresses the following GitHub issues:

 - Fixes #3594