### PR TITLE
Skip attempting to build PRoot in rpm on riscv64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ Changes since 1.5.x
   by using the shorter `src` and `dst` aliases in the example.
 - Fixed a bug that prevented multiple mount entries in the `APPTAINER_MOUNT`
   env var from having different numbers of options.
+- Skip attempting to build PRoot in rpm packages on riscv64 architecture
+  like had already been done for ppc64le and s390x.
 
 ## v1.5.3 - \[2026-07-21\]
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -34,7 +34,7 @@
 %global e2fsprogs_version 1.47.4
 %global fuse_overlayfs_version 1.16
 %global squashfs_tools_version 4.7.5
-%ifnarch ppc64le s390x
+%ifnarch ppc64le s390x riscv64
 %if !(0%{?fedora} >= 45 || 0%{?rhel} >= 11) || "%{_arch}" != "x86_64"
 # On fedora45 & epel11 x86_64 building PRoot dies with
 # "relocation truncated to fit: R_X86_64_PC32 against `.rodata'"


### PR DESCRIPTION
This adds riscv64 to the list of architectures skipped for building PRoot in rpm packages.

Backported from [fedora rawhide PR](https://src.fedoraproject.org/rpms/apptainer/pull-request/5).  I'm not sure how that got missed because riscv* was already excluded in download-dependencies.