### PR TITLE
Fix the usage wrapping issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ Changes since 1.5.x
 
 ## v1.5.x changes
 
+- Fix the help text for the `--mount` option not wrapping at 80 columns,
+  by using the shorter `src` and `dst` aliases in the example.
+
 ## v1.5.3 - \[2026-07-21\]
 
 - If the `ptrace()` system call does not work while building an image as

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -129,7 +129,7 @@ var actionMountFlag = cmdline.Flag{
 	Value:        &mounts,
 	DefaultValue: cmdline.StringArray{},
 	Name:         "mount",
-	Usage:        "a mount specification e.g. 'type=bind,source=/opt,destination=/hostopt'.  The 'nonested' flag prevents the mount from being passed to nested containers via APPTAINER_BIND.",
+	Usage:        "a mount specification e.g. 'type=bind,src=/opt,dst=/hostopt'.",
 	EnvKeys:      []string{"MOUNT"},
 	Tag:          "<spec>",
 	EnvHandler:   cmdline.EnvAppendValue,

--- a/cmd/internal/cli/build.go
+++ b/cmd/internal/cli/build.go
@@ -267,7 +267,7 @@ var buildMountFlag = cmdline.Flag{
 	Value:        &buildArgs.mounts,
 	DefaultValue: cmdline.StringArray{}, // to allow commas in bind path
 	Name:         "mount",
-	Usage:        "a mount specification e.g. 'type=bind,source=/opt,destination=/hostopt'.",
+	Usage:        "a mount specification e.g. 'type=bind,src=/opt,dst=/hostopt'.",
 	EnvKeys:      []string{"MOUNT"},
 	Tag:          "<spec>",
 	EnvHandler:   cmdline.EnvAppendValue,

--- a/cmd/internal/cli/usage_test.go
+++ b/cmd/internal/cli/usage_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// helpColumns is the width that docs.HelpTemplate wraps flag usage output to.
+const helpColumns = 80
+
+// TestFlagUsageWrapping checks that the flag usage shown by --help fits within
+// helpColumns.
+//
+// pflag stops wrapping the remainder of a usage string as soon as it meets a
+// word that is wider than the description column, so a long example in the
+// middle of a usage string silently turns wrapping off for all the text that
+// follows it.
+func TestFlagUsageWrapping(t *testing.T) {
+	// Init is not idempotent, and another test in this package may have
+	// called it already.
+	if ExecCmd.Flags().Lookup("mount") == nil {
+		Init(false)
+	}
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{"exec", ExecCmd},
+		{"shell", ShellCmd},
+		{"run", RunCmd},
+		{"build", buildCmd},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usage := tt.cmd.LocalFlags().FlagUsagesWrapped(helpColumns)
+			for _, line := range strings.Split(usage, "\n") {
+				line = strings.TrimRight(line, " ")
+				if len(line) > helpColumns {
+					t.Errorf("flag usage is %d columns, expected at most %d:\n%s",
+						len(line), helpColumns, line)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

As #3668 suggested, there's an issue with the usage string added by #3501.

The issue is on the pflag side (https://github.com/spf13/pflag/issues/501), but let's patch this quickly one apptainer's side.


The trick: by using src/dst aliases, we can prevent it from triggering the unwrapped remainder string logic.


### This fixes or addresses the following GitHub issues:

 - Fixes #3668


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
