### PR TITLE
Drop debian11 from ci checks (release-1.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,23 +114,6 @@ jobs:
       - name: Check License Changes
         run: git diff --exit-code -- LICENSE_DEPENDENCIES.md
 
-  debbuild-debian11:
-    name: debbuild-debian11
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Build and test deb under docker
-        env:
-          OS_TYPE: debian
-          OS_VERSION: 11
-          # setting GO_ARCH speeds things by using go binaries instead of source
-          GO_ARCH: linux-amd64
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/ci-docker-run
-
   debbuild-debian12:
     name: debbuild-debian12
     runs-on: ubuntu-22.04
@@ -218,10 +201,10 @@ jobs:
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 
-      - name: Install and test unprivileged for debian 11
+      - name: Install and test unprivileged for debian 12
         env:
           OS_TYPE: debian
-          OS_VERSION: 11
+          OS_VERSION: 12
           TEST_TYPE: unpriv
         run: ./scripts/ci-docker-run
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         if: env.do_release
         env:
           OS_TYPE: debian
-          OS_VERSION: 11
+          OS_VERSION: 12
           GO_ARCH: linux-amd64
         run: |
           # Make another new copy of the source files for this build
@@ -84,8 +84,7 @@ jobs:
         if: env.do_release
         env:
           OS_TYPE: debian
-          # once released, this version should change to 13
-          OS_VERSION: trixie
+          OS_VERSION: 13
           GO_ARCH: linux-amd64
         run: |
           # Make another new copy of the source files for this build


### PR DESCRIPTION
This drops debian11 from ci checks for release-1.5 because it is end of life.