### PR TITLE
Bind getopt from the host for fakeroot command mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ Changes since 1.5.x
 - If the `ptrace()` system call does not work while building an image as
   an unprivileged user, skip using PRoot to preserve file ownership and
   print an INFO message.
+- Bind `getopt` from the host when using fakeroot command mode, to make
+  the fakeroot command work with EL10 and Fedora base containers which
+  no longer contain getopt by default.
 
 ## v1.5.2 - \[2026-06-23\]
 

--- a/e2e/imgbuild/imgbuild.go
+++ b/e2e/imgbuild/imgbuild.go
@@ -2052,6 +2052,15 @@ func (c *imgBuildTests) testContainerBuildUnderFakerootModes(t *testing.T) {
 		e2e.ExpectExit(0),
 	)
 
+	// also test recent redhat in mode 3 to make sure getopt is bound in
+	c.env.RunApptainer(
+		t,
+		e2e.WithProfile(e2e.UserProfile),
+		e2e.WithCommand("build"),
+		e2e.WithArgs("--force", "--build-arg", "FROMIMAGE=fedora:latest", "--userns", "--ignore-subuid", fmt.Sprintf("%s/openssh-mode3b.sif", tmpDir), "testdata/redhat_build.def"),
+		e2e.ExpectExit(0),
+	)
+
 	// running under the mode 4(https://apptainer.org/docs/user/main/fakeroot.html)
 	c.env.RunApptainer(
 		t,

--- a/e2e/testdata/redhat_build.def
+++ b/e2e/testdata/redhat_build.def
@@ -1,0 +1,5 @@
+Bootstrap: docker
+From: {{ FROMIMAGE }}
+
+%post
+    dnf install -y openssh-clients

--- a/internal/pkg/fakeroot/fakefake.go
+++ b/internal/pkg/fakeroot/fakefake.go
@@ -97,6 +97,34 @@ func GetFakeArgs() []string {
 	}
 }
 
+// Given an existing environment, modify it as needed to successfully
+// execute the fakeroot command.  If cleanLdLibraryPath is true, also
+// remove any existing $LD_LIBRARY_PATH variable.
+func GetFakeEnviron(environ []string, cleanLdLibraryPath bool) []string {
+	hasPath := false
+	for idx := range environ {
+		if cleanLdLibraryPath && strings.HasPrefix(environ[idx], "LD_LIBRARY_PATH=") {
+			// Remove any incoming LD_LIBRARY_PATH
+			environ[idx] = "LD_LIBRARY_PATH="
+		} else if strings.HasPrefix(environ[idx], "PATH=") && environ[idx] != "PATH=" {
+			hasPath = true
+			// Append /:singularity.d/libs to the PATH for getopt
+			environ[idx] = environ[idx] + ":/.singularity.d/libs"
+		}
+	}
+	if !hasPath {
+		environ = append(environ, "PATH="+env.DefaultPath+":/.singularity.d/libs")
+	}
+
+	// Without this workaround fakeroot does not work
+	//  properly in a user namespace. It is especially
+	//  noticeable with debian containers.  Learned from
+	//  https://salsa.debian.org/clint/fakeroot/-/merge_requests/4
+	environ = append(environ, "FAKEROOTDONTTRYCHOWN=1")
+
+	return environ
+}
+
 // Get the binds needed to map the fakeroot command into the container
 // The incoming parameter is the path to fakeroot
 func GetFakeBinds(fakerootPath string) ([]string, error) {
@@ -109,29 +137,19 @@ func GetFakeBinds(fakerootPath string) ([]string, error) {
 
 	if fakerootPath == args[0] {
 		// The binding has already been done, this is for nesting
+		// Include getopt if it was included previously
+		if _, err := os.Stat("/.singularity.d/libs/getopt"); err == nil {
+			binds = append(binds, "/.singularity.d/libs/getopt")
+		}
 		return binds, nil
 	}
 
 	// Start by examining the environment fakeroot creates
 	cmd := osExec.Command(fakerootPath, "env")
-	environ := os.Environ()
-	hasPath := false
-	for idx := range environ {
-		if strings.HasPrefix(environ[idx], "LD_LIBRARY_PATH=") {
-			// Remove any incoming LD_LIBRARY_PATH
-			environ[idx] = "LD_LIBRARY_PATH="
-		} else if strings.HasPrefix(environ[idx], "PATH=") &&
-			environ[idx] != "PATH=" {
-			hasPath = true
-		}
-	}
-	if !hasPath {
-		environ = append(environ, "PATH="+env.DefaultPath)
-	}
-	cmd.Env = environ
+	cmd.Env = GetFakeEnviron(os.Environ(), true)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return binds, fmt.Errorf("error make fakeroot stdout pipe: %v", err)
+		return binds, fmt.Errorf("error making fakeroot stdout pipe: %v", err)
 	}
 
 	err = cmd.Start()
@@ -189,6 +207,12 @@ func GetFakeBinds(fakerootPath string) ([]string, error) {
 			binds[2] = src + ":" + point
 			break
 		}
+	}
+	// Check if getopt exists and add it to binds if it does
+	if getoptPath, err := bin.FindBin("getopt"); err == nil {
+		binds = append(binds, getoptPath+":/.singularity.d/libs/getopt")
+	} else {
+		sylog.Infof("getopt not found; could interfere with fakeroot command")
 	}
 	return binds, nil
 }

--- a/internal/pkg/runtime/engine/apptainer/process_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/process_linux.go
@@ -945,11 +945,7 @@ func runActionScript(engineConfig *apptainerConfig.EngineConfig) ([]string, []st
 		sylog.Verbosef("Running command with %v", filepath.Base(fakerootPath))
 		args = append(fakeargs, args...)
 
-		// Without this workaround fakeroot does not work
-		//  properly in a user namespace. It is especially
-		//  noticeable with debian containers.  Learned from
-		//  https://salsa.debian.org/clint/fakeroot/-/merge_requests/4
-		penv = append(penv, "FAKEROOTDONTTRYCHOWN=1")
+		penv = fakeroot.GetFakeEnviron(penv, false)
 
 		if engineConfig.GetFakerootPath() == "" {
 			// Must be joining an instance, so also set BIND

--- a/internal/pkg/util/bin/bin.go
+++ b/internal/pkg/util/bin/bin.go
@@ -57,6 +57,7 @@ func FindBin(name string) (path string, err error) {
 		"fakeroot-sysv",
 		"fuse-overlayfs",
 		"fuse2fs",
+		"getopt",
 		"go",
 		"mksquashfs",
 		"newgidmap",

--- a/tools/install-unprivileged.sh
+++ b/tools/install-unprivileged.sh
@@ -318,7 +318,7 @@ if ! rmdir usr; then
 	fatal "error removing usr"
 fi
 
-OSUTILS=""
+OSUTILS="util-linux"
 NEEDSFUSE2FS=true
 LIBEXEC=libexec
 if [ "$DIST" == suse15 ] || [ "$DIST" == opensuse-leap ]; then
@@ -456,7 +456,7 @@ mv tmp/usr/lib*/* utils/lib
 mv tmp/lib*/* utils/lib 2>/dev/null || true # optional
 mv tmp/usr/*bin/*squashfs utils/libexec
 mv tmp/usr/*bin/fuse* utils/libexec 2>/dev/null || true # optional
-mv tmp/usr/bin/fake*sysv utils/bin
+mv tmp/usr/bin/fake*sysv tmp/usr/bin/getopt utils/bin
 cat >utils/bin/.wrapper <<'!EOF!'
 #!/bin/bash
 BASEME=${0##*/}


### PR DESCRIPTION
The fakeroot command uses getopt, but getopt is not installed in EL10 and Fedora base containers by default.  So bind it in from the host if possible.  Also include getopt in unprivileged installs.

- Fixes #3629