### PR TITLE
disable record length test in mount string parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Changes since 1.5.x
 
 - Fix the help text for the `--mount` option not wrapping at 80 columns,
   by using the shorter `src` and `dst` aliases in the example.
+- Fixed a bug that prevented multiple mount entries in the `APPTAINER_MOUNT`
+  env var from having different numbers of options.
 
 ## v1.5.3 - \[2026-07-21\]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -119,6 +119,7 @@
 - Richard Neuboeck <hawk@tbi.univie.ac.at>
 - Rémy Dernat <remy.dernat@umontpellier.fr>
 - Robert Clarke <robert.clarke@bristol.ac.uk>
+- Robin Heinemann <robin.ole.heinemann@gmail.com>
 - Rushil Patel <rushil.patel@gsacapital.com>
 - Sasha Yakovtseva <sasha@sylabs.io>, <sashayakovtseva@gmail.com>
 - Satish Chebrolu  <satish@sylabs.io>

--- a/pkg/runtime/engine/apptainer/config/mount.go
+++ b/pkg/runtime/engine/apptainer/config/mount.go
@@ -32,6 +32,7 @@ import (
 func ParseMountString(mount string) (bindPaths []BindPath, err error) {
 	r := strings.NewReader(mount)
 	c := csv.NewReader(r)
+	c.FieldsPerRecord = -1
 	records, err := c.ReadAll()
 	if err != nil {
 		return []BindPath{}, fmt.Errorf("error parsing mount: %v", err)

--- a/pkg/runtime/engine/apptainer/config/mount_test.go
+++ b/pkg/runtime/engine/apptainer/config/mount_test.go
@@ -241,6 +241,25 @@ func TestParseMountString(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:        "multipleDifferentLength",
+			mountString: "type=bind,source=/opt,destination=/opt\ntype=bind,source=/srv,destination=/srv,ro",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/opt",
+					Options:     map[string]*BindOption{},
+				},
+				{
+					Source:      "/srv",
+					Destination: "/srv",
+					Options: map[string]*BindOption{
+						"ro": {},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This allows for multiple entries in `APPTAINER_MOUNT` with different number of options. See the added test for an example. 

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
