### PR TITLE
Default to /var/tmp if /tmp is on tmpfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes since 1.5.x
 - Add a `sync writable extfs` directive to apptainer.conf. When enabled,
   writable extfs image mounts use the `sync` mount option.
 - Added support for NVIDIA Tegra to `nvliblist.conf`
+- The `APPTAINER_TMPDIR` now defaults to /var/tmp, if /tmp is on tmpfs.
 
 ## v1.5.x changes
 

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -10,8 +10,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/apptainer/apptainer/pkg/cmdline"
 )
 
@@ -317,7 +315,7 @@ var actionFuseMountFlag = cmdline.Flag{
 var actionTmpDirFlag = cmdline.Flag{
 	ID:           "actionTmpDirFlag",
 	Value:        &tmpDir,
-	DefaultValue: os.TempDir(),
+	DefaultValue: tempDir(),
 	Name:         "tmpdir",
 	Usage:        "specify a temporary directory to use for build",
 	Hidden:       true,

--- a/cmd/internal/cli/apptainer.go
+++ b/cmd/internal/cli/apptainer.go
@@ -251,7 +251,7 @@ var commonOldNoHTTPSFlag = cmdline.Flag{
 var commonTmpDirFlag = cmdline.Flag{
 	ID:           "commonTmpDirFlag",
 	Value:        &tmpDir,
-	DefaultValue: os.TempDir(),
+	DefaultValue: tempDir(),
 	Hidden:       true,
 	Name:         "tmpdir",
 	Usage:        "specify a temporary directory to use for build",

--- a/cmd/internal/cli/fs_linux.go
+++ b/cmd/internal/cli/fs_linux.go
@@ -1,0 +1,37 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// tempDir returns the default directory to use for temporary files.
+// it is a replacement for os.TempDir() that does not return a tmpfs.
+func tempDir() string {
+	dir := os.Getenv("TMPDIR")
+	if dir == "" {
+		dir = "/tmp"
+		tmpfs, err := isTmpFS(dir)
+		if err == nil && tmpfs {
+			dir = "/var/tmp"
+		}
+	}
+	return dir
+}
+
+func isTmpFS(path string) (bool, error) {
+	var sf unix.Statfs_t
+	if err := unix.Statfs(path, &sf); err != nil {
+		return false, err
+	}
+	return sf.Type == unix.TMPFS_MAGIC, nil
+}


### PR DESCRIPTION
The tmpfs mount on /tmp by systemd typically has "nodev" and is too small for use by Apptainer. Use /var/tmp instead.

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.


### This fixes or addresses the following GitHub issues:

 - Fixes #3657


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
