### PR TITLE
disable record length test in mount string parsing (release-1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The Singularity Project has been
 and re-branded as Apptainer.
 For older changes see the [archived Singularity change log](https://github.com/apptainer/singularity/blob/release-3.8/CHANGELOG.md).
 
+## v1.5.x changes
+
+- Fixed a bug that prevented multiple mount entries in the `APPTAINER_MOUNT`
+  env var from having different numbers of options.
+
 ## v1.5.3 - \[2026-07-21\]
 
 - If the `ptrace()` system call does not work while building an image as

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -102,6 +102,7 @@
 - Richard Hattersley <richard.hattersley@metoffice.gov.uk>
 - Richard Neuboeck <hawk@tbi.univie.ac.at>
 - Robert Clarke <robert.clarke@bristol.ac.uk>
+- Robin Heinemann <robin.ole.heinemann@gmail.com>
 - Sasha Yakovtseva <sasha@sylabs.io>, <sashayakovtseva@gmail.com>
 - Satish Chebrolu  <satish@sylabs.io>
 - Shane Loretz <sloretz@openrobotics.org>, <shane.loretz@gmail.com>

--- a/pkg/runtime/engine/apptainer/config/mount.go
+++ b/pkg/runtime/engine/apptainer/config/mount.go
@@ -32,6 +32,7 @@ import (
 func ParseMountString(mount string) (bindPaths []BindPath, err error) {
 	r := strings.NewReader(mount)
 	c := csv.NewReader(r)
+	c.FieldsPerRecord = -1
 	records, err := c.ReadAll()
 	if err != nil {
 		return []BindPath{}, fmt.Errorf("error parsing mount: %v", err)

--- a/pkg/runtime/engine/apptainer/config/mount_test.go
+++ b/pkg/runtime/engine/apptainer/config/mount_test.go
@@ -241,6 +241,25 @@ func TestParseMountString(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:        "multipleDifferentLength",
+			mountString: "type=bind,source=/opt,destination=/opt\ntype=bind,source=/srv,destination=/srv,ro",
+			want: []BindPath{
+				{
+					Source:      "/opt",
+					Destination: "/opt",
+					Options:     map[string]*BindOption{},
+				},
+				{
+					Source:      "/srv",
+					Destination: "/srv",
+					Options: map[string]*BindOption{
+						"ro": {},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Cherry-pick https://github.com/apptainer/apptainer/pull/3667 to release-1.5