### PR TITLE
Add Nvidia gpu CI tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,51 @@
+# Based on https://gitlab.spack.io/warpx/warpx/-/blob/development/.gitlab/ci.yaml
+# Syncing is set up in https://gitlab.spac.io/apptainer/apptainer-ci-sync
+
+.common-setup:
+  before_script:
+    - |
+      set -ex
+      : check that user namespaces work
+      uname -a
+      unshare -rm id
+      : check for /dev/fuse
+      ls -l /dev/fuse
+      : install dependencies
+      apt-get update
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get install -y curl git sudo
+      : show apptainer version before getting the rest of the dependencies
+      scripts/get-version
+      apt-get install -y build-essential libseccomp-dev libtalloc-dev libattr1-dev libprotobuf-c-dev uidmap fakeroot cryptsetup dbus-user-session
+      apt-get install -y autoconf automake libtool pkg-config libfuse3-dev zlib1g-dev liblzo2-dev liblz4-dev liblzma-dev libzstd-dev
+      : install go
+      GOVERSION=$(scripts/get-min-go-version)
+      curl -Ls https://go.dev/dl/go${GOVERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+      export PATH=$PATH:/usr/local/go/bin
+      go version
+      : download, compile, and install dependencies
+      ./scripts/download-dependencies 
+      ./scripts/compile-dependencies
+      mkdir -p /usr/local/libexec/apptainer/bin
+      ./scripts/install-dependencies /usr/local/libexec
+      : build and install apptainer
+      ./mconfig -v -p /usr/local --with-suid
+      make -C ./builddir all && make -C ./builddir install
+      apptainer version
+      : set up sudo for unprivileged ubuntu user
+      echo "Defaults:ubuntu verifypw=any" >/etc/sudoers.d/ubuntu
+      echo "ubuntu ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers.d/ubuntu
+      : set up /etc/subuid for root user
+      apptainer config fakeroot --add root
+
+e2e-nvidia:
+  rules:
+    - if: $CI_SERVER_HOST == "gitlab.spack.io"
+  extends: .common-setup
+  tags: [userns-nvidia-gpu]
+  image: nvcr.io/nvidia/cuda:13.3.1-base-ubuntu24.04
+  script:
+    - |
+      set -ex
+      nvidia-smi
+      su ubuntu -c "./scripts/e2e-test -v -run TestE2E/PAR/GPU"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,4 +48,4 @@ e2e-nvidia:
     - |
       set -ex
       nvidia-smi
-      su ubuntu -c "./scripts/e2e-test -v -run TestE2E/PAR/GPU"
+      su ubuntu -c "E2E_NO_ISOLATION=1 ./scripts/e2e-test -v -run TestE2E/PAR/GPU"

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -37,7 +37,7 @@ func TestE2E(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if os.Getenv("E2E_NO_REAPER") != "" {
+	if os.Getenv("E2E_NO_REAPER") != "" || os.Getenv("E2E_NO_ISOLATION") != "" {
 		ret := m.Run()
 		os.Exit(ret)
 	}

--- a/e2e/internal/e2e/home.go
+++ b/e2e/internal/e2e/home.go
@@ -69,91 +69,101 @@ func SetupHomeDirectories(t *testing.T, testRegistry string) {
 
 		privUser = CurrentUser(t)
 
-		// create the temporary filesystem
-		if err := syscall.Mount("tmpfs", sessionDir, "tmpfs", 0, "mode=0777"); err != nil {
-			t.Fatalf("failed to mount temporary filesystem: %v", err)
-		}
+		var unprivSessionHome, privSessionHome string
+		var err error
 
-		// want the already resolved current working directory
-		cwd, err := os.Readlink("/proc/self/cwd")
-		err = errors.Wrap(err, "getting current working directory from /proc/self/cwd")
-		if err != nil {
-			t.Fatalf("could not readlink /proc/self/cwd: %+v", err)
-		}
-		unprivResolvedHome, err := filepath.EvalSymlinks(unprivUser.Dir)
-		err = errors.Wrapf(err, "resolving home from %q", unprivUser.Dir)
-		if err != nil {
-			t.Fatalf("could not resolve home directory: %+v", err)
-		}
-		privResolvedHome, err := filepath.EvalSymlinks(privUser.Dir)
-		err = errors.Wrapf(err, "resolving home from %q", privUser.Dir)
-		if err != nil {
-			t.Fatalf("could not resolve home directory: %+v", err)
-		}
-
-		// prepare user temporary homes
-		unprivSessionHome := filepath.Join(sessionDir, unprivUser.Name)
-		privSessionHome := filepath.Join(sessionDir, privUser.Name)
-
-		oldUmask := syscall.Umask(0)
-		defer syscall.Umask(oldUmask)
-
-		if err := os.Mkdir(unprivSessionHome, 0o700); err != nil {
-			err = errors.Wrapf(err, "creating temporary home directory at %s", unprivSessionHome)
-			t.Fatalf("failed to create temporary home: %+v", err)
-		}
-		if err := os.Chown(unprivSessionHome, int(unprivUser.UID), int(unprivUser.GID)); err != nil {
-			err = errors.Wrapf(err, "changing temporary home directory ownership at %s", unprivSessionHome)
-			t.Fatalf("failed to set temporary home owner: %+v", err)
-		}
-		// Privileged home setup
-		if err := os.Mkdir(privSessionHome, 0o700); err != nil {
-			err = errors.Wrapf(err, "changing temporary home directory %s", privSessionHome)
-			t.Fatalf("failed to create temporary home: %+v", err)
-		}
-
-		sourceDir := buildcfg.SOURCEDIR
-
-		// re-create the current source directory if it's located in the user
-		// home directory and bind it. Root home directory is not checked because
-		// the whole test suite can not run from there as we are dropping privileges
-		if strings.HasPrefix(sourceDir, unprivResolvedHome) {
-			trimmedSourceDir := strings.TrimPrefix(sourceDir, unprivResolvedHome)
-			sessionSourceDir := filepath.Join(unprivSessionHome, trimmedSourceDir)
-			if err := os.MkdirAll(sessionSourceDir, 0o755); err != nil {
-				err = errors.Wrapf(err, "creating temporary source directory at %q", sessionSourceDir)
-				t.Fatalf("failed to create temporary home source directory: %+v", err)
+		if os.Getenv("E2E_NO_ISOLATION") != "" {
+			unprivSessionHome = unprivUser.Dir
+			privSessionHome = privUser.Dir
+			// This is needed for finding the docker config
+			os.Setenv("HOME", unprivSessionHome)
+		} else {
+			// create the temporary filesystem
+			if err := syscall.Mount("tmpfs", sessionDir, "tmpfs", 0, "mode=0777"); err != nil {
+				t.Fatalf("failed to mount temporary filesystem: %v", err)
 			}
-			if err := syscall.Mount(sourceDir, sessionSourceDir, "", syscall.MS_BIND, ""); err != nil {
-				err = errors.Wrapf(err, "bind mounting source directory from %q to %q", sourceDir, sessionSourceDir)
-				t.Fatalf("failed to bind mount source directory: %+v", err)
+
+			// want the already resolved current working directory
+			cwd, err := os.Readlink("/proc/self/cwd")
+			err = errors.Wrap(err, "getting current working directory from /proc/self/cwd")
+			if err != nil {
+				t.Fatalf("could not readlink /proc/self/cwd: %+v", err)
 			}
-			// fix go directory permission for unprivileged user
-			goDir := filepath.Join(unprivSessionHome, "go")
-			if _, err := os.Stat(goDir); err == nil {
-				if err := os.Chown(goDir, int(unprivUser.UID), int(unprivUser.GID)); err != nil {
-					err = errors.Wrapf(err, "changing temporary home go directory ownership at %s", goDir)
-					t.Fatalf("failed to set owner: %+v", err)
+			unprivResolvedHome, err := filepath.EvalSymlinks(unprivUser.Dir)
+			err = errors.Wrapf(err, "resolving home from %q", unprivUser.Dir)
+			if err != nil {
+				t.Fatalf("could not resolve home directory: %+v", err)
+			}
+			privResolvedHome, err := filepath.EvalSymlinks(privUser.Dir)
+			err = errors.Wrapf(err, "resolving home from %q", privUser.Dir)
+			if err != nil {
+				t.Fatalf("could not resolve home directory: %+v", err)
+			}
+
+			// prepare user temporary homes
+			unprivSessionHome = filepath.Join(sessionDir, unprivUser.Name)
+			privSessionHome = filepath.Join(sessionDir, privUser.Name)
+
+			oldUmask := syscall.Umask(0)
+			defer syscall.Umask(oldUmask)
+
+			if err := os.Mkdir(unprivSessionHome, 0o700); err != nil {
+				err = errors.Wrapf(err, "creating temporary home directory at %s", unprivSessionHome)
+				t.Fatalf("failed to create temporary home: %+v", err)
+			}
+			if err := os.Chown(unprivSessionHome, int(unprivUser.UID), int(unprivUser.GID)); err != nil {
+				err = errors.Wrapf(err, "changing temporary home directory ownership at %s", unprivSessionHome)
+				t.Fatalf("failed to set temporary home owner: %+v", err)
+			}
+			// Privileged home setup
+			if err := os.Mkdir(privSessionHome, 0o700); err != nil {
+				err = errors.Wrapf(err, "changing temporary home directory %s", privSessionHome)
+				t.Fatalf("failed to create temporary home: %+v", err)
+			}
+
+			sourceDir := buildcfg.SOURCEDIR
+
+			// re-create the current source directory if it's located in the user
+			// home directory and bind it. Root home directory is not checked because
+			// the whole test suite can not run from there as we are dropping privileges
+			if strings.HasPrefix(sourceDir, unprivResolvedHome) {
+				trimmedSourceDir := strings.TrimPrefix(sourceDir, unprivResolvedHome)
+				sessionSourceDir := filepath.Join(unprivSessionHome, trimmedSourceDir)
+				if err := os.MkdirAll(sessionSourceDir, 0o755); err != nil {
+					err = errors.Wrapf(err, "creating temporary source directory at %q", sessionSourceDir)
+					t.Fatalf("failed to create temporary home source directory: %+v", err)
+				}
+				if err := syscall.Mount(sourceDir, sessionSourceDir, "", syscall.MS_BIND, ""); err != nil {
+					err = errors.Wrapf(err, "bind mounting source directory from %q to %q", sourceDir, sessionSourceDir)
+					t.Fatalf("failed to bind mount source directory: %+v", err)
+				}
+				// fix go directory permission for unprivileged user
+				goDir := filepath.Join(unprivSessionHome, "go")
+				if _, err := os.Stat(goDir); err == nil {
+					if err := os.Chown(goDir, int(unprivUser.UID), int(unprivUser.GID)); err != nil {
+						err = errors.Wrapf(err, "changing temporary home go directory ownership at %s", goDir)
+						t.Fatalf("failed to set owner: %+v", err)
+					}
 				}
 			}
-		}
 
-		// finally bind temporary homes on top of real ones
-		// in order to not screw them by accident during e2e
-		// tests execution
-		if err := syscall.Mount(unprivSessionHome, unprivResolvedHome, "", syscall.MS_BIND|syscall.MS_REC, ""); err != nil {
-			err = errors.Wrapf(err, "bind mounting source directory from %q to %q", unprivSessionHome, unprivResolvedHome)
-			t.Fatalf("failed to bind mount home directory: %+v", err)
-		}
-		if err := syscall.Mount(privSessionHome, privResolvedHome, "", syscall.MS_BIND, ""); err != nil {
-			err = errors.Wrapf(err, "bind mounting source directory from %q to %q", privSessionHome, privResolvedHome)
-			t.Fatalf("failed to bind mount home directory: %+v", err)
-		}
-		// change to the "new" working directory if above mount override
-		// the current working directory
-		if err := os.Chdir(cwd); err != nil {
-			err = errors.Wrapf(err, "change working directory to %s", cwd)
-			t.Fatalf("failed to change working directory: %+v", err)
+			// finally bind temporary homes on top of real ones
+			// in order to not screw them by accident during e2e
+			// tests execution
+			if err := syscall.Mount(unprivSessionHome, unprivResolvedHome, "", syscall.MS_BIND|syscall.MS_REC, ""); err != nil {
+				err = errors.Wrapf(err, "bind mounting source directory from %q to %q", unprivSessionHome, unprivResolvedHome)
+				t.Fatalf("failed to bind mount home directory: %+v", err)
+			}
+			if err := syscall.Mount(privSessionHome, privResolvedHome, "", syscall.MS_BIND, ""); err != nil {
+				err = errors.Wrapf(err, "bind mounting source directory from %q to %q", privSessionHome, privResolvedHome)
+				t.Fatalf("failed to bind mount home directory: %+v", err)
+			}
+			// change to the "new" working directory if above mount override
+			// the current working directory
+			if err := os.Chdir(cwd); err != nil {
+				err = errors.Wrapf(err, "change working directory to %s", cwd)
+				t.Fatalf("failed to change working directory: %+v", err)
+			}
 		}
 
 		// create .rpmmacros files for yum bootstrap builds

--- a/e2e/internal/e2e/image.go
+++ b/e2e/internal/e2e/image.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -224,8 +223,7 @@ func CopyImage(t *testing.T, source, dest string, insecureSource, insecureDest b
 	// Use the auth config written out in dockerhub_auth.go - only if
 	// source/dest are not insecure, or are the localhost. We don't want to
 	// inadvertently send out credentials over http (!)
-	u := CurrentUser(t)
-	configPath := filepath.Join(u.Dir, ".apptainer", syfs.DockerConfFile)
+	configPath := syfs.SearchDockerConf()
 
 	srcType, srcRef, err := ociimage.URItoSourceSinkRef(source)
 	if err != nil {

--- a/e2e/internal/e2e/init/init_linux.go
+++ b/e2e/internal/e2e/init/init_linux.go
@@ -46,8 +46,12 @@ __attribute__((constructor)) static void init(void) {
 	uid = atoi(getenv("E2E_ORIG_UID"));
 
 	if ( mount(NULL, "/", NULL, MS_PRIVATE|MS_REC, NULL) < 0 ) {
-		fprintf(stderr, "failed to set private mount propagation: %s\n", strerror(errno));
-		exit(1);
+
+		char *no_isolation = getenv("E2E_NO_ISOLATION");
+		if ( ( no_isolation == NULL ) || ( no_isolation[0] != '\0' ) ) {
+			fprintf(stderr, "failed to set private mount propagation: %s\n", strerror(errno));
+			exit(1);
+		}
 	}
 
 	// set original user identity and retain privileges for

--- a/e2e/suite.go
+++ b/e2e/suite.go
@@ -126,23 +126,26 @@ func Run(t *testing.T) {
 	testenv.UnprivCacheDir = unprivCacheDir
 	defer cleanUnprivCache(t)
 
-	// e2e tests need to run in a somehow agnostic environment, so we
-	// don't use environment of user executing tests in order to not
-	// wrongly interfering with cache stuff, sylabs library tokens,
-	// PGP keys
 	e2e.SetupHomeDirectories(t, testenv.TestRegistry)
 
-	// generate apptainer.conf with default values
-	e2e.SetupDefaultConfig(t, filepath.Join(testenv.TestDir, "apptainer.conf"))
+	if os.Getenv("E2E_NO_ISOLATION") == "" {
+		// e2e tests need to run in a somehow agnostic environment, so we
+		// don't use environment of user executing tests in order to not
+		// wrongly interfering with cache stuff, sylabs library tokens,
+		// PGP keys
 
-	// create an empty plugin directory
-	e2e.SetupPluginDir(t, testenv.TestDir)
+		// generate apptainer.conf with default values
+		e2e.SetupDefaultConfig(t, filepath.Join(testenv.TestDir, "apptainer.conf"))
 
-	// duplicate system remote.yaml and create a temporary one on top of original
-	e2e.SetupSystemRemoteFile(t, testenv.TestDir)
+		// create an empty plugin directory
+		e2e.SetupPluginDir(t, testenv.TestDir)
 
-	// create an empty ECL configuration and empty global keyring
-	e2e.SetupSystemECLAndGlobalKeyRing(t, testenv.TestDir)
+		// duplicate system remote.yaml and create a temporary one on top of original
+		e2e.SetupSystemRemoteFile(t, testenv.TestDir)
+
+		// create an empty ECL configuration and empty global keyring
+		e2e.SetupSystemECLAndGlobalKeyRing(t, testenv.TestDir)
+	}
 
 	// Creates '$HOME/.apptainer/docker-config.json' with credentials
 	e2e.SetupDockerHubCredentials(t)

--- a/scripts/e2e-test
+++ b/scripts/e2e-test
@@ -39,5 +39,5 @@ proxy_vars="HTTP_PROXY=$HTTP_PROXY HTTPS_PROXY=$HTTPS_PROXY ALL_PROXY=$ALL_PROXY
 cred_vars="E2E_DOCKER_USERNAME=$E2E_DOCKER_USERNAME E2E_DOCKER_PASSWORD=$E2E_DOCKER_PASSWORD"
 docker_mirror_vars="E2E_DOCKER_MIRROR=$E2E_DOCKER_MIRROR E2E_DOCKER_MIRROR_INSECURE=$E2E_DOCKER_MIRROR_INSECURE"
 rootless_vars="XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
-export sudo_args="env -i PATH=$PATH HOME=$HOME $id_vars $proxy_vars $docker_mirror_vars $cred_vars $rootless_vars APPTAINER_E2E_COVERAGE=$APPTAINER_E2E_COVERAGE"
+export sudo_args="env -i PATH=$PATH HOME=$HOME $id_vars $proxy_vars $docker_mirror_vars $cred_vars $rootless_vars APPTAINER_E2E_COVERAGE=$APPTAINER_E2E_COVERAGE E2E_NO_ISOLATION=$E2E_NO_ISOLATION"
 exec scripts/go-test -sudo -parallel $procs -tags "e2e_test" "$@" ./e2e


### PR DESCRIPTION
This adds Nvidia gpu CI tests on runners hosted on gitlab.spack.io.  PRs on github are synchronized to gitlab via https://gitlab.spack.io/apptainer/apptainer-ci-sync. 

Includes a modification to the e2e system to honor an `E2E_NO_ISOLATION` option which skips some steps done for isolation because they don't work in the unprivileged docker used on those runners.

They also have amd gpu runners but they're not set up for this yet, I will add them later.