### PR TITLE
Allow oras to upload multiple images with index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
 
 Changes since 1.5.x
 
+- Allow pushing multiple images with different architectures (multi-arch)
+  to an oras URI, creating an image index with all the pushed arch images.
 - Add a new `gpu library path` option to `apptainer.conf`, giving a list of
   directories to search for the GPU driver libraries named in
   `nvliblist.conf` and `rocmliblist.conf` when binding them with `--nv` or

--- a/cmd/internal/cli/push.go
+++ b/cmd/internal/cli/push.go
@@ -100,9 +100,9 @@ func init() {
 // PushCmd apptainer push
 var PushCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
-	Args:                  cobra.ExactArgs(2),
+	Args:                  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		file, dest := args[0], args[1]
+		dest := args[len(args)-1]
 
 		transport, ref := uri.Split(dest)
 		if transport == "" {
@@ -111,6 +111,11 @@ var PushCmd = &cobra.Command{
 
 		switch transport {
 		case LibraryProtocol: // Handle pushing to a library
+			if len(args) > 2 {
+				sylog.Fatalf("Unable to push multi-arch to library")
+			}
+			file := args[0]
+
 			destRef, err := library.NormalizeLibraryRef(dest)
 			if err != nil {
 				sylog.Fatalf("Malformed library reference: %v", err)
@@ -173,6 +178,8 @@ var PushCmd = &cobra.Command{
 			}
 
 		case OrasProtocol:
+			files := args[0 : len(args)-1]
+
 			if cmd.Flag(pushDescriptionFlag.Name).Changed {
 				description := fmt.Sprintf("%s=%s", "org.opencontainers.image.description", pushDescription)
 				pushAnnotations = append(pushAnnotations, description)
@@ -182,7 +189,7 @@ var PushCmd = &cobra.Command{
 				sylog.Fatalf("Unable to make docker oci credentials: %s", err)
 			}
 
-			if err := oras.Push(cmd.Context(), file, ref, ociAuth, noHTTPS, reqAuthFile, pushAnnotations); err != nil {
+			if err := oras.Push(cmd.Context(), files, ref, ociAuth, noHTTPS, reqAuthFile, pushAnnotations); err != nil {
 				sylog.Fatalf("Unable to push image to oci registry: %v", err)
 			}
 			sylog.Infof("Upload complete")

--- a/docs/content.go
+++ b/docs/content.go
@@ -732,8 +732,8 @@ const (
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// push
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	PushUse   string = `push [push options...] <image> <URI>`
-	PushShort string = `Upload image to the provided URI`
+	PushUse   string = `push [push options...] <image> ... <URI>`
+	PushShort string = `Upload image(s) to the provided URI`
 	PushLong  string = `
   The 'push' command allows you to upload a SIF container to a given
   URI.  Supported URIs include:

--- a/internal/pkg/client/oras/image.go
+++ b/internal/pkg/client/oras/image.go
@@ -30,6 +30,11 @@ func (si *SifImage) Layers() ([]v1.Layer, error) {
 	return []v1.Layer{si.layer}, nil
 }
 
+// ArtifactType of this image's manifest.
+func (si *SifImage) ArtifactType() (string, error) {
+	return "", nil
+}
+
 // MediaType of this image's manifest.
 func (si *SifImage) MediaType() (types.MediaType, error) {
 	return si.manifest.MediaType, nil

--- a/internal/pkg/client/oras/image.go
+++ b/internal/pkg/client/oras/image.go
@@ -37,7 +37,7 @@ func (si *SifImage) MediaType() (types.MediaType, error) {
 
 // Size returns the size of the manifest.
 func (si *SifImage) Size() (int64, error) {
-	return 0, nil
+	return partial.Size(si)
 }
 
 // ConfigName returns the hash of the image's config file, also known as

--- a/internal/pkg/client/oras/oras.go
+++ b/internal/pkg/client/oras/oras.go
@@ -34,6 +34,8 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"golang.org/x/term"
 )
@@ -211,6 +213,142 @@ func UploadImage(ctx context.Context, path, ref, arch string, ociAuth *authn.Aut
 		remoteOpts = append(remoteOpts, remote.WithProgress(progChan))
 	}
 	return remote.Write(ir, im, remoteOpts...)
+}
+
+// UploadImages uploads the images specified by paths and pushes them along with an index to the provided oci reference,
+// it will use credentials if supplied
+func UploadImages(ctx context.Context, paths []string, ref string, archs []string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string, annotations []string) error {
+	var base v1.ImageIndex = empty.Index
+	var adds []mutate.IndexAddendum
+
+	ref = strings.TrimPrefix(ref, "oras://")
+	ref = strings.TrimPrefix(ref, "//")
+
+	// Get reference to image index in the remote
+	opts := []name.Option{name.WithDefaultTag(name.DefaultTag), name.WithDefaultRegistry(name.DefaultRegistry)}
+	if noHTTPS {
+		opts = append(opts, name.Insecure)
+	}
+	ir, err := name.ParseReference(ref, opts...)
+	if err != nil {
+		return err
+	}
+
+	annotationsMap := map[string]string{}
+	for _, annotation := range annotations {
+		key, value, found := strings.Cut(annotation, "=")
+		if !found {
+			sylog.Warningf("Value missing for %q, not setting", key)
+			continue
+		}
+		annotationsMap[key] = value
+	}
+
+	archSeen := map[string]bool{}
+
+	for i, path := range paths {
+		arch := archs[i]
+
+		// ensure that are uploading a SIF
+		if err := ensureSIF(path); err != nil {
+			return err
+		}
+
+		// We don't want to overwrite same arch
+		if archSeen[arch] {
+			return fmt.Errorf("have already added arch %q to %s", arch, ref)
+		}
+		archSeen[arch] = true
+
+		// Get reference to image in the remote
+		ia, err := name.ParseReference(ir.Name()+"_"+arch, opts...)
+		if err != nil {
+			return err
+		}
+
+		im, err := NewImageFromSIF(path, SifConfigMediaTypeV1, SifLayerMediaTypeV1, annotationsMap) // nolint:contextcheck
+		if err != nil {
+			return err
+		}
+
+		digest, err := im.Digest()
+		if err != nil {
+			return err
+		}
+		sylog.Infof("Digest: %s (%s)\n", digest, arch)
+
+		platform := v1.Platform{
+			Architecture: arch,
+			OS:           "linux",
+		}
+		remoteOpts := []remote.Option{
+			ociauth.AuthOptn(ociAuth, reqAuthFile),
+			remote.WithUserAgent(useragent.Value()),
+			remote.WithContext(ctx),
+			remote.WithPlatform(platform),
+		}
+
+		if term.IsTerminal(2) {
+			pb := &client.DownloadProgressBar{}
+			progChan := make(chan v1.Update, 1)
+			go func() {
+				var total int64
+				soFar := int64(0)
+				for {
+					// The following is concurrency-safe because this is the only
+					// goroutine that's going to be reading progChan updates.
+					update := <-progChan
+					if update.Error != nil {
+						pb.Abort(false)
+						return
+					}
+					if update.Total != total {
+						pb.Init(update.Total)
+						total = update.Total
+					}
+					pb.IncrBy(int(update.Complete - soFar))
+					soFar = update.Complete
+					if soFar >= total {
+						pb.Wait()
+						return
+					}
+				}
+			}()
+			remoteOpts = append(remoteOpts, remote.WithProgress(progChan))
+		}
+
+		err = remote.Write(ia, im, remoteOpts...)
+		if err != nil {
+			return err
+		}
+
+		desc, err := partial.Descriptor(partial.Describable(im))
+		if err != nil {
+			return err
+		}
+		desc.Platform = &platform
+
+		adds = append(adds, mutate.IndexAddendum{
+			Add:        im,
+			Descriptor: *desc,
+		})
+	}
+
+	idx := mutate.AppendManifests(base, adds...)
+
+	digest, err := idx.Digest()
+	if err != nil {
+		return err
+	}
+	sylog.Infof("Digest: %s\n", digest)
+
+	remoteOpts := []remote.Option{
+		ociauth.AuthOptn(ociAuth, reqAuthFile),
+		remote.WithUserAgent(useragent.Value()),
+		remote.WithContext(ctx),
+	}
+
+	return remote.WriteIndex(ir, idx, remoteOpts...)
 }
 
 // ensureSIF checks for a SIF image at filepath and returns an error if it is not, or an error is encountered

--- a/internal/pkg/client/oras/push.go
+++ b/internal/pkg/client/oras/push.go
@@ -20,12 +20,22 @@ import (
 )
 
 // Push will push an oras image from the specified location
-func Push(ctx context.Context, path, ref string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string, annotations []string) error {
-	arch, err := sifArch(path)
-	if err != nil {
-		return err
+func Push(ctx context.Context, paths []string, ref string, ociAuth *authn.AuthConfig, noHTTPS bool, reqAuthFile string, annotations []string) error {
+	archs := make([]string, 0, len(paths))
+	for _, path := range paths {
+		arch, err := sifArch(path)
+		if err != nil {
+			return err
+		}
+		archs = append(archs, arch)
 	}
-	return UploadImage(ctx, path, ref, arch, ociAuth, noHTTPS, reqAuthFile, annotations)
+
+	if len(paths) == 1 {
+		path := paths[0]
+		arch := archs[0]
+		return UploadImage(ctx, path, ref, arch, ociAuth, noHTTPS, reqAuthFile, annotations)
+	}
+	return UploadImages(ctx, paths, ref, archs, ociAuth, noHTTPS, reqAuthFile, annotations)
 }
 
 func sifArch(filename string) (string, error) {


### PR DESCRIPTION
When uploading more than one image, create an image index.

Set platform in the index, but don't set the ArtifactType.

## Description of the Pull Request (PR):

Allows uploading more than one SIF image to an ORAS URI:

`apptainer push [push options...] <image> ... <URI>`

```console
$ apptainer pull --arch amd64 alpine-amd64.sif docker://alpine
INFO:    Using cached SIF image
$ apptainer pull --arch arm64 alpine-arm64.sif docker://alpine
INFO:    Using cached SIF image
$ apptainer push alpine-amd64.sif alpine-arm64.sif oras://localhost:5000/alpine_sif
INFO:    Digest: sha256:6ce5455fc3cb4ccfafc711f0054e269e3d919397b37c57293dd2368643b18d2f (amd64)
3.6MiB / 3.6MiB [==================================================================================================================================================================================] 100 %0s
INFO:    Digest: sha256:7e887bf28123c79b3a98ab68e55a334805c0c5f2a7442ac0e226fc445418e514 (arm64)
3.9MiB / 3.9MiB [==================================================================================================================================================================================] 100 %0s
INFO:    Digest: sha256:10eb0c20b6ab70ccb73fb9f69020e998e4611bd7724c45b9007b7abafeec684e
INFO:    Upload complete
$ oras manifest fetch --pretty localhost:5000/alpine.sif@sha256:10eb0c20b6ab70ccb73fb9f69020e998e4611bd7724c45b9007b7abafeec684e
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 0,
      "digest": "sha256:6ce5455fc3cb4ccfafc711f0054e269e3d919397b37c57293dd2368643b18d2f",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 0,
      "digest": "sha256:7e887bf28123c79b3a98ab68e55a334805c0c5f2a7442ac0e226fc445418e514",
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ]
}
$ apptainer search oras://localhost:5000/alpine_sif
Found 3 container images for amd64 matching "localhost:5000/alpine_sif":

	oras://localhost:5000/alpine_sif:latest

	oras://localhost:5000/alpine_sif:latest_amd64

	oras://localhost:5000/alpine_sif:latest_arm64
```

Seems to be some bug with search and arch, but...

~~EDIT: And the "size" seems to be wrong (0), as well~~ FIXED

### This fixes or addresses the following GitHub issues:

 - Fixes #3751 

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] Made sure all commits are signed-off with `git commit -s`; see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#getting-started).
- [x] Either did not use AI or followed the AI Asistance Policy as found in the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#ai-assistance-policy).
- [x] Added changes to the [CHANGELOG](https://github.com/apptainer/apptainer/blob/main/CHANGELOG.md), if necessary according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#pull-requests-prs).
- [ ] Added tests to validate this PR, linted with `make check`  and tested this PR locally with a `make test`, and `make testall` if possible (see the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#pull-requests-prs)).
- [x] Based this PR against the appropriate branch according to the [Guidelines for Contributing](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTING.md#pull-requests-prs).
- [x] Added myself as a contributor to the [Contributors File](https://github.com/apptainer/apptainer/blob/main/CONTRIBUTORS.md).
