### PR TITLE
Add make target for debugging apptainer cli rst documentation

### DIFF
--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -101,7 +101,7 @@ $(remote_config_INSTALL): $(remote_config)
 INSTALLFILES += $(remote_config_INSTALL)
 
 man_pages := $(BUILDDIR_ABSPATH)$(MANDIR)/man1
-$(man_pages): apptainer
+$(man_pages): $(apptainer)
 	@echo " MAN" $@
 	mkdir -p $@
 	$(V)cd $(SOURCEDIR) && $(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" \

--- a/mlocal/frags/build_cli.mk
+++ b/mlocal/frags/build_cli.mk
@@ -100,6 +100,13 @@ $(remote_config_INSTALL): $(remote_config)
 
 INSTALLFILES += $(remote_config_INSTALL)
 
+rst_docs := $(BUILDDIR_ABSPATH)$(DOCDIR)/cli
+$(rst_docs): $(apptainer)
+	@echo " DOC" $@
+	mkdir -p $@
+	$(V)cd $(SOURCEDIR) && $(GO) run $(GO_MODFLAGS) -tags "$(GO_TAGS)" \
+		cmd/docs/docs.go rst --dir $@
+
 man_pages := $(BUILDDIR_ABSPATH)$(MANDIR)/man1
 $(man_pages): $(apptainer)
 	@echo " MAN" $@


### PR DESCRIPTION
## Description of the Pull Request (PR):

The documentation is generated (by admin-userdocs) from apptainer as a submodule:

https://apptainer.org/docs/user/main/cli.html

But there is no good way to generate the documentation in apptainer, for debugging...

There are some issues with newlines not being preserved, in the rendered html.

And inserting random boldface into lists, seems like `image:` is somehow special?

They don't have to be installed (the generated docs), having them on web is OK.

`make -C builddir $PWD/builddir/usr/local/share/doc/apptainer/cli`

(compare: `make -C builddir $PWD/builddir/usr/local/share/man/man1`)
