### PR TITLE
e2e: basic nested in docker/podman testing, from sylabs3545

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
 
   e2e_tests:
     name: e2e_tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -433,6 +433,11 @@ jobs:
               echo "E: ./scripts/should-e2e-run returned with exit code $rc. Abort."
               exit $rc ;;
           esac
+
+      - name: Disable Ubuntu 24.04 userns apparmor restriction
+        if: env.run_tests
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Setup Go
         if: env.run_tests
@@ -481,7 +486,7 @@ jobs:
           sudo apptainer run docker://multiarch/qemu-user-static --reset -p yes
           supported_misc=`ls -al /proc/sys/fs/binfmt_misc/qemu-* | wc -l`
           if [ "$supported_misc" -le 1 ]; then
-              echo "binfmt_misc registerred failed"
+              echo "binfmt_misc registration failed"
               exit 1
           fi
 

--- a/e2e/internal/e2e/env.go
+++ b/e2e/internal/e2e/env.go
@@ -17,6 +17,7 @@ type TestEnv struct {
 	ImagePath             string // Path to the image that has to be used for the execution of an Apptainer command
 	SingularityImagePath  string // Path to a Singularity image for legacy tests
 	DebianImagePath       string // Path to an image containing a Debian distribution with libc compatible to the host libc
+	DebianImageSource     string // Dockerhub name of Debian image
 	OrasTestImage         string // URI to SIF image pushed into local registry with ORAS
 	TestDir               string // Path to the directory from which an Apptainer command needs to be executed
 	TestRegistry          string // Host:Port of local registry

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -91,9 +91,47 @@ func EnsureSingularityImage(t *testing.T, env TestEnv) {
 	)
 }
 
-// EnsureDebianImage checks if the e2e test Debian-based image, with a libc
-// that is compatible with the host libc, is already built or builds it
-// otherwise.
+// Return dockerhub name of a Debian image that is compatible with the host libc
+func GetDebianImageSource(t *testing.T) string {
+	out, err := exec.Command("ldd", "--version").Output()
+	if err != nil {
+		t.Fatalf("Error running ldd --version while getting Debian image source: %+v\n",
+			err)
+	}
+	outstr := string(out)
+	end := strings.Index(outstr, "\n")
+	if end == -1 {
+		t.Fatalf("No newline in ldd output while getting Debian image source: %+v\n",
+			err)
+	}
+	dot := strings.LastIndex(outstr[0:end], ".")
+	if dot == -1 {
+		t.Fatalf("No dot in ldd first line while getting Debian image source: %+v\n",
+			err)
+	}
+	lddversion, err := strconv.Atoi(outstr[dot+1 : end])
+	if err != nil {
+		t.Fatalf("Could not convert lddversion (%s) to integer while getting Debian image source: %+v\n",
+			outstr[dot+1:end],
+			err)
+	}
+	if lddversion < 17 {
+		t.Fatalf("ldd version (%d) not 17 or newer while getting Debian image source: %+v\n",
+			lddversion,
+			err)
+	}
+
+	imageSource := "ubuntu:20.04"
+	if lddversion >= 39 {
+		imageSource = "ubuntu:24.04"
+	} else if lddversion >= 35 {
+		imageSource = "ubuntu:22.04"
+	}
+	return imageSource
+}
+
+// EnsureDebianImage checks if the e2e test Debian-based image is already
+// built or builds it otherwise.
 func EnsureDebianImage(t *testing.T, env TestEnv) {
 	ensureMutex.Lock()
 	defer ensureMutex.Unlock()
@@ -113,46 +151,6 @@ func EnsureDebianImage(t *testing.T, env TestEnv) {
 			err)
 	}
 
-	out, err := exec.Command("ldd", "--version").Output()
-	if err != nil {
-		t.Fatalf("Error running ldd --version while getting image %q: %+v\n",
-			env.DebianImagePath,
-			err)
-	}
-	outstr := string(out)
-	end := strings.Index(outstr, "\n")
-	if end == -1 {
-		t.Fatalf("No newline in ldd output while getting image %q: %+v\n",
-			env.DebianImagePath,
-			err)
-	}
-	dot := strings.LastIndex(outstr[0:end], ".")
-	if dot == -1 {
-		t.Fatalf("No dot in ldd first line while getting image %q: %+v\n",
-			env.DebianImagePath,
-			err)
-	}
-	lddversion, err := strconv.Atoi(outstr[dot+1 : end])
-	if err != nil {
-		t.Fatalf("Could not convert lddversion (%s) to integer while getting image %q: %+v\n",
-			outstr[dot+1:end],
-			env.DebianImagePath,
-			err)
-	}
-	if lddversion < 17 {
-		t.Fatalf("ldd version (%d) not 17 or older while getting image %q: %+v\n",
-			lddversion,
-			env.DebianImagePath,
-			err)
-	}
-
-	imageSource := "ubuntu:20.04"
-	if lddversion >= 39 {
-		imageSource = "ubuntu:24.04"
-	} else if lddversion >= 35 {
-		imageSource = "ubuntu:22.04"
-	}
-
 	env.RunApptainer(
 		t,
 		// If this is built with the RootProfile, it does not get
@@ -160,7 +158,7 @@ func EnsureDebianImage(t *testing.T, env TestEnv) {
 		// becomes too restricted.
 		WithProfile(UserProfile),
 		WithCommand("build"),
-		WithArgs("--force", env.DebianImagePath, "docker://"+imageSource),
+		WithArgs("--force", env.DebianImagePath, "docker://"+env.DebianImageSource),
 		ExpectExit(0),
 	)
 }

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -146,9 +146,11 @@ func EnsureDebianImage(t *testing.T, env TestEnv) {
 			err)
 	}
 
-	imageSource := "docker://ubuntu:20.04"
-	if lddversion >= 35 {
-		imageSource = "docker://ubuntu:22.04"
+	imageSource := "ubuntu:20.04"
+	if lddversion >= 39 {
+		imageSource = "ubuntu:24.04"
+	} else if lddversion >= 35 {
+		imageSource = "ubuntu:22.04"
 	}
 
 	env.RunApptainer(
@@ -158,7 +160,7 @@ func EnsureDebianImage(t *testing.T, env TestEnv) {
 		// becomes too restricted.
 		WithProfile(UserProfile),
 		WithCommand("build"),
-		WithArgs("--force", env.DebianImagePath, imageSource),
+		WithArgs("--force", env.DebianImagePath, "docker://"+imageSource),
 		ExpectExit(0),
 	)
 }

--- a/e2e/nested/nested.go
+++ b/e2e/nested/nested.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2025, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package nested
+
+import (
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/apptainer/apptainer/e2e/internal/e2e"
+	"github.com/apptainer/apptainer/e2e/internal/testhelper"
+	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
+)
+
+type ctx struct {
+	env e2e.TestEnv
+}
+
+//nolint:dupl
+func (c ctx) docker(t *testing.T) {
+	require.Command(t, "docker")
+	e2e.EnsureORASImage(t, c.env)
+
+	// Temporary homedir for docker commands, so invoking docker doesn't create
+	// a ~/.docker that may interfere elsewhere.
+	tmpHome, cleanupHome := e2e.MakeTempDir(t, c.env.TestDir, "nested-docker-", "")
+	t.Cleanup(func() { e2e.Privileged(cleanupHome)(t) })
+
+	dockerFile := "testdata/Dockerfile.nested"
+	dockerRef := "apptainer-e2e-docker-nested"
+	dockerBuild(t, dockerFile, dockerRef, "../", tmpHome)
+	defer dockerRMI(t, dockerRef, tmpHome)
+
+	// Execution using privileged Docker. Root in outer Docker container.
+	dockerRunPrivileged(t, "version", dockerRef, tmpHome)
+	dockerRunPrivileged(t, "exec", dockerRef, tmpHome, "exec", c.env.OrasTestImage, "/bin/true")
+	dockerRunPrivileged(t, "execUserNS", dockerRef, tmpHome, "exec", "-u", c.env.OrasTestImage, "/bin/true")
+	dockerRunPrivileged(t, "buildSIF", dockerRef, tmpHome, "build", "test.sif", "apptainer/examples/library/Apptainer")
+}
+
+func dockerBuild(t *testing.T, dockerFile, dockerRef, contextPath, homeDir string) {
+	t.Run("build/"+dockerRef, e2e.Privileged(func(t *testing.T) {
+		cmd := exec.Command("docker", "build",
+			"--build-arg", "GOVERSION="+runtime.Version(),
+			"--build-arg", "GOOS="+runtime.GOOS,
+			"--build-arg", "GOARCH="+runtime.GOARCH,
+			"-t", dockerRef, "-f", dockerFile, contextPath)
+		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		out, err := cmd.CombinedOutput()
+		t.Log(cmd.Args)
+		if err != nil {
+			t.Fatalf("Failed building docker container.\n%s: %s", err, string(out))
+		}
+	}))
+}
+
+func dockerRMI(t *testing.T, dockerRef, homeDir string) {
+	t.Run("rmi/"+dockerRef, e2e.Privileged(func(t *testing.T) {
+		cmd := exec.Command("docker", "rmi", dockerRef)
+		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		out, err := cmd.CombinedOutput()
+		t.Log(cmd.Args)
+		if err != nil {
+			t.Fatalf("Failed removing docker container.\n%s: %s", err, string(out))
+		}
+	}))
+}
+
+func dockerRunPrivileged(t *testing.T, name, dockerRef, homeDir string, args ...string) { //nolint:unparam
+	t.Run(name, e2e.Privileged(func(t *testing.T) {
+		cmdArgs := []string{"run", "-i", "--rm", "--privileged", "--network=host", dockerRef}
+		cmdArgs = append(cmdArgs, args...)
+		cmd := exec.Command("docker", cmdArgs...)
+		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		out, err := cmd.CombinedOutput()
+		t.Log(cmd.Args)
+		if err != nil {
+			t.Fatalf("Failed running docker container.\n%s: %s", err, string(out))
+		}
+	}))
+}
+
+//nolint:dupl
+func (c ctx) podman(t *testing.T) {
+	require.Command(t, "podman")
+	e2e.EnsureORASImage(t, c.env)
+
+	// Temporary homedir for docker commands, so invoking docker doesn't create
+	// a ~/.docker that may interfere elsewhere.
+	tmpHome, cleanupHome := e2e.MakeTempDir(t, c.env.TestDir, "nested-docker-", "")
+	t.Cleanup(func() { e2e.Privileged(cleanupHome)(t) })
+
+	dockerFile := "testdata/Dockerfile.nested"
+	dockerRef := "localhost/apptainer-e2e-podman-nested"
+	podmanBuild(t, dockerFile, dockerRef, "../", tmpHome)
+	defer podmanRMI(t, dockerRef, tmpHome)
+
+	// Rootless podman - fake userns root in outer podman container.
+	podmanRun(t, "version", dockerRef, tmpHome)
+	podmanRun(t, "exec", dockerRef, tmpHome, "exec", c.env.OrasTestImage, "/bin/true")
+	podmanRun(t, "execUserNS", dockerRef, tmpHome, "exec", "-u", c.env.OrasTestImage, "/bin/true")
+	podmanRun(t, "buildSIF", dockerRef, tmpHome, "build", "test.sif", "apptainer/examples/library/Apptainer")
+}
+
+func podmanBuild(t *testing.T, dockerFile, dockerRef, contextPath, homeDir string) {
+	t.Run("build/"+dockerRef, func(t *testing.T) {
+		cmd := exec.Command("podman", "build",
+			"--runtime=runc", // ubuntu22.04 crun is buggy
+			"--build-arg", "GOVERSION="+runtime.Version(),
+			"--build-arg", "GOOS="+runtime.GOOS,
+			"--build-arg", "GOARCH="+runtime.GOARCH,
+			"-t", dockerRef, "-f", dockerFile, contextPath)
+		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		out, err := cmd.CombinedOutput()
+		t.Log(cmd.Args)
+		if err != nil {
+			t.Fatalf("Failed building podman container.\n%s: %s", err, string(out))
+		}
+	})
+}
+
+func podmanRMI(t *testing.T, dockerRef, homeDir string) {
+	t.Run("rmi/"+dockerRef, func(t *testing.T) {
+		cmd := exec.Command("podman", "rmi", dockerRef)
+		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		out, err := cmd.CombinedOutput()
+		t.Log(cmd.Args)
+		if err != nil {
+			t.Fatalf("Failed removing podman container.\n%s: %s", err, string(out))
+		}
+	})
+}
+
+func podmanRun(t *testing.T, name, dockerRef, homeDir string, args ...string) { //nolint:unparam
+	t.Run(name, func(t *testing.T) {
+		cmdArgs := []string{"run", "-i", "--rm", "--privileged", "--network=host", dockerRef}
+		cmdArgs = append(cmdArgs, args...)
+		cmd := exec.Command("podman", cmdArgs...)
+		cmd.Env = append(cmd.Env, "HOME="+homeDir)
+		out, err := cmd.CombinedOutput()
+		t.Log(cmd.Args)
+		if err != nil {
+			t.Fatalf("Failed running podman container.\n%s: %s", err, string(out))
+		}
+	})
+}
+
+// E2ETests is the main func to trigger the test suite
+func E2ETests(env e2e.TestEnv) testhelper.Tests {
+	c := ctx{
+		env: env,
+	}
+
+	return testhelper.Tests{
+		"Docker": c.docker,
+		"Podman": c.podman,
+	}
+}

--- a/e2e/nested/nested.go
+++ b/e2e/nested/nested.go
@@ -10,8 +10,8 @@
 package nested
 
 import (
+	"os"
 	"os/exec"
-	"runtime"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
@@ -25,130 +25,80 @@ type ctx struct {
 
 //nolint:dupl
 func (c ctx) docker(t *testing.T) {
-	require.Command(t, "docker")
+	// Execution using privileged Docker. Root in outer Docker container.
+	c.nestedContainerTest(t, "docker", "apptainer-e2e-docker-nested")
+}
+
+func (c ctx) nestedContainerTest(t *testing.T, prog, ref string) {
+	require.Command(t, prog)
 	e2e.EnsureORASImage(t, c.env)
 
-	// Temporary homedir for docker commands, so invoking docker doesn't create
+	// Temporary homedir for docker/podman commands, so they don't create
 	// a ~/.docker that may interfere elsewhere.
-	tmpHome, cleanupHome := e2e.MakeTempDir(t, c.env.TestDir, "nested-docker-", "")
+	tmpHome, cleanupHome := e2e.MakeTempDir(t, c.env.TestDir, "nested-"+prog+"-", "")
 	t.Cleanup(func() { e2e.Privileged(cleanupHome)(t) })
 
 	dockerFile := "testdata/Dockerfile.nested"
-	dockerRef := "apptainer-e2e-docker-nested"
-	dockerBuild(t, dockerFile, dockerRef, "../", tmpHome)
-	defer dockerRMI(t, dockerRef, tmpHome)
 
-	// Execution using privileged Docker. Root in outer Docker container.
-	dockerRunPrivileged(t, "version", dockerRef, tmpHome)
-	dockerRunPrivileged(t, "exec", dockerRef, tmpHome, "exec", c.env.OrasTestImage, "/bin/true")
-	dockerRunPrivileged(t, "execUserNS", dockerRef, tmpHome, "exec", "-u", c.env.OrasTestImage, "/bin/true")
-	dockerRunPrivileged(t, "buildSIF", dockerRef, tmpHome, "build", "test.sif", "apptainer/examples/library/Apptainer")
+	containerBuild(t, prog, dockerFile, ref, "../", c.env.DebianImageSource, tmpHome)
+	defer containerRMI(t, prog, ref, tmpHome)
+
+	containerRun(t, prog, "version", ref, tmpHome)
+	containerRun(t, prog, "exec", ref, tmpHome, "exec", c.env.OrasTestImage, "/bin/true")
+	containerRun(t, prog, "execUserNS", ref, tmpHome, "exec", "-u", c.env.OrasTestImage, "/bin/true")
+	containerRun(t, prog, "buildSIF", ref, tmpHome, "build", "test.sif", "/e2e/testdata/Apptainer")
 }
 
-func dockerBuild(t *testing.T, dockerFile, dockerRef, contextPath, homeDir string) {
-	t.Run("build/"+dockerRef, e2e.Privileged(func(t *testing.T) {
-		cmd := exec.Command("docker", "build",
-			"--build-arg", "GOVERSION="+runtime.Version(),
-			"--build-arg", "GOOS="+runtime.GOOS,
-			"--build-arg", "GOARCH="+runtime.GOARCH,
-			"-t", dockerRef, "-f", dockerFile, contextPath)
+func containerBuild(t *testing.T, prog, dockerFile, ref, contextPath, baseImage, homeDir string) {
+	t.Run("build/"+ref, e2e.Privileged(func(t *testing.T) {
+		cmd := exec.Command(prog, "build", "--network=host",
+			"--build-arg", "BASEIMAGE="+baseImage,
+			"-t", ref, "-f", dockerFile, contextPath)
 		cmd.Env = append(cmd.Env, "HOME="+homeDir)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
-			t.Fatalf("Failed building docker container.\n%s: %s", err, string(out))
+			t.Fatalf("Failed building %s container.\n%s: %s", prog, err, string(out))
 		}
 	}))
 }
 
-func dockerRMI(t *testing.T, dockerRef, homeDir string) {
-	t.Run("rmi/"+dockerRef, e2e.Privileged(func(t *testing.T) {
-		cmd := exec.Command("docker", "rmi", dockerRef)
+func containerRMI(t *testing.T, prog, ref, homeDir string) {
+	t.Run("rmi/"+ref, e2e.Privileged(func(t *testing.T) {
+		cmd := exec.Command(prog, "rmi", ref)
 		cmd.Env = append(cmd.Env, "HOME="+homeDir)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
-			t.Fatalf("Failed removing docker container.\n%s: %s", err, string(out))
+			t.Fatalf("Failed removing %s container.\n%s: %s", prog, err, string(out))
 		}
 	}))
 }
 
-func dockerRunPrivileged(t *testing.T, name, dockerRef, homeDir string, args ...string) { //nolint:unparam
+func containerRun(t *testing.T, prog, name, ref, homeDir string, args ...string) { //nolint:unparam
 	t.Run(name, e2e.Privileged(func(t *testing.T) {
-		cmdArgs := []string{"run", "-i", "--rm", "--privileged", "--network=host", dockerRef}
+		cwd, _ := os.Getwd()
+		cmdArgs := []string{
+			"run", "-i", "--rm", "--privileged", "--network=host",
+			"-v", "/usr/local:/usr/local",
+			"-v", cwd + ":/e2e",
+			ref,
+		}
 		cmdArgs = append(cmdArgs, args...)
-		cmd := exec.Command("docker", cmdArgs...)
+		cmd := exec.Command(prog, cmdArgs...)
 		cmd.Env = append(cmd.Env, "HOME="+homeDir)
 		out, err := cmd.CombinedOutput()
 		t.Log(cmd.Args)
 		if err != nil {
-			t.Fatalf("Failed running docker container.\n%s: %s", err, string(out))
+			t.Fatalf("Failed running %s container.\n%s: %s", prog, err, string(out))
 		}
 	}))
 }
 
 //nolint:dupl
 func (c ctx) podman(t *testing.T) {
-	require.Command(t, "podman")
-	e2e.EnsureORASImage(t, c.env)
-
-	// Temporary homedir for docker commands, so invoking docker doesn't create
-	// a ~/.docker that may interfere elsewhere.
-	tmpHome, cleanupHome := e2e.MakeTempDir(t, c.env.TestDir, "nested-docker-", "")
-	t.Cleanup(func() { e2e.Privileged(cleanupHome)(t) })
-
-	dockerFile := "testdata/Dockerfile.nested"
-	dockerRef := "localhost/apptainer-e2e-podman-nested"
-	podmanBuild(t, dockerFile, dockerRef, "../", tmpHome)
-	defer podmanRMI(t, dockerRef, tmpHome)
-
 	// Rootless podman - fake userns root in outer podman container.
-	podmanRun(t, "version", dockerRef, tmpHome)
-	podmanRun(t, "exec", dockerRef, tmpHome, "exec", c.env.OrasTestImage, "/bin/true")
-	podmanRun(t, "execUserNS", dockerRef, tmpHome, "exec", "-u", c.env.OrasTestImage, "/bin/true")
-	podmanRun(t, "buildSIF", dockerRef, tmpHome, "build", "test.sif", "apptainer/examples/library/Apptainer")
-}
-
-func podmanBuild(t *testing.T, dockerFile, dockerRef, contextPath, homeDir string) {
-	t.Run("build/"+dockerRef, func(t *testing.T) {
-		cmd := exec.Command("podman", "build",
-			"--build-arg", "GOVERSION="+runtime.Version(),
-			"--build-arg", "GOOS="+runtime.GOOS,
-			"--build-arg", "GOARCH="+runtime.GOARCH,
-			"-t", dockerRef, "-f", dockerFile, contextPath)
-		cmd.Env = append(cmd.Env, "HOME="+homeDir)
-		out, err := cmd.CombinedOutput()
-		t.Log(cmd.Args)
-		if err != nil {
-			t.Fatalf("Failed building podman container.\n%s: %s", err, string(out))
-		}
-	})
-}
-
-func podmanRMI(t *testing.T, dockerRef, homeDir string) {
-	t.Run("rmi/"+dockerRef, func(t *testing.T) {
-		cmd := exec.Command("podman", "rmi", dockerRef)
-		cmd.Env = append(cmd.Env, "HOME="+homeDir)
-		out, err := cmd.CombinedOutput()
-		t.Log(cmd.Args)
-		if err != nil {
-			t.Fatalf("Failed removing podman container.\n%s: %s", err, string(out))
-		}
-	})
-}
-
-func podmanRun(t *testing.T, name, dockerRef, homeDir string, args ...string) { //nolint:unparam
-	t.Run(name, func(t *testing.T) {
-		cmdArgs := []string{"run", "-i", "--rm", "--privileged", "--network=host", dockerRef}
-		cmdArgs = append(cmdArgs, args...)
-		cmd := exec.Command("podman", cmdArgs...)
-		cmd.Env = append(cmd.Env, "HOME="+homeDir)
-		out, err := cmd.CombinedOutput()
-		t.Log(cmd.Args)
-		if err != nil {
-			t.Fatalf("Failed running podman container.\n%s: %s", err, string(out))
-		}
-	})
+	c.nestedContainerTest(t, "podman", "localhost/apptainer-e2e-podman-nested")
 }
 
 // E2ETests is the main func to trigger the test suite

--- a/e2e/nested/nested.go
+++ b/e2e/nested/nested.go
@@ -1,3 +1,7 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
 // Copyright (c) 2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
@@ -108,7 +112,6 @@ func (c ctx) podman(t *testing.T) {
 func podmanBuild(t *testing.T, dockerFile, dockerRef, contextPath, homeDir string) {
 	t.Run("build/"+dockerRef, func(t *testing.T) {
 		cmd := exec.Command("podman", "build",
-			"--runtime=runc", // ubuntu22.04 crun is buggy
 			"--build-arg", "GOVERSION="+runtime.Version(),
 			"--build-arg", "GOOS="+runtime.GOOS,
 			"--build-arg", "GOARCH="+runtime.GOARCH,

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -3,7 +3,7 @@
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
 // Copyright (c) 2020, Control Command Inc. All rights reserved.
-// Copyright (c) 2019-2022 Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2025 Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -42,6 +42,7 @@ import (
 	"github.com/apptainer/apptainer/e2e/key"
 	"github.com/apptainer/apptainer/e2e/keyserver"
 	"github.com/apptainer/apptainer/e2e/legacy"
+	"github.com/apptainer/apptainer/e2e/nested"
 	"github.com/apptainer/apptainer/e2e/oci"
 	"github.com/apptainer/apptainer/e2e/overlay"
 	"github.com/apptainer/apptainer/e2e/plugin"
@@ -226,6 +227,7 @@ func Run(t *testing.T) {
 	suite.AddGroup("KEY", key.E2ETests)
 	suite.AddGroup("KEYSERVER", keyserver.E2ETests)
 	suite.AddGroup("LEGACY", legacy.E2ETests)
+	suite.AddGroup("NESTED", nested.E2ETests)
 	suite.AddGroup("OCI", oci.E2ETests)
 	suite.AddGroup("OVERLAY", overlay.E2ETests)
 	suite.AddGroup("PLUGIN", plugin.E2ETests)

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -168,6 +168,8 @@ func Run(t *testing.T) {
 	testenv.SingularityImagePath = path.Join(name, "test-singularity.sif")
 	defer os.Remove(testenv.SingularityImagePath)
 
+	testenv.DebianImageSource = e2e.GetDebianImageSource(t)
+
 	testenv.DebianImagePath = path.Join(name, "test-debian.sif")
 	defer os.Remove(testenv.DebianImagePath)
 

--- a/e2e/testdata/Dockerfile.nested
+++ b/e2e/testdata/Dockerfile.nested
@@ -1,0 +1,40 @@
+FROM ubuntu:24.04
+
+ARG GOVERSION="go1.25.6"
+ARG GOOS="linux"
+ARG GOARCH="amd64"
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system packages
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+	libsubid-dev \
+	libseccomp-dev \
+	uidmap \
+	fakeroot \
+	cryptsetup \
+	tzdata \
+	dh-apparmor \
+	curl wget git && \
+    apt-get install -y \
+	autoconf automake libtool pkg-config libfuse3-dev \
+	zlib1g-dev liblzo2-dev liblz4-dev liblzma-dev libzstd-dev
+
+# Install GO
+RUN wget -O /tmp/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz https://go.dev/dl/${GOVERSION}.${GOOS}-${GOARCH}.tar.gz && tar -C /usr/local -xzf /tmp/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz
+
+# Install Apptainer
+ADD . apptainer
+RUN cd apptainer && \
+    git clean -fdx && \
+    ./mconfig && \
+    make -C builddir && \
+    make -C builddir install && \
+    ./scripts/download-dependencies && \
+    ./scripts/compile-dependencies && \
+    ./scripts/install-dependencies
+
+ENTRYPOINT ["/usr/local/bin/apptainer"]
+CMD ["version"]

--- a/e2e/testdata/Dockerfile.nested
+++ b/e2e/testdata/Dockerfile.nested
@@ -12,6 +12,9 @@ RUN apt-get update && \
         build-essential \
 	libsubid-dev \
 	libseccomp-dev \
+	libtalloc-dev \
+	libattr1-dev \
+	libprotobuf-c-dev \
 	uidmap \
 	fakeroot \
 	cryptsetup \
@@ -29,7 +32,7 @@ RUN wget -O /tmp/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz https://go.dev/dl/${GO
 ADD . apptainer
 RUN cd apptainer && \
     git clean -fdx && \
-    ./mconfig && \
+    ./mconfig --with-suid && \
     make -C builddir && \
     make -C builddir install && \
     ./scripts/download-dependencies && \

--- a/e2e/testdata/Dockerfile.nested
+++ b/e2e/testdata/Dockerfile.nested
@@ -1,43 +1,21 @@
-FROM ubuntu:24.04
+ARG BASEIMAGE="ubuntu:latest"
+FROM ${BASEIMAGE}
 
-ARG GOVERSION="go1.25.6"
-ARG GOOS="linux"
-ARG GOARCH="amd64"
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install system packages
+# Install libraries needed by bundled Apptainer dependencies
+# and essential Apptainer operation
 RUN apt-get update && \
     apt-get install -y \
-        build-essential \
-	libsubid-dev \
-	libseccomp-dev \
-	libtalloc-dev \
-	libattr1-dev \
-	libprotobuf-c-dev \
-	uidmap \
-	fakeroot \
-	cryptsetup \
+	ca-certificates \
 	tzdata \
-	dh-apparmor \
-	curl wget git && \
-    apt-get install -y \
-	autoconf automake libtool pkg-config libfuse3-dev \
-	zlib1g-dev liblzo2-dev liblz4-dev liblzma-dev libzstd-dev
-
-# Install GO
-RUN wget -O /tmp/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz https://go.dev/dl/${GOVERSION}.${GOOS}-${GOARCH}.tar.gz && tar -C /usr/local -xzf /tmp/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz
-
-# Install Apptainer
-ADD . apptainer
-RUN cd apptainer && \
-    git clean -fdx && \
-    ./mconfig --with-suid && \
-    make -C builddir && \
-    make -C builddir install && \
-    ./scripts/download-dependencies && \
-    ./scripts/compile-dependencies && \
-    ./scripts/install-dependencies
+	libfuse3-dev \
+	liblzma-dev \
+	liblzo2-dev \
+	liblz4-dev \
+	libzstd-dev \
+	zlib1g-dev
 
 ENTRYPOINT ["/usr/local/bin/apptainer"]
 CMD ["version"]


### PR DESCRIPTION
This imports and modifies sylabs/singularity#3545.  It eliminates duplicated code and makes the tests import the already built apptainer into the nested container rather than building it again. It also updates the e2e tests to run under ubuntu24.04.

The relevant part of the description in the original PR was
> Basic testing of minimal container build and execution nested under privileged docker, and rootless podman.

Fixes one of the items in #3580.