### PR TITLE
Skip making a PID namespace if /proc cannot be mounted in fakeroot build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ Changes since 1.5.x
   "org.opencontainers.image.architecture" (optional ".variant").
   The old deprecated labels: "org.label-schema.build-date" and
   "org.label-schema.build-arch" are still set, for compatibility.
+- When `/proc` cannot be mounted in a new PID namespace while using
+  fakeroot to build an image from a definition file, use the host PID
+  namespace instead of a separate PID namespace and print an INFO
+  message.  This can happen inside unprivileged docker which by default
+  blocks mounting `/proc`.
 - Add possibility to add description and annotations for oras,
   when pushing images to a registry using the `push` command.
   The --description flag sets "org.opencontainers.image.description",

--- a/internal/pkg/runtime/engine/fakeroot/config/config.go
+++ b/internal/pkg/runtime/engine/fakeroot/config/config.go
@@ -15,8 +15,9 @@ const Name = "fakeroot"
 // EngineConfig is the config for the fakeroot engine used to execute
 // a command in a fakeroot context
 type EngineConfig struct {
-	Args     []string `json:"args"`
-	Envs     []string `json:"envs"`
-	Home     string   `json:"home"`
-	BuildEnv bool     `json:"buildEnv"`
+	Args            []string `json:"args"`
+	Envs            []string `json:"envs"`
+	Home            string   `json:"home"`
+	BuildEnv        bool     `json:"buildEnv"`
+	HasPIDNamespace bool     `json:"hasPIDNamespace"`
 }

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"syscall"
@@ -27,7 +26,6 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/starter"
 	fakerootConfig "github.com/apptainer/apptainer/internal/pkg/runtime/engine/fakeroot/config"
 	"github.com/apptainer/apptainer/internal/pkg/security/seccomp"
-	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	fakerootcallback "github.com/apptainer/apptainer/pkg/plugin/callback/runtime/fakeroot"
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
@@ -43,19 +41,6 @@ import (
 type EngineOperations struct {
 	CommonConfig *config.Common               `json:"-"`
 	EngineConfig *fakerootConfig.EngineConfig `json:"engineConfig"`
-}
-
-func canMountSlashProc() bool {
-	mountPath, err := bin.FindBin("mount")
-	if err != nil {
-		sylog.Debugf("no mount command found, assuming /proc can be mounted")
-		return true
-	}
-	cmd := exec.Command(mountPath, "-t", "proc", "proc", "/proc")
-	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWPID | syscall.CLONE_NEWNS | syscall.CLONE_NEWUSER
-
-	return cmd.Run() == nil
 }
 
 // InitConfig stores the parsed config.Common inside the engine.
@@ -120,12 +105,18 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 	g.AddOrReplaceLinuxNamespace(specs.UserNamespace, "")
 	g.AddOrReplaceLinuxNamespace(specs.MountNamespace, "")
 
-	if canMountSlashProc() {
-		g.AddOrReplaceLinuxNamespace(specs.PIDNamespace, "")
-		e.EngineConfig.HasPIDNamespace = true
-	} else {
+	// Check if there are bind mounts under /proc that would prevent
+	// a new /proc mount from being created in a PID namespace
+	hasMounts, err := proc.HasBindMountsUnderProc()
+	if err == nil && hasMounts {
 		sylog.Infof("Cannot mount /proc, proceeding without PID namespace")
 		e.EngineConfig.HasPIDNamespace = false
+	} else {
+		if err != nil {
+			sylog.Debugf("error checking /proc mounts, proceeding: %s", err)
+		}
+		g.AddOrReplaceLinuxNamespace(specs.PIDNamespace, "")
+		e.EngineConfig.HasPIDNamespace = true
 	}
 
 	uid, err := safecast.Convert[uint32](os.Getuid())

--- a/internal/pkg/runtime/engine/fakeroot/engine_linux.go
+++ b/internal/pkg/runtime/engine/fakeroot/engine_linux.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"syscall"
@@ -26,6 +27,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/runtime/engine/config/starter"
 	fakerootConfig "github.com/apptainer/apptainer/internal/pkg/runtime/engine/fakeroot/config"
 	"github.com/apptainer/apptainer/internal/pkg/security/seccomp"
+	"github.com/apptainer/apptainer/internal/pkg/util/bin"
 	"github.com/apptainer/apptainer/internal/pkg/util/fs"
 	fakerootcallback "github.com/apptainer/apptainer/pkg/plugin/callback/runtime/fakeroot"
 	"github.com/apptainer/apptainer/pkg/runtime/engine/config"
@@ -41,6 +43,19 @@ import (
 type EngineOperations struct {
 	CommonConfig *config.Common               `json:"-"`
 	EngineConfig *fakerootConfig.EngineConfig `json:"engineConfig"`
+}
+
+func canMountSlashProc() bool {
+	mountPath, err := bin.FindBin("mount")
+	if err != nil {
+		sylog.Debugf("no mount command found, assuming /proc can be mounted")
+		return true
+	}
+	cmd := exec.Command(mountPath, "-t", "proc", "proc", "/proc")
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWPID | syscall.CLONE_NEWNS | syscall.CLONE_NEWUSER
+
+	return cmd.Run() == nil
 }
 
 // InitConfig stores the parsed config.Common inside the engine.
@@ -104,7 +119,14 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 
 	g.AddOrReplaceLinuxNamespace(specs.UserNamespace, "")
 	g.AddOrReplaceLinuxNamespace(specs.MountNamespace, "")
-	g.AddOrReplaceLinuxNamespace(specs.PIDNamespace, "")
+
+	if canMountSlashProc() {
+		g.AddOrReplaceLinuxNamespace(specs.PIDNamespace, "")
+		e.EngineConfig.HasPIDNamespace = true
+	} else {
+		sylog.Infof("Cannot mount /proc, proceeding without PID namespace")
+		e.EngineConfig.HasPIDNamespace = false
+	}
 
 	uid, err := safecast.Convert[uint32](os.Getuid())
 	if err != nil {
@@ -307,25 +329,28 @@ func (e *EngineOperations) StartProcess(_ int) error {
 	if err != nil {
 		return fmt.Errorf("failed to mount %s to /root: %s", e.EngineConfig.Home, err)
 	}
-	tmpdir, err := os.MkdirTemp("", "bind-mount-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temporary directory: %s", err)
-	}
-	err = syscall.Mount("proc", tmpdir, "proc", syscall.MS_NOSUID|syscall.MS_NOEXEC|syscall.MS_NODEV, "")
-	if err != nil {
-		return fmt.Errorf("failed to mount proc filesystem: %s", err)
-	}
-	err = syscall.Mount(binfmtMisc, filepath.Join(tmpdir, "sys", "fs", "binfmt_misc"), "", syscall.MS_BIND, "")
-	if err != nil {
-		return fmt.Errorf("failed to mount binfmt_misc filesystem: %s", err)
-	}
-	err = syscall.Mount(tmpdir, "/proc", "", syscall.MS_MOVE, "")
-	if err != nil {
-		return fmt.Errorf("failed to mount proc filesystem: %s", err)
-	}
-	err = os.Remove(tmpdir)
-	if err != nil {
-		return fmt.Errorf("failed to remove temporary directory: %s", err)
+
+	if e.EngineConfig.HasPIDNamespace {
+		tmpdir, err := os.MkdirTemp("", "bind-mount-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temporary directory: %s", err)
+		}
+		err = syscall.Mount("proc", tmpdir, "proc", syscall.MS_NOSUID|syscall.MS_NOEXEC|syscall.MS_NODEV, "")
+		if err != nil {
+			return fmt.Errorf("failed to mount proc filesystem: %s", err)
+		}
+		err = syscall.Mount(binfmtMisc, filepath.Join(tmpdir, "sys", "fs", "binfmt_misc"), "", syscall.MS_BIND, "")
+		if err != nil {
+			return fmt.Errorf("failed to mount binfmt_misc filesystem: %s", err)
+		}
+		err = syscall.Mount(tmpdir, "/proc", "", syscall.MS_MOVE, "")
+		if err != nil {
+			return fmt.Errorf("failed to mount proc filesystem: %s", err)
+		}
+		err = os.Remove(tmpdir)
+		if err != nil {
+			return fmt.Errorf("failed to remove temporary directory: %s", err)
+		}
 	}
 
 	// fix potential issue with SELinux (https://github.com/apptainer/singularity/issues/4038)

--- a/pkg/util/fs/proc/proc.go
+++ b/pkg/util/fs/proc/proc.go
@@ -39,6 +39,24 @@ func HasFilesystem(fs string) (bool, error) {
 	return false, nil
 }
 
+// HasBindMountsUnderProc returns whether there are any bind mounts under /proc.
+// This is useful to check if /proc can be remounted, as existing sub bindmounts
+// would prevent a new /proc mount from being created.
+func HasBindMountsUnderProc() (bool, error) {
+	entries, err := GetMountInfoEntry("/proc/self/mountinfo")
+	if err != nil {
+		return false, fmt.Errorf("can't parse /proc/self/mountinfo: %s", err)
+	}
+
+	for _, entry := range entries {
+		// bind mounts have a "Root" that is not "/"
+		if strings.HasPrefix(entry.Point, "/proc/") && entry.Root != "/" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // GetMountPointMap parses mountinfo pointing to path and returns
 // a map of parent mount points with associated child mount points.
 func GetMountPointMap(path string) (map[string][]string, error) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

This checks to see if /proc can be mounted in a PID namespace before allocating one during fakeroot builds.

### This fixes or addresses the following GitHub issues:

 - Fixes #3725 