### PR TITLE
Skip attempting to build PRoot in rpm on riscv64 (release-1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For older changes see the [archived Singularity change log](https://github.com/a
   env var from having different numbers of options.
 - Fix the help text for the `--mount` option not wrapping at 80 columns,
   by using the shorter `src` and `dst` aliases in the example.
+- Skip attempting to build PRoot in rpm packages on riscv64 architecture
+  like had already been done for ppc64le and s390x.
 
 ## v1.5.3 - \[2026-07-21\]
 

--- a/dist/rpm/apptainer.spec.in
+++ b/dist/rpm/apptainer.spec.in
@@ -34,7 +34,7 @@
 %global e2fsprogs_version 1.47.4
 %global fuse_overlayfs_version 1.16
 %global squashfs_tools_version 4.7.5
-%ifnarch ppc64le s390x
+%ifnarch ppc64le s390x riscv64
 %if !(0%{?fedora} >= 45 || 0%{?rhel} >= 11) || "%{_arch}" != "x86_64"
 # On fedora45 & epel11 x86_64 building PRoot dies with
 # "relocation truncated to fit: R_X86_64_PC32 against `.rodata'"


### PR DESCRIPTION
Cherry-pick #3759 to the release-1.5 branch.