### PR TITLE
feat: Make ldconfig optional for GPU library discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.5.x
 
+- Add a new `gpu library path` option to `apptainer.conf`, giving a list of
+  directories to search for the GPU driver libraries named in
+  `nvliblist.conf` and `rocmliblist.conf` when binding them with `--nv` or
+  `--rocm`. The directories are searched ahead of the ld.so cache, and make
+  `ldconfig` optional: when it cannot be found or run, the configured
+  directories are used on their own. This allows the host GPU libraries to be
+  found on systems that keep them outside the ld.so cache, or that do not
+  ship `ldconfig` at all, such as NixOS and Guix, where previously no host
+  GPU libraries would be found at all.
 - Add a new `--compat32` flag (action and build) which, alongside `--nv` or
   `--rocm`, additionally binds the 32-bit GPU driver libraries of the
   host into `/.singularity.d/libs32` in the container, and adds that

--- a/e2e/gpu/gpu.go
+++ b/e2e/gpu/gpu.go
@@ -10,17 +10,21 @@
 package gpu
 
 import (
+	"debug/elf"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/apptainer/apptainer/e2e/internal/e2e"
 	"github.com/apptainer/apptainer/e2e/internal/testhelper"
+	"github.com/apptainer/apptainer/internal/pkg/buildcfg"
 	"github.com/apptainer/apptainer/internal/pkg/test/tool/require"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
+	utilgpu "github.com/apptainer/apptainer/internal/pkg/util/gpu"
 )
 
 var buildDefinition = `Bootstrap: localimage
@@ -680,20 +684,316 @@ func (c ctx) testBuildRocm(t *testing.T) {
 	}
 }
 
+// gpuStandInLib is the name given to the stand-in library used by
+// testGpuLibraryPath. It matches the libEGL_installertest.so entry of
+// nvliblist.conf, which is listed there but is not part of a driver
+// installation, so a library of this name reaching the container can only
+// have come from the configured 'gpu library path', whether or not the host
+// has a GPU driver installed.
+const gpuStandInLib = "libEGL_installertest.so.1"
+
+// gpuDanglingLib is the name given to the dangling symlink used by
+// testGpuLibraryPath. It matches the libcuda.so entry of nvliblist.conf, so
+// it is looked for, and it does not resolve to a library, so it must never be
+// provisioned.
+const gpuDanglingLib = "libcuda.so.1"
+
+// hostLibrary returns the path of a shared library on the host, built for the
+// same machine and ELF class as the libraries that --nv provisions, to stand
+// in for a GPU driver library.
+func hostLibrary(t *testing.T) string {
+	t.Helper()
+
+	self, err := elf.Open("/proc/self/exe")
+	if err != nil {
+		t.Skipf("Could not read the ELF header of the test binary: %v", err)
+	}
+	machine, class := self.Machine, self.Class
+	self.Close()
+
+	// The C library is present on any host able to run these tests. Cover
+	// where the multiarch, lib64 and musl layouts keep it.
+	for _, glob := range []string{
+		"/lib/*/libc.so.*",
+		"/lib64/libc.so.*",
+		"/lib/libc.so.*",
+		"/usr/lib/*/libc.so.*",
+		"/usr/lib64/libc.so.*",
+		"/usr/lib/libc.so.*",
+		"/lib/libc.musl-*.so.*",
+		"/usr/lib/libc.musl-*.so.*",
+	} {
+		matches, err := filepath.Glob(glob)
+		if err != nil {
+			t.Fatalf("Could not search for a host library: %v", err)
+		}
+		for _, match := range matches {
+			lib, err := elf.Open(match)
+			if err != nil {
+				continue
+			}
+			matching := lib.Machine == machine && lib.Class == class
+			lib.Close()
+			if matching {
+				return match
+			}
+		}
+	}
+
+	t.Skip("Could not find a host library to stand in for a GPU driver library")
+	return ""
+}
+
+// noLdCacheEnv returns an environment in which apptainer has no ld cache to
+// read, by creating an ldconfig which fails to run under dir and putting it at
+// the front of PATH, where apptainer finds it in place of the system one. It
+// stands in for a host which does not ship ldconfig, or which does not
+// populate an ld.so cache. "ldconfig.real" is created as well, as apptainer
+// looks for that name first.
+func noLdCacheEnv(t *testing.T, dir string) []string {
+	t.Helper()
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatalf("Could not create directory: %v", err)
+	}
+	script := []byte("#!/bin/sh\necho 'ldconfig: no ld.so cache on this host' >&2\nexit 1\n")
+	for _, name := range []string{"ldconfig", "ldconfig.real"} {
+		if err := os.WriteFile(filepath.Join(binDir, name), script, 0o755); err != nil {
+			t.Fatalf("Could not create %s: %v", name, err)
+		}
+	}
+
+	return append(os.Environ(), "PATH="+binDir+":"+os.Getenv("PATH"))
+}
+
+// testGpuLibraryPath checks the 'gpu library path' directive of
+// apptainer.conf, which names the directories to search for the GPU driver
+// libraries listed in nvliblist.conf and rocmliblist.conf, ahead of and
+// without needing the ld cache.
+//
+// A GPU is not required: a copy of a host library, named after an entry of
+// nvliblist.conf that no driver provides, stands in for a driver library, so
+// whether --nv provisions it tells us whether the configured directory was
+// searched.
+func (c ctx) testGpuLibraryPath(t *testing.T) {
+	e2e.EnsureImage(t, c.env)
+
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "gpu-library-path-", "gpu library path")
+	defer cleanup(t)
+
+	// libDir holds the stand-in library. firstDir holds nothing usable, and
+	// is configured ahead of libDir to check that the whole of the
+	// configured list is searched, and that an entry which does not resolve
+	// is passed over.
+	libDir := filepath.Join(tmpDir, "lib")
+	firstDir := filepath.Join(tmpDir, "first")
+	for _, dir := range []string{libDir, firstDir} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatalf("Could not create directory: %v", err)
+		}
+	}
+	if err := fs.CopyFile(hostLibrary(t), filepath.Join(libDir, gpuStandInLib), 0o755); err != nil {
+		t.Fatalf("Could not create stand-in library: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(firstDir, "removed"), filepath.Join(firstDir, gpuDanglingLib)); err != nil {
+		t.Fatalf("Could not create symlink: %v", err)
+	}
+
+	noLdCache := noLdCacheEnv(t, tmpDir)
+	standInLib := "/.singularity.d/libs/" + gpuStandInLib
+
+	tests := []struct {
+		name        string
+		env         []string
+		libraryPath string
+		args        []string
+		exit        int
+		expectMatch e2e.ApptainerCmdResultOp
+	}{
+		{
+			// Nothing but a configured directory can provide the stand-in
+			// library, so it must not turn up when none is configured.
+			name: "Unconfigured",
+			args: []string{"--nv", c.env.ImagePath, "test", "-e", standInLib},
+			exit: 1,
+		},
+		{
+			// The configured directory is searched alongside the ld cache.
+			name:        "Configured",
+			libraryPath: libDir,
+			args:        []string{"--nv", c.env.ImagePath, "test", "-e", standInLib},
+			exit:        0,
+		},
+		{
+			// With neither an ld cache nor a configured directory there is
+			// nowhere left to look, and the warning has to say so.
+			name:        "NoLdCacheUnconfigured",
+			env:         noLdCache,
+			args:        []string{"--nv", c.env.ImagePath, "test", "-e", standInLib},
+			exit:        1,
+			expectMatch: e2e.ExpectError(e2e.ContainMatch, "no 'gpu library path' is configured in apptainer.conf"),
+		},
+		{
+			// The configured directory is enough on its own: the ld cache is
+			// optional, and doing without it is not worth a warning.
+			name:        "NoLdCacheConfigured",
+			env:         noLdCache,
+			libraryPath: libDir,
+			args:        []string{"--nv", c.env.ImagePath, "test", "-e", standInLib},
+			exit:        0,
+			expectMatch: e2e.ExpectError(e2e.UnwantedContainMatch, "Could not read the ld cache"),
+		},
+		{
+			// Every configured directory is searched, not only the first.
+			name:        "NoLdCacheSecondDirectory",
+			env:         noLdCache,
+			libraryPath: firstDir + "," + libDir,
+			args:        []string{"--nv", c.env.ImagePath, "test", "-e", standInLib},
+			exit:        0,
+		},
+		{
+			// The dangling symlink is the only candidate for its name here,
+			// and it must be passed over rather than provisioned.
+			name:        "NoLdCacheDangling",
+			env:         noLdCache,
+			libraryPath: firstDir + "," + libDir,
+			args:        []string{"--nv", c.env.ImagePath, "test", "!", "-e", "/.singularity.d/libs/" + gpuDanglingLib},
+			exit:        0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.PreRun(func(t *testing.T) {
+				if tt.libraryPath != "" {
+					e2e.SetDirective(t, c.env, "gpu library path", tt.libraryPath)
+				}
+			}),
+			e2e.PostRun(func(t *testing.T) {
+				if tt.libraryPath != "" {
+					e2e.ResetDirective(t, c.env, "gpu library path")
+				}
+			}),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(tt.args...),
+			e2e.WithEnv(tt.env),
+			e2e.ExpectExit(tt.exit, tt.expectMatch),
+		)
+	}
+}
+
+// testNvidiaLibraryPath checks that the NVIDIA driver libraries of a host with
+// a GPU are provisioned from the directories named by 'gpu library path'
+// alone, on a host where apptainer has no ld cache to fall back on.
+func (c ctx) testNvidiaLibraryPath(t *testing.T) {
+	require.Nvidia(t)
+	// Use a Debian-based image, as we can't use our test image which is
+	// alpine based and we need a compatible glibc.
+	e2e.EnsureDebianImage(t, c.env)
+	imagePath := c.env.DebianImagePath
+
+	// Find where this host keeps its driver libraries by resolving them the
+	// usual way, through the ld cache. Configuring those directories has to
+	// give --nv the same libraries with the ld cache out of reach.
+	libs, _, _, err := utilgpu.NvidiaPaths(buildcfg.NVIDIALIBS_FILE)
+	if err != nil {
+		t.Skipf("Could not resolve the NVIDIA libraries of this host: %v", err)
+	}
+	var libraryPath []string
+	for _, lib := range libs {
+		if dir := filepath.Dir(lib); !slices.Contains(libraryPath, dir) {
+			libraryPath = append(libraryPath, dir)
+		}
+	}
+	if len(libraryPath) == 0 {
+		t.Skip("No NVIDIA libraries found on this host")
+	}
+	t.Logf("Setting 'gpu library path' to %s", strings.Join(libraryPath, ", "))
+
+	tmpDir, cleanup := e2e.MakeTempDir(t, c.env.TestDir, "nvidia-library-path-", "nvidia gpu library path")
+	defer cleanup(t)
+
+	noLdCache := noLdCacheEnv(t, tmpDir)
+
+	tests := []struct {
+		name        string
+		env         []string
+		libraryPath string
+		args        []string
+		expectMatch e2e.ApptainerCmdResultOp
+	}{
+		{
+			// Searching the configured directories ahead of the ld cache
+			// must not disturb provisioning when both are available.
+			name:        "Configured",
+			libraryPath: strings.Join(libraryPath, ","),
+			args:        []string{"--nv", imagePath, "nvidia-smi"},
+		},
+		{
+			// Without an ld cache and without the directive there is nothing
+			// left to provision the driver libraries from.
+			name:        "NoLdCacheUnconfigured",
+			env:         noLdCache,
+			args:        []string{"--nv", imagePath, "sh", "-c", "ls /.singularity.d/libs | wc -l"},
+			expectMatch: e2e.ExpectOutput(e2e.ExactMatch, "0"),
+		},
+		{
+			// The configured directories are enough on their own to run a
+			// program against the GPU.
+			name:        "NoLdCacheConfigured",
+			env:         noLdCache,
+			libraryPath: strings.Join(libraryPath, ","),
+			args:        []string{"--nv", imagePath, "nvidia-smi"},
+		},
+	}
+
+	for _, tt := range tests {
+		c.env.RunApptainer(
+			t,
+			e2e.AsSubtest(tt.name),
+			e2e.WithProfile(e2e.UserProfile),
+			e2e.PreRun(func(t *testing.T) {
+				if tt.libraryPath != "" {
+					e2e.SetDirective(t, c.env, "gpu library path", tt.libraryPath)
+				}
+			}),
+			e2e.PostRun(func(t *testing.T) {
+				if tt.libraryPath != "" {
+					e2e.ResetDirective(t, c.env, "gpu library path")
+				}
+			}),
+			e2e.WithCommand("exec"),
+			e2e.WithArgs(tt.args...),
+			e2e.WithEnv(tt.env),
+			e2e.ExpectExit(0, tt.expectMatch),
+		)
+	}
+}
+
 // E2ETests is the main func to trigger the test suite
 func E2ETests(env e2e.TestEnv) testhelper.Tests {
 	c := ctx{
 		env: env,
 	}
 
+	// The 'gpu library path' tests change apptainer.conf, so they must not
+	// run alongside anything else.
+	np := testhelper.NoParallel
+
 	return testhelper.Tests{
-		"nvidia":          c.testNvidiaLegacy,
-		"nvidia compat32": c.testNvidiaCompat32,
-		"nvccli":          c.testNvCCLI,
-		"rocm":            c.testRocm,
-		"intel-hpu":       c.testIntelHpu,
-		"build nvidia":    c.testBuildNvidiaLegacy,
-		"build nvccli":    c.testBuildNvCCLI,
-		"build rocm":      c.testBuildRocm,
+		"nvidia":                  c.testNvidiaLegacy,
+		"nvidia compat32":         c.testNvidiaCompat32,
+		"nvccli":                  c.testNvCCLI,
+		"rocm":                    c.testRocm,
+		"intel-hpu":               c.testIntelHpu,
+		"build nvidia":            c.testBuildNvidiaLegacy,
+		"build nvccli":            c.testBuildNvCCLI,
+		"build rocm":              c.testBuildRocm,
+		"gpu library path":        np(c.testGpuLibraryPath),
+		"nvidia gpu library path": np(c.testNvidiaLibraryPath),
 	}
 }

--- a/internal/pkg/util/paths/resolve.go
+++ b/internal/pkg/util/paths/resolve.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 )
 
 const (
@@ -90,9 +91,9 @@ func Resolve(fileList []string) ([]string, []string, []string, error) {
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("could not retrieve ELF machine ID: %v", err)
 	}
-	ldCache, err := ldCache()
+	ldCache, err := libraryCache()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("could not retrieve ld cache: %v", err)
+		return nil, nil, nil, fmt.Errorf("could not retrieve library cache: %v", err)
 	}
 
 	// Track processed binaries to eliminate duplicates
@@ -148,9 +149,9 @@ func ResolveCompat32(fileList []string) ([]string, error) {
 	if !ok {
 		return nil, errNoCompat32
 	}
-	ldCache, err := ldCache()
+	ldCache, err := libraryCache()
 	if err != nil {
-		return nil, fmt.Errorf("could not retrieve ld cache: %v", err)
+		return nil, fmt.Errorf("could not retrieve library cache: %v", err)
 	}
 
 	return resolveLibs(fileList, machine32, elf.ELFCLASS32, ldCache, ContainerCompat32LibsDir), nil
@@ -236,6 +237,104 @@ func matchingLib(libPath string, machine elf.Machine, class elf.Class) bool {
 		sylog.Warningf("Could not close ELIB: %v", err)
 	}
 	return match
+}
+
+// libraryCache retrieves a map of <library>.so[.version] to the absolute paths
+// at which it can be found.
+//
+// The directories configured as 'gpu library path' in apptainer.conf are
+// searched first, in order, and the paths from the system ld cache follow. The
+// ld cache is only an optional source: it is skipped, with a warning, when
+// ldconfig is not available or fails to run. This allows Apptainer to find the
+// GPU driver libraries on systems that do not populate an ld.so cache, or that
+// do not ship ldconfig at all, such as NixOS and Guix.
+//
+// As with ldCache, all of the paths found for a given <library>.so[.version]
+// are kept, in search order, so that callers can pick the variant built for
+// the architecture they are resolving for.
+func libraryCache() (map[string][]string, error) {
+	libCache := make(map[string][]string)
+
+	searchPaths := gpuLibraryPath()
+	if len(searchPaths) > 0 {
+		sylog.Debugf("Searching for GPU libraries in configured 'gpu library path': %s", strings.Join(searchPaths, ", "))
+	}
+	for _, dir := range searchPaths {
+		addDirToCache(libCache, dir)
+	}
+
+	ldCache, err := ldCache()
+	if err != nil {
+		// ldconfig is not essential when the libraries can be found via
+		// the configured search paths.
+		if len(libCache) == 0 {
+			sylog.Warningf("Could not read the ld cache, and no 'gpu library path' is configured in apptainer.conf: %v", err)
+		} else {
+			sylog.Debugf("Not using the ld cache: %v", err)
+		}
+		return libCache, nil
+	}
+	for libName, libPaths := range ldCache {
+		for _, libPath := range libPaths {
+			if !slices.Contains(libCache[libName], libPath) {
+				libCache[libName] = append(libCache[libName], libPath)
+			}
+		}
+	}
+
+	return libCache, nil
+}
+
+// gpuLibraryPath returns the directories configured as 'gpu library path' in
+// apptainer.conf, to be searched for GPU driver libraries.
+func gpuLibraryPath() []string {
+	config := apptainerconf.GetCurrentConfig()
+	if config == nil {
+		// The configuration has not been loaded, e.g. in a unit test.
+		return nil
+	}
+
+	dirs := make([]string, 0, len(config.GpuLibraryPath))
+	for _, dir := range config.GpuLibraryPath {
+		dir = strings.TrimSpace(dir)
+		if dir != "" {
+			dirs = append(dirs, dir)
+		}
+	}
+	return dirs
+}
+
+// addDirToCache adds the libraries directly contained in dir to libCache,
+// after the paths already present from a higher priority source.
+func addDirToCache(libCache map[string][]string, dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		sylog.Debugf("Skipping GPU library path %s: %v", dir, err)
+		return
+	}
+	for _, entry := range entries {
+		libName := entry.Name()
+		if !strings.Contains(libName, ".so") {
+			continue
+		}
+		libPath := filepath.Join(dir, libName)
+		// Versioned libraries are usually symlinks, so resolve the entry
+		// rather than requiring a regular file here. Skipping entries
+		// that do not resolve, e.g. dangling symlinks, keeps them from
+		// being offered ahead of a working library of the same name
+		// found later.
+		fi, err := os.Stat(libPath)
+		if err != nil {
+			sylog.Debugf("Skipping GPU library %s: %v", libPath, err)
+			continue
+		}
+		if !fi.Mode().IsRegular() {
+			continue
+		}
+		if !slices.Contains(libCache[libName], libPath) {
+			libCache[libName] = append(libCache[libName], libPath)
+		}
+	}
 }
 
 // ldCache retrieves a map of <library>.so[.version] to the absolute paths at

--- a/internal/pkg/util/paths/resolve_test.go
+++ b/internal/pkg/util/paths/resolve_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/apptainer/apptainer/pkg/util/apptainerconf"
 )
 
 var testLibList = []string{"libc.so", "echo"}
@@ -252,5 +254,103 @@ func TestResolveCompat32(t *testing.T) {
 		if !matchingLib(lib, compat32Machine[machine], elf.ELFCLASS32) {
 			t.Errorf("ResolveCompat32() returned %s, which is not a 32-bit library", lib)
 		}
+	}
+}
+
+// setGpuLibraryPath sets the 'gpu library path' configuration directive for
+// the duration of a test.
+func setGpuLibraryPath(t *testing.T, dirs ...string) {
+	t.Helper()
+
+	old := apptainerconf.GetCurrentConfig()
+	t.Cleanup(func() { apptainerconf.SetCurrentConfig(old) })
+
+	config := &apptainerconf.File{}
+	if old != nil {
+		copied := *old
+		config = &copied
+	}
+	config.GpuLibraryPath = dirs
+	apptainerconf.SetCurrentConfig(config)
+}
+
+// TestLibraryCacheSearchPaths checks that the directories configured as 'gpu
+// library path' are searched, in order, ahead of the ld cache.
+func TestLibraryCacheSearchPaths(t *testing.T) {
+	firstDir := filepath.Join(t.TempDir(), "first")
+	secondDir := filepath.Join(t.TempDir(), "second")
+	for _, dir := range []string{firstDir, secondDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("Could not create dir: %v", err)
+		}
+	}
+
+	// libboth.so.1 is in both directories, and the one in the directory
+	// configured first must be listed first. libsecond.so.1 is only in the
+	// second.
+	firstBoth := filepath.Join(firstDir, "libboth.so.1")
+	secondBoth := filepath.Join(secondDir, "libboth.so.1")
+	for _, lib := range []string{firstBoth, secondBoth, filepath.Join(secondDir, "libsecond.so.1")} {
+		if err := os.WriteFile(lib, nil, 0o644); err != nil {
+			t.Fatalf("Could not create file: %v", err)
+		}
+	}
+	// A non-library file must be ignored.
+	if err := os.WriteFile(filepath.Join(firstDir, "notalib.txt"), nil, 0o644); err != nil {
+		t.Fatalf("Could not create file: %v", err)
+	}
+	// A dangling symlink must not be listed ahead of the working library of
+	// the same name in the second directory.
+	shadowed := filepath.Join(secondDir, "libshadowed.so.1")
+	if err := os.WriteFile(shadowed, nil, 0o644); err != nil {
+		t.Fatalf("Could not create file: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(firstDir, "nonexistent.so"), filepath.Join(firstDir, "libshadowed.so.1")); err != nil {
+		t.Fatalf("Could not symlink: %v", err)
+	}
+
+	setGpuLibraryPath(t, firstDir, secondDir, filepath.Join(firstDir, "nonexistent"))
+
+	gotCache, err := libraryCache()
+	if err != nil {
+		t.Fatalf("libraryCache() error = %v", err)
+	}
+	if want := []string{firstBoth, secondBoth}; !reflect.DeepEqual(gotCache["libboth.so.1"], want) {
+		t.Errorf("libraryCache() gave libboth.so.1 = %q, expected %q", gotCache["libboth.so.1"], want)
+	}
+	if _, ok := gotCache["libsecond.so.1"]; !ok {
+		t.Error("libraryCache() did not include libsecond.so.1 from the second search path")
+	}
+	if _, ok := gotCache["notalib.txt"]; ok {
+		t.Error("libraryCache() included a non-library file")
+	}
+	if want := []string{shadowed}; !reflect.DeepEqual(gotCache["libshadowed.so.1"], want) {
+		t.Errorf("libraryCache() gave libshadowed.so.1 = %q, expected the dangling symlink to be skipped in favor of %q", gotCache["libshadowed.so.1"], want)
+	}
+}
+
+// TestLibraryCacheWithoutLdconfig checks that a configured 'gpu library path'
+// is sufficient on its own, i.e. that resolution does not fail when the ld
+// cache is unavailable. bin.FindBin("ldconfig") fails in the unit test
+// environment because the installed apptainer.conf is not present, which is
+// the same code path taken on a host without ldconfig.
+func TestLibraryCacheWithoutLdconfig(t *testing.T) {
+	if _, err := ldCache(); err == nil {
+		t.Skip("ldconfig is available in this environment")
+	}
+
+	dir := t.TempDir()
+	lib := filepath.Join(dir, "libtest.so.1")
+	if err := os.WriteFile(lib, nil, 0o644); err != nil {
+		t.Fatalf("Could not create file: %v", err)
+	}
+	setGpuLibraryPath(t, dir)
+
+	gotCache, err := libraryCache()
+	if err != nil {
+		t.Fatalf("libraryCache() error = %v, expected the missing ld cache to be tolerated", err)
+	}
+	if want := []string{lib}; !reflect.DeepEqual(gotCache["libtest.so.1"], want) {
+		t.Errorf("libraryCache() gave libtest.so.1 = %q, expected %q", gotCache["libtest.so.1"], want)
 	}
 }

--- a/pkg/util/apptainerconf/config.go
+++ b/pkg/util/apptainerconf/config.go
@@ -106,6 +106,7 @@ type File struct {
 	AlwaysUseNv               bool     `default:"no" authorized:"yes,no" directive:"always use nv"`
 	UseNvCCLI                 bool     `default:"no" authorized:"yes,no" directive:"use nvidia-container-cli"`
 	AlwaysUseRocm             bool     `default:"no" authorized:"yes,no" directive:"always use rocm"`
+	GpuLibraryPath            []string `directive:"gpu library path"`
 	SharedLoopDevices         bool     `default:"no" authorized:"yes,no" directive:"shared loop devices"`
 	MaxLoopDevices            uint     `default:"256" directive:"max loop devices"`
 	SessiondirMaxSize         uint     `default:"64" directive:"sessiondir max size"`
@@ -536,6 +537,23 @@ use nvidia-container-cli = {{ if eq .UseNvCCLI true }}yes{{ else }}no{{ end }}
 # should be executed implicitly with the --rocm option (useful for GPU only
 # environments).
 always use rocm = {{ if eq .AlwaysUseRocm true }}yes{{ else }}no{{ end }}
+
+# GPU LIBRARY PATH: [STRING]
+# DEFAULT: undefined
+# A comma separated list of directories to search for the GPU driver libraries
+# named in nvliblist.conf and rocmliblist.conf, when binding them into a
+# container with --nv or --rocm.  These directories are searched ahead of, and
+# without needing, the ld.so cache reported by "ldconfig -p".
+# Set this on systems where the driver libraries are not in the ld.so cache, or
+# where ldconfig is not available at all, such as NixOS or Guix.  If it is not
+# set, and ldconfig cannot be run, then no host GPU libraries will be found.
+# The directories holding the 32-bit libraries used by --compat32 are listed
+# alongside the 64-bit ones; libraries are picked by architecture, not by the
+# directory they are found in.
+#gpu library path = /run/opengl-driver/lib, /run/opengl-driver-32/lib
+{{ range $index, $path := .GpuLibraryPath }}
+{{- if eq $index 0 }}gpu library path = {{ else }}, {{ end }}{{$path}}
+{{- end }}
 
 # ROOT DEFAULT CAPABILITIES: [full/file/no]
 # DEFAULT: full


### PR DESCRIPTION
Reviewer: @DrDaveD 

## Description of the Pull Request (PR):

Apptainer locates the GPU driver libraries named in nvliblist.conf and rocmliblist.conf by running "ldconfig -p". That fails on systems which do not populate an ld.so cache, or which do not ship ldconfig at all, such as NixOS and Guix, where the driver libraries live in unusual paths. On those hosts --nv and --rocm find nothing to bind.

Add a "gpu library path" option to apptainer.conf, holding a list of directories to search for those libraries. The configured directories are searched first, in order, and the ld.so cache becomes an optional secondary source: when ldconfig cannot be found or run, the configured directories are used on their own instead of the lookup coming up empty.

Entries which do not resolve, such as dangling symlinks, are skipped so that they cannot shadow a working library of the same name found in a lower priority location.

The warning issued when no libraries can be found now names the setting to configure, rather than only reporting that the ld cache is unreadable.

### This fixes or addresses the following GitHub issues:

 - Fixes #1894

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Make sure all commits are signed-off with `git commit -s`, see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
