### PR TITLE
Add --writable-tmpfs-size argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.5.x
 
+- Add a `--writable-tmpfs-size` option, and a corresponding
+  `APPTAINER_WRITABLE_TMPFS_SIZE` environment variable, to override the
+  `sessiondir max size` directive that limits `--writable-tmpfs`. It is
+  ignored when running setuid, where the session directory size is set by
+  the administrator.
 - Update minimum go version to 1.26.5.
 - Add support for variant to more architectures, but without verification.
   The previous arm32v5, arm32v6 and arm32v7 (= "arm") are still verified.

--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -85,6 +85,7 @@ var (
 	memorySwap        string // bytes
 	oomKillDisable    bool
 	pidsLimit         int
+	writableTmpfsSize uint32
 	unsquash          bool
 
 	ignoreSubuid      bool
@@ -435,6 +436,17 @@ var actionWritableTmpfsFlag = cmdline.Flag{
 	Name:         "writable-tmpfs",
 	Usage:        "makes the file system accessible as read-write with non persistent data (with overlay support only)",
 	EnvKeys:      []string{"WRITABLE_TMPFS"},
+}
+
+// --writable-tmpfs-size
+var actionWritableTmpfsSizeFlag = cmdline.Flag{
+	ID:           "actionWritableTmpfsSizeFlag",
+	Value:        &writableTmpfsSize,
+	DefaultValue: uint32(0),
+	Name:         "writable-tmpfs-size",
+	Usage:        "size in MiB of the tmpfs used by --writable-tmpfs, overriding the 'sessiondir max size' directive.  Zero uses the configured size.  Ignored when running setuid.",
+	EnvKeys:      []string{"WRITABLE_TMPFS_SIZE"},
+	Tag:          "<MiB>",
 }
 
 // --no-home
@@ -965,6 +977,7 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&actionWorkdirFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionWritableFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&actionWritableTmpfsFlag, actionsInstanceCmd...)
+		cmdManager.RegisterFlagForCmd(&actionWritableTmpfsSizeFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonNoHTTPSFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&commonOldNoHTTPSFlag, actionsInstanceCmd...)
 		cmdManager.RegisterFlagForCmd(&dockerLoginFlag, actionsInstanceCmd...)

--- a/cmd/internal/cli/actions.go
+++ b/cmd/internal/cli/actions.go
@@ -317,6 +317,7 @@ func launchContainer(cmd *cobra.Command, image string, args []string, instanceNa
 	opts := []launch.Option{
 		launch.OptWritable(isWritable),
 		launch.OptWritableTmpfs(isWritableTmpfs),
+		launch.OptWritableTmpfsSize(writableTmpfsSize),
 		launch.OptOverlayPaths(overlayPath),
 		launch.OptScratchDirs(scratchPath),
 		launch.OptWorkDir(workdirPath),

--- a/e2e/actions/actions.go
+++ b/e2e/actions/actions.go
@@ -3331,6 +3331,7 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"fuse mount":                   c.fuseMount,             // test fusemount option
 		"bind image":                   c.bindImage,             // test bind image with --bind and --mount
 		"unsquash":                     c.actionUnsquash,        // test --unsquash
+		"writable-tmpfs-size":          c.actionTmpfsSize,       // test --writable-tmpfs-size
 		"no-mount":                     c.actionNoMount,         // test --no-mount
 		"compat":                       np(c.actionCompat),      // test --compat
 		"umask":                        np(c.actionUmask),       // test umask propagation
@@ -3339,5 +3340,54 @@ func E2ETests(env e2e.TestEnv) testhelper.Tests {
 		"relWorkdirScratch":            np(c.relWorkdirScratch), // test relative --workdir with --scratch
 		"issue 1868":                   c.issue1868,             // https://github.com/apptainer/apptainer/issues/1868
 		"auth":                         np(c.actionAuth),        // tests action cmds w/authenticated pulls from OCI registries
+	}
+}
+
+// actionTmpfsSize checks that --writable-tmpfs-size raises the limit
+// that 'sessiondir max size' otherwise places on a --writable-tmpfs overlay.
+// The directive is only consulted when the session tmpfs is mounted
+// unprivileged, so these run in a user namespace.
+// https://github.com/apptainer/apptainer/issues/1313
+func (c actionTests) actionTmpfsSize(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	require.Filesystem(t, "overlay")
+
+	tests := []struct {
+		name     string
+		args     []string
+		exitCode int
+	}{
+		{
+			// The default 'sessiondir max size' is 64 MiB, so 100 MiB
+			// must not fit.
+			name:     "default too small",
+			args:     []string{"--writable-tmpfs"},
+			exitCode: 1,
+		},
+		{
+			name:     "size raised",
+			args:     []string{"--writable-tmpfs", "--writable-tmpfs-size", "256"},
+			exitCode: 0,
+		},
+		{
+			// Without --writable-tmpfs there is no overlay to size, so the
+			// container is read-only and the write fails whatever the size.
+			name:     "ignored without writable tmpfs",
+			args:     []string{"--writable-tmpfs-size", "256"},
+			exitCode: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		args := append(tt.args, c.env.ImagePath, "dd", "if=/dev/zero", "of=/test", "bs=1M", "count=100")
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserNamespaceProfile),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(args...),
+			e2e.ExpectExit(tt.exitCode),
+		)
 	}
 }

--- a/internal/pkg/runtime/launch/launcher_linux.go
+++ b/internal/pkg/runtime/launch/launcher_linux.go
@@ -263,6 +263,8 @@ func (l *Launcher) Exec(ctx context.Context, image string, args []string, instan
 		l.engineConfig.SetWritableTmpfs(l.cfg.WritableTmpfs)
 	}
 
+	l.setWritableTmpfsSize()
+
 	// Additional user requested library binds into /.singularity.d/libs.
 	l.engineConfig.AppendLibrariesPath(l.cfg.ContainLibs...)
 
@@ -1350,6 +1352,38 @@ func hidepidProc() bool {
 		}
 	}
 	return false
+}
+
+// setWritableTmpfsSize applies a --writable-tmpfs-size request by overriding
+// the 'sessiondir max size' directive, which sizes the tmpfs holding the
+// session directory and hence the --writable-tmpfs overlay.
+//
+// It must be called after the value of --writable-tmpfs has settled, because
+// --compat and --nvccli can turn it on, and --writable turns it back off.
+func (l *Launcher) setWritableTmpfsSize() {
+	if l.cfg.WritableTmpfsSize == 0 {
+		return
+	}
+
+	// The overlay is what the size is being asked about, so leave the
+	// administrator's value alone if there is not going to be one. The session
+	// directory is used for other things, and resizing it here would be a
+	// surprising thing for this option to do.
+	if !l.engineConfig.GetWritableTmpfs() {
+		sylog.Warningf("Ignoring --writable-tmpfs-size, it only applies together with --writable-tmpfs")
+		return
+	}
+
+	// The engine only consults the directive when the session tmpfs is mounted
+	// unprivileged. Under the setuid workflow it is mounted by root and left
+	// unlimited, so there is nothing to raise.
+	if buildcfg.APPTAINER_SUID_INSTALL == 1 && l.engineConfig.File.AllowSetuid && !l.cfg.Namespaces.User {
+		sylog.Warningf("Ignoring --writable-tmpfs-size, the session directory size is set by the administrator when running setuid")
+		return
+	}
+
+	sylog.Debugf("Setting session directory size to %d MiB", l.cfg.WritableTmpfsSize)
+	l.engineConfig.File.SessiondirMaxSize = uint(l.cfg.WritableTmpfsSize)
 }
 
 // convertImage extracts the image found at filename to directory dir within a temporary directory

--- a/internal/pkg/runtime/launch/options.go
+++ b/internal/pkg/runtime/launch/options.go
@@ -33,6 +33,9 @@ type launchOptions struct {
 	Writable bool
 	// WritableTmpfs applies an ephemeral writable overlay to the container.
 	WritableTmpfs bool
+	// WritableTmpfsSize overrides the 'sessiondir max size' directive, in MiB,
+	// for the tmpfs backing WritableTmpfs. Zero means use the configured value.
+	WritableTmpfsSize uint32
 	// OverlayPaths holds paths to image or directory overlays to be applied.
 	OverlayPaths []string
 	// Scratchdir lists paths into the container to be mounted from a temporary location on the host.
@@ -204,6 +207,15 @@ func OptWritable(b bool) Option {
 func OptWritableTmpfs(b bool) Option {
 	return func(lo *launchOptions) error {
 		lo.WritableTmpfs = b
+		return nil
+	}
+}
+
+// OptWritableTmpfsSize sets the size, in MiB, of the tmpfs backing an
+// ephemeral writable overlay. Zero leaves the configured size in place.
+func OptWritableTmpfsSize(s uint32) Option {
+	return func(lo *launchOptions) error {
+		lo.WritableTmpfsSize = s
 		return nil
 	}
 }

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -331,7 +331,9 @@ mount slave = {{ if eq .MountSlave true }}yes{{ else }}no{{ end }}
 # This specifies how large the default sessiondir should be (in MB). It will
 # affect users who use the "--contain" options and don't also specify a
 # location to do default read/writes to (e.g. "--workdir" or "--home") and
-# it will also affect users of "--writable-tmpfs".
+# it will also affect users of "--writable-tmpfs". Unprivileged users can
+# override it with the "--writable-tmpfs-size" option, which has no effect
+# when running setuid.
 sessiondir max size = {{ .SessiondirMaxSize }}
 
 # *****************************************************************************


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds `--writable-tmpfs-size` argument to control the size of the disposable overlay that is created, simialar how #1313 and https://github.com/apptainer/singularity/issues/5718 discussed.


This would be particularly useful for one-line commands. While `--overlay` offers similar functionality, it requires manually running `mkdir /tmp/overlay` (or `apptainer overlay create`), launching Apptainer, and then performing cleanup. The cleanup process is especially tricky with `--fakeroot`, as it can create files owned by sub-UIDs that a standard `rm` cannot delete (I have to do this multiple times a day).

In my experience, increasing the `tmpfs` size to 10GB in `apptainer.conf` was a helpful workaround, but it requires creating a custom configuration file and setting `APPTAINER_CONFIGDIR`.

It would be ideal to have direct control over the size via command-line arguments, especially since everything runs in userspace for non-setuid installations. A feature similar to `docker run --rm` that automatically cleans up leftovers would be incredibly helpful.


### This fixes or addresses the following GitHub issues:

 - Fixes #1313


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
