### PR TITLE
Build bundled PRoot without its Python extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ Changes since 1.5.x
   writable extfs image mounts use the `sync` mount option.
 - Added support for NVIDIA Tegra to `nvliblist.conf`
 - The `APPTAINER_TMPDIR` now defaults to /var/tmp, if /tmp is on tmpfs.
+- Build the bundled PRoot without its optional Python extension. The
+  extension was enabled automatically whenever `swig` and `python3-config`
+  happened to be installed on the build host, which made the resulting
+  proot binary depend on `libpython`. Apptainer does not use the PRoot
+  Python extension, and explicitly disabling it improves the build
+  reproducibility by ensuring a `libpython` dependency does not get
+  introduced based on the build host's environment.
 
 ## v1.5.x changes
 

--- a/scripts/compile-dependencies
+++ b/scripts/compile-dependencies
@@ -67,7 +67,9 @@ for PKG in squashfs-tools squashfuse e2fsprogs fuse-overlayfs gocryptfs PRoot; d
                 -B 0x`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'`"
             ;;
         PRoot)
-            make -C src proot
+            # Disable the PRoot Python extension support by explicitly setting HAS_SWIG
+            # and HAS_PYTHON_CONFIG to avoid a libpython dependency on the built binary
+            make -C src proot HAS_SWIG= HAS_PYTHON_CONFIG=
             ;;
         *)
             echo "unrecognized package $PKG" >&2


### PR DESCRIPTION
## Description of the Pull Request (PR):

When building the bundled PRoot, explicitly unset the `HAS_SWIG` and `HAS_PYTHON_CONFIG` variables to disable PRoot's Python extension support.

Apptainer does not use PRoot's Python extension, and disabling it makes the bundled proot's dependencies reproducible. Otherwise, proot's dependencies [vary with whether swig and python3-config are installed on the build host](https://github.com/rootless-containers/PRoot/blob/9f70ae6f1a02f7a62c1b6f826114dbed198dac29/src/GNUmakefile#L97).

This was first observed when running E2E tests of Apptainer nested inside itself (#3580) on a GitHub CI host, which has both `swig` and `python3-config` installed. The resulting proot binary linked against `libpython`, and failed to start when Apptainer ran it to wrap mksquashfs during an unprivileged build inside a container that did not have `libpython` installed.

Also note that currently neither the RPM or Debian packages declare the `libpython` dependency. This is not necessarily an issue unless the packages are built in a machine with swig and python3-config installed, but this PR removes the possibility of that dependency existing in the bundled `proot` binary.

### Reproducing the issue

Tested on an AlmaLinux 9.8 machine with a local checkout of the `main` branch. Note the extra linked libraries on the bundled `proot` binary after we run `./scripts/compile-dependencies` with `swig` and `python3-devel` installed.

```
$ rpm -q swig python3-devel
package swig is not installed
package python3-devel is not installed
$ ./scripts/download-dependencies
...
$ ./scripts/compile-dependencies
...
$ ldd PRoot-*/src/proot
	linux-vdso.so.1 (0x00007ffc288df000)
	libtalloc.so.2 => /lib64/libtalloc.so.2 (0x00007f5d746eb000)
	libprotobuf-c.so.1 => /lib64/libprotobuf-c.so.1 (0x00007f5d746e0000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f5d74400000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f5d74701000)
$ sudo dnf install -y swig python3-devel
...
$ ./scripts/compile-dependencies
...
$ ldd PRoot-*/src/proot
	linux-vdso.so.1 (0x00007ffdd95ba000)
	libtalloc.so.2 => /lib64/libtalloc.so.2 (0x00007fe3acfd0000)
	libprotobuf-c.so.1 => /lib64/libprotobuf-c.so.1 (0x00007fe3acfc5000)
	libpython3.9.so.1.0 => /lib64/libpython3.9.so.1.0 (0x00007fe3acc00000)
	libcrypt.so.2 => /lib64/libcrypt.so.2 (0x00007fe3acbc6000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fe3acae9000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fe3ac800000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fe3acfe6000)
```

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Made sure all commits are signed-off with `git commit -s`; see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#getting-started).
- [x] Either did not use AI or followed the AI Asistance Policy as found in the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#ai-assistance-policy).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#pull-requests-prs).
- [x] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#pull-requests-prs)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#pull-requests-prs).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
